### PR TITLE
Add the JSONReader helper

### DIFF
--- a/esutil/doc.go
+++ b/esutil/doc.go
@@ -1,0 +1,5 @@
+/*
+Package esutil provides helper utilities to the Go client for Elasticsearch.
+
+*/
+package esutil

--- a/esutil/json_reader.go
+++ b/esutil/json_reader.go
@@ -1,0 +1,63 @@
+package esutil
+
+import (
+	"bytes"
+	"encoding/json"
+	"io"
+)
+
+// JSONReader is an utility function which encodes v into JSON and returns it as a reader.
+//
+func JSONReader(v interface{}) io.Reader {
+	return &jsonReader{val: v, buf: nil}
+}
+
+// JSONEncoder defines the interface for custom JSON encoders.
+//
+type JSONEncoder interface {
+	EncodeJSON(io.Writer) error
+}
+
+type jsonReader struct {
+	val interface{}
+	buf interface {
+		io.ReadWriter
+		io.WriterTo
+	}
+}
+
+func (r *jsonReader) Read(p []byte) (int, error) {
+	if err := r.initialize(); err != nil {
+		return 0, err
+	}
+	return r.buf.Read(p)
+}
+
+func (r *jsonReader) WriteTo(w io.Writer) (int64, error) {
+	if err := r.initialize(); err != nil {
+		return 0, err
+	}
+	return r.buf.WriteTo(w)
+}
+
+func (r *jsonReader) initialize() error {
+	if r.buf == nil {
+		r.buf = new(bytes.Buffer)
+		return r.encode()
+	}
+	return nil
+}
+
+func (r *jsonReader) encode() error {
+	var err error
+
+	if e, ok := r.val.(JSONEncoder); ok {
+		err = e.EncodeJSON(r.buf)
+		if err != nil {
+			return err
+		}
+		return nil
+	}
+
+	return json.NewEncoder(r.buf).Encode(r.val)
+}

