### PR TITLE
Set TLS MinVersion not MaxVersion

### DIFF
--- a/_examples/configuration.go
+++ b/_examples/configuration.go
@@ -27,8 +27,7 @@ func main() {
 			ResponseHeaderTimeout: time.Millisecond,
 			DialContext:           (&net.Dialer{Timeout: time.Nanosecond}).DialContext,
 			TLSClientConfig: &tls.Config{
-				MaxVersion:         tls.VersionTLS11,
-				InsecureSkipVerify: true,
+				MinVersion:         tls.VersionTLS11,
 			},
 		},
 	}

--- a/doc.go
+++ b/doc.go
@@ -20,8 +20,7 @@ To configure the client, pass a Config object to the NewClient function:
 		    ResponseHeaderTimeout: time.Second,
 		    DialContext:           (&net.Dialer{Timeout: time.Second}).DialContext,
 		    TLSClientConfig: &tls.Config{
-		      MaxVersion:         tls.VersionTLS11,
-		      InsecureSkipVerify: true,
+		      MinVersion:         tls.VersionTLS11,
 		    },
 		  },
 		}

--- a/elasticsearch_example_test.go
+++ b/elasticsearch_example_test.go
@@ -42,8 +42,7 @@ func ExampleNewClient() {
 			ResponseHeaderTimeout: time.Second,
 			DialContext:           (&net.Dialer{Timeout: time.Second}).DialContext,
 			TLSClientConfig: &tls.Config{
-				MaxVersion:         tls.VersionTLS11,
-				InsecureSkipVerify: true,
+				MinVersion:         tls.VersionTLS11,
 			},
 		},
 	}

--- a/elasticsearch_integration_test.go
+++ b/elasticsearch_integration_test.go
@@ -125,7 +125,7 @@ func TestClientTransport(t *testing.T) {
 				ResponseHeaderTimeout: time.Second,
 				DialContext:           (&net.Dialer{Timeout: time.Nanosecond}).DialContext,
 				TLSClientConfig: &tls.Config{
-					MaxVersion:         tls.VersionTLS11,
+					MinVersion:         tls.VersionTLS11,
 					InsecureSkipVerify: true,
 				},
 			},


### PR DESCRIPTION
Let the examples pin the minimum supported TLS version, not the maximum. This
will prevent connections to TLS 1.0.

I removed InsecureSkipVerify from the examples so that users to don't inadvertently
copy this insecure setup into their applications. Alternatively we could set the value to false
in these examples.