### PR TITLE
Format time duration to nanos

### DIFF
--- a/internal/cmd/generate/commands/gensource/generator.go
+++ b/internal/cmd/generate/commands/gensource/generator.go
@@ -625,7 +625,7 @@ func (r ` + g.Endpoint.MethodWithNamespace() + `Request) Do(ctx context.Context,
 				fieldValue = `strings.Join(r.` + fieldName + `, ",")`
 			case "time.Duration":
 				fieldCondition = `r.` + fieldName + ` != 0`
-				fieldValue = `time.Duration(r.` + fieldName + ` * time.Millisecond).String()`
+				fieldValue = `strconv.FormatInt(int64(r.` + fieldName +`), 10) + "nanos"`
 			default: // interface{}
 				fieldCondition = `r.` + fieldName + ` != nil`
 				// TODO: Use type switching instead?


### PR DESCRIPTION
The scroll time was being formatted based on the Go time.Duration format. So for one minute
it would use 16666h40m0s. Elasticsearch supports nanoseconds as a time unit so so it can
pass the Go time.Duration value through without any conversion just by appending "nanos".

This updates the generator but doesn't regenerate the API sources.

Fixes #25 