### PR TITLE
Fix `time.Duration` conversion to Elasticsearch's time unit

### DIFF
--- a/esapi/api.search.go
+++ b/esapi/api.search.go
@@ -261,7 +261,7 @@ func (r SearchRequest) Do(ctx context.Context, transport Transport) (*Response, 
 	}
 
 	if r.Timeout != 0 {
-		params["timeout"] = time.Duration(r.Timeout * time.Millisecond).String()
+		params["timeout"] = formatDuration(r.Timeout)
 	}
 
 	if r.TrackScores != nil {

--- a/esapi/esapi.go
+++ b/esapi/esapi.go
@@ -2,6 +2,8 @@ package esapi // import "github.com/elastic/go-elasticsearch/esapi"
 
 import (
 	"net/http"
+	"strconv"
+	"time"
 )
 
 // Transport defines the interface for an API client.
@@ -25,3 +27,13 @@ func BoolPtr(v bool) *bool { return &v }
 // which expects a pointer.
 //
 func IntPtr(v int) *int { return &v }
+
+// formatDuration converts duration to a string in the format
+// accepted by Elasticsearch.
+//
+func formatDuration(d time.Duration) string {
+	if d < time.Millisecond {
+		return strconv.FormatInt(int64(d), 10) + "nanos"
+	}
+	return strconv.FormatInt(int64(d)/int64(time.Millisecond), 10) + "ms"
+}

--- a/esapi/esapi_integration_test.go
+++ b/esapi/esapi_integration_test.go
@@ -1,0 +1,38 @@
+// +build integration
+
+package esapi_test
+
+import (
+	"encoding/json"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/elastic/go-elasticsearch"
+)
+
+func TestAPI(t *testing.T) {
+	t.Run("Search", func(t *testing.T) {
+		es, err := elasticsearch.NewDefaultClient()
+		if err != nil {
+			t.Fatalf("Error creating the client: %s\n", err)
+		}
+
+		res, err := es.Search(es.Search.WithTimeout(500 * time.Millisecond))
+		if err != nil {
+			t.Fatalf("Error getting the response: %s\n", err)
+		}
+		defer res.Body.Close()
+
+		if res.IsError() {
+			t.Fatalf("Error response: %s", res.String())
+		}
+
+		var d map[string]interface{}
+		err = json.NewDecoder(res.Body).Decode(&d)
+		if err != nil {
+			t.Fatalf("Error parsing the response: %s\n", err)
+		}
+		fmt.Printf("took=%vms\n", d["took"])
+	})
+}

--- a/esapi/esapi_internal_test.go
+++ b/esapi/esapi_internal_test.go
@@ -4,6 +4,7 @@ package esapi
 
 import (
 	"testing"
+	"time"
 )
 
 func TestAPIHelpers(t *testing.T) {
@@ -23,6 +24,30 @@ func TestAPIHelpers(t *testing.T) {
 		v := IntPtr(0)
 		if v == nil || *v != 0 {
 			t.Errorf("Expected 0, got: %v", v)
+		}
+	})
+
+	t.Run("FormatDuration", func(t *testing.T) {
+		var tt = []struct {
+			duration time.Duration
+			expected string
+		}{
+			{1 * time.Nanosecond, "1nanos"},
+			{100 * time.Nanosecond, "100nanos"},
+			{1 * time.Microsecond, "1000nanos"},
+			{1 * time.Millisecond, "1ms"},
+			{100 * time.Millisecond, "100ms"},
+			{1 * time.Minute, "60000ms"},
+			{10 * time.Minute, "600000ms"},
+			{1 * time.Hour, "3600000ms"},
+			{10 * time.Hour, "36000000ms"},
+		}
+
+		for _, tc := range tt {
+			actual := formatDuration(tc.duration)
+			if actual != tc.expected {
+				t.Errorf("Unexpected output: got=%s, want=%s", actual, tc.expected)
+			}
 		}
 	})
 }


### PR DESCRIPTION
As reported in #25 and #35, the current conversion of `time.Duration` into an Elasticsearch [time unit](https://www.elastic.co/guide/en/elasticsearch/reference/current/common-options.html#time-units) is broken.

This patch builds on the implementation and discussion in #27, and adds a `esapi.formatDuration()` unexported helper function to be used in the generated code.