--- a/esutil/json_reader_benchmark_test.go
+++ b/esutil/json_reader_benchmark_test.go
@@ -39,12 +39,13 @@ func BenchmarkJSONReader(b *testing.B) {
 	b.Run("None", func(b *testing.B) {
 		b.ResetTimer()
 
+		var buf bytes.Buffer
 		for i := 0; i < b.N; i++ {
-			var buf bytes.Buffer
 			json.NewEncoder(&buf).Encode(map[string]string{"foo": "bar"})
 			if string(buf.String()) != `{"foo":"bar"}`+"\n" {
 				b.Fatalf("Unexpected output: %q", buf.String())
 			}
+			buf.Reset()
 		}
 	})
 
@@ -62,12 +63,13 @@ func BenchmarkJSONReader(b *testing.B) {
 	b.Run("Default-Copy", func(b *testing.B) {
 		b.ResetTimer()
 
+		var buf bytes.Buffer
 		for i := 0; i < b.N; i++ {
-			var buf bytes.Buffer
 			io.Copy(&buf, esutil.JSONReader(map[string]string{"foo": "bar"}))
 			if buf.String() != `{"foo":"bar"}`+"\n" {
 				b.Fatalf("Unexpected output: %q", buf.String())
 			}
+			buf.Reset()
 		}
 	})
 

--- a/esutil/json_reader_benchmark_test.go
+++ b/esutil/json_reader_benchmark_test.go
@@ -1,0 +1,84 @@
+// +build !integration
+
+package esutil_test
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io"
+	"io/ioutil"
+	"strings"
+	"testing"
+
+	"github.com/elastic/go-elasticsearch/v8/esutil"
+)
+
+var _ = fmt.Print
+
+type Foo struct {
+	Bar string
+}
+
+func (f Foo) EncodeJSON(w io.Writer) error {
+	var b bytes.Buffer
+	b.WriteString(`{"bar":"`)
+	b.WriteString(strings.ToUpper(f.Bar))
+	b.WriteString(`"}`)
+	b.WriteString("\n")
+	_, err := b.WriteTo(w)
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+func BenchmarkJSONReader(b *testing.B) {
+	b.ReportAllocs()
+
+	b.Run("None", func(b *testing.B) {
+		b.ResetTimer()
+
+		for i := 0; i < b.N; i++ {
+			var buf bytes.Buffer
+			json.NewEncoder(&buf).Encode(map[string]string{"foo": "bar"})
+			if string(buf.String()) != `{"foo":"bar"}`+"\n" {
+				b.Fatalf("Unexpected output: %q", buf.String())
+			}
+		}
+	})
+
+	b.Run("Default", func(b *testing.B) {
+		b.ResetTimer()
+
+		for i := 0; i < b.N; i++ {
+			out, _ := ioutil.ReadAll(esutil.JSONReader(map[string]string{"foo": "bar"}))
+			if string(out) != `{"foo":"bar"}`+"\n" {
+				b.Fatalf("Unexpected output: %q", out)
+			}
+		}
+	})
+
+	b.Run("Default-Copy", func(b *testing.B) {
+		b.ResetTimer()
+
+		for i := 0; i < b.N; i++ {
+			var buf bytes.Buffer
+			io.Copy(&buf, esutil.JSONReader(map[string]string{"foo": "bar"}))
+			if buf.String() != `{"foo":"bar"}`+"\n" {
+				b.Fatalf("Unexpected output: %q", buf.String())
+			}
+		}
+	})
+
+	b.Run("Custom", func(b *testing.B) {
+		b.ResetTimer()
+
+		for i := 0; i < b.N; i++ {
+			out, _ := ioutil.ReadAll(esutil.JSONReader(Foo{Bar: "baz"}))
+			if string(out) != `{"bar":"BAZ"}`+"\n" {
+				b.Fatalf("Unexpected output: %q", out)
+			}
+		}
+	})
+}

--- a/esutil/json_reader_internal_test.go
+++ b/esutil/json_reader_internal_test.go
@@ -1,0 +1,64 @@
+// +build !integration
+
+package esutil
+
+import (
+	"bytes"
+	"errors"
+	"io"
+	"io/ioutil"
+	"strings"
+	"testing"
+)
+
+type errReader struct{}
+
+func (errReader) Read(p []byte) (int, error)         { return 1, errors.New("MOCK ERROR") }
+func (errReader) Write(p []byte) (int, error)        { return 0, errors.New("MOCK ERROR") }
+func (errReader) WriteTo(w io.Writer) (int64, error) { return 0, errors.New("MOCK ERROR") }
+
+type Foo struct {
+	Bar string
+}
+
+func (f Foo) EncodeJSON(w io.Writer) error {
+	_, err := w.Write([]byte(`{"bar":"` + strings.ToUpper(f.Bar) + `"}` + "\n"))
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+func TestJSONReader(t *testing.T) {
+	t.Run("Default", func(t *testing.T) {
+		out, _ := ioutil.ReadAll(JSONReader(map[string]string{"foo": "bar"}))
+		if string(out) != `{"foo":"bar"}`+"\n" {
+			t.Fatalf("Unexpected output: %s", out)
+		}
+	})
+
+	t.Run("Custom", func(t *testing.T) {
+		out, _ := ioutil.ReadAll(JSONReader(Foo{Bar: "baz"}))
+		if string(out) != `{"bar":"BAZ"}`+"\n" {
+			t.Fatalf("Unexpected output: %s", out)
+		}
+	})
+
+	t.Run("WriteTo", func(t *testing.T) {
+		b := bytes.NewBuffer([]byte{})
+		r := jsonReader{val: map[string]string{"foo": "bar"}}
+		r.WriteTo(b)
+		if b.String() != `{"foo":"bar"}`+"\n" {
+			t.Fatalf("Unexpected output: %s", b.String())
+		}
+	})
+
+	t.Run("Read error", func(t *testing.T) {
+		b := []byte{}
+		r := jsonReader{val: map[string]string{"foo": "bar"}, buf: errReader{}}
+		_, err := r.Read(b)
+		if err == nil {
+			t.Fatalf("Expected error, got: %#v", err)
+		}
+	})
+}


### PR DESCRIPTION
This patch adds a `JSONReader()` helper method to facilitate passing eg. a `map[string]string` as the body, without requiring the user to manually encode it into JSON and create eg. a `strings.Reader`:

```golang
res, err = es.Search(
	es.Search.WithIndex("test"),
	es.Search.WithBody(esutil.JSONReader(map[string]string{"query": {"match": {"title": "test"}}})),
)
```

The package defines the `JSONEncoder` interface, so it's possible for the outside code to provide
an object implementing it, in order to use eg. a third-party JSON package. The default encoder
is "encoding/json".

(Related: https://github.com/elastic/go-elasticsearch/issues/42)