### PR TITLE
style changes

### DIFF
--- a/elasticsearch.go
+++ b/elasticsearch.go
@@ -1,6 +1,7 @@
 package elasticsearch // import "github.com/elastic/go-elasticsearch"
 
 import (
+	"errors"
 	"fmt"
 	"net/http"
 	"net/url"
@@ -59,7 +60,7 @@ func NewClient(cfg Config) (*Client, error) {
 	addrs := addressesFromEnvironment()
 
 	if len(addrs) > 0 && len(cfg.Addresses) > 0 {
-		return nil, fmt.Errorf("cannot create client: both ELASTICSEARCH_URL and Addresses are set")
+		return nil, errors.New("cannot create client: both ELASTICSEARCH_URL and Addresses are set")
 	}
 
 	for _, addr := range addrs {

--- a/esapi/esapi_internal_test.go
+++ b/esapi/esapi_internal_test.go
@@ -8,9 +8,7 @@ import (
 
 func TestAPIHelpers(t *testing.T) {
 	t.Run("BoolPtr", func(t *testing.T) {
-		var v *bool
-
-		v = BoolPtr(false)
+		v := BoolPtr(false)
 		if v == nil || *v != false {
 			t.Errorf("Expected false, got: %v", v)
 		}
@@ -22,9 +20,7 @@ func TestAPIHelpers(t *testing.T) {
 	})
 
 	t.Run("IntPtr", func(t *testing.T) {
-		var v *int
-
-		v = IntPtr(0)
+		v := IntPtr(0)
 		if v == nil || *v != 0 {
 			t.Errorf("Expected 0, got: %v", v)
 		}

--- a/internal/cmd/generate/commands/gentests/command.go
+++ b/internal/cmd/generate/commands/gentests/command.go
@@ -4,6 +4,7 @@ package gentests
 
 import (
 	"bytes"
+	"errors"
 	"fmt"
 	"io"
 	"os"
@@ -85,7 +86,7 @@ type Command struct {
 //
 func (cmd *Command) Execute() error {
 	if len(apiRegistry) < 1 {
-		return fmt.Errorf("API registry in 'api_registry.gen.go' is empty: Did you run go generate?")
+		return errors.New("API registry in 'api_registry.gen.go' is empty: Did you run go generate?")
 	}
 
 	inputFiles, err := filepath.Glob(cmd.Input)


### PR DESCRIPTION
Removed redundant allocation in internal tests, 
changed `fmt.Errorf` to `errors.New` where string does not need format.