### PR TITLE
Fix SIGSEGV on connection refused

### DIFF
--- a/estransport/estransport.go
+++ b/estransport/estransport.go
@@ -113,7 +113,7 @@ func (c *Client) Perform(req *http.Request) (*http.Response, error) {
 			}
 		}
 		if c.logger.ResponseBodyEnabled() {
-			if res.Body != nil && res.Body != http.NoBody {
+			if res != nil && res.Body != nil && res.Body != http.NoBody {
 				b1, b2, _ := duplicateBody(res.Body)
 				dupRes.Body = b1
 				res.Body = b2


### PR DESCRIPTION
Fixes SIGSEGV that occurs when `http.Do` returns an error, for example `connection refused`