### PR TITLE
Add support for custom request HTTP headers

### DIFF
--- a/esapi/api._.go
+++ b/esapi/api._.go
@@ -1,4 +1,4 @@
-// Code generated from specification version 8.0.0 (c108b093b5a): DO NOT EDIT
+// Code generated from specification version 8.0.0 (d062fe9a44e): DO NOT EDIT
 
 package esapi
 

--- a/esapi/api.bulk.go
+++ b/esapi/api.bulk.go
@@ -147,7 +147,11 @@ func (r BulkRequest) Do(ctx context.Context, transport Transport) (*Response, er
 	}
 
 	if len(r.Header) > 0 {
-		req.Header = r.Header
+		for k, vv := range r.Header {
+			for _, v := range vv {
+				req.Header.Add(k, v)
+			}
+		}
 	}
 
 	if ctx != nil {

--- a/esapi/api.bulk.go
+++ b/esapi/api.bulk.go
@@ -147,9 +147,13 @@ func (r BulkRequest) Do(ctx context.Context, transport Transport) (*Response, er
 	}
 
 	if len(r.Header) > 0 {
-		for k, vv := range r.Header {
-			for _, v := range vv {
-				req.Header.Add(k, v)
+		if len(req.Header) == 0 {
+			req.Header = r.Header
+		} else {
+			for k, vv := range r.Header {
+				for _, v := range vv {
+					req.Header.Add(k, v)
+				}
 			}
 		}
 	}

--- a/esapi/api.bulk.go
+++ b/esapi/api.bulk.go
@@ -5,6 +5,7 @@ package esapi
 import (
 	"context"
 	"io"
+	"net/http"
 	"strings"
 	"time"
 )
@@ -48,6 +49,8 @@ type BulkRequest struct {
 	Human      bool
 	ErrorTrace bool
 	FilterPath []string
+
+	Header http.Header
 
 	ctx context.Context
 }
@@ -141,6 +144,10 @@ func (r BulkRequest) Do(ctx context.Context, transport Transport) (*Response, er
 
 	if r.Body != nil {
 		req.Header[headerContentType] = headerContentTypeJSON
+	}
+
+	if len(r.Header) > 0 {
+		req.Header = r.Header
 	}
 
 	if ctx != nil {
@@ -278,5 +285,18 @@ func (f Bulk) WithErrorTrace() func(*BulkRequest) {
 func (f Bulk) WithFilterPath(v ...string) func(*BulkRequest) {
 	return func(r *BulkRequest) {
 		r.FilterPath = v
+	}
+}
+
+// WithHeader adds the headers to the HTTP request
+//
+func (f Bulk) WithHeader(h map[string]string) func(*BulkRequest) {
+	return func(r *BulkRequest) {
+		if r.Header == nil {
+			r.Header = make(http.Header)
+		}
+		for k, v := range h {
+			r.Header.Add(k, v)
+		}
 	}
 }

--- a/esapi/api.cat.aliases.go
+++ b/esapi/api.cat.aliases.go
@@ -129,7 +129,11 @@ func (r CatAliasesRequest) Do(ctx context.Context, transport Transport) (*Respon
 	}
 
 	if len(r.Header) > 0 {
-		req.Header = r.Header
+		for k, vv := range r.Header {
+			for _, v := range vv {
+				req.Header.Add(k, v)
+			}
+		}
 	}
 
 	if ctx != nil {

--- a/esapi/api.cat.aliases.go
+++ b/esapi/api.cat.aliases.go
@@ -4,6 +4,7 @@ package esapi
 
 import (
 	"context"
+	"net/http"
 	"strconv"
 	"strings"
 	"time"
@@ -44,6 +45,8 @@ type CatAliasesRequest struct {
 	Human      bool
 	ErrorTrace bool
 	FilterPath []string
+
+	Header http.Header
 
 	ctx context.Context
 }
@@ -123,6 +126,10 @@ func (r CatAliasesRequest) Do(ctx context.Context, transport Transport) (*Respon
 			q.Set(k, v)
 		}
 		req.URL.RawQuery = q.Encode()
+	}
+
+	if len(r.Header) > 0 {
+		req.Header = r.Header
 	}
 
 	if ctx != nil {
@@ -244,5 +251,18 @@ func (f CatAliases) WithErrorTrace() func(*CatAliasesRequest) {
 func (f CatAliases) WithFilterPath(v ...string) func(*CatAliasesRequest) {
 	return func(r *CatAliasesRequest) {
 		r.FilterPath = v
+	}
+}
+
+// WithHeader adds the headers to the HTTP request
+//
+func (f CatAliases) WithHeader(h map[string]string) func(*CatAliasesRequest) {
+	return func(r *CatAliasesRequest) {
+		if r.Header == nil {
+			r.Header = make(http.Header)
+		}
+		for k, v := range h {
+			r.Header.Add(k, v)
+		}
 	}
 }

--- a/esapi/api.cat.aliases.go
+++ b/esapi/api.cat.aliases.go
@@ -129,9 +129,13 @@ func (r CatAliasesRequest) Do(ctx context.Context, transport Transport) (*Respon
 	}
 
 	if len(r.Header) > 0 {
-		for k, vv := range r.Header {
-			for _, v := range vv {
-				req.Header.Add(k, v)
+		if len(req.Header) == 0 {
+			req.Header = r.Header
+		} else {
+			for k, vv := range r.Header {
+				for _, v := range vv {
+					req.Header.Add(k, v)
+				}
 			}
 		}
 	}

--- a/esapi/api.cat.allocation.go
+++ b/esapi/api.cat.allocation.go
@@ -134,7 +134,11 @@ func (r CatAllocationRequest) Do(ctx context.Context, transport Transport) (*Res
 	}
 
 	if len(r.Header) > 0 {
-		req.Header = r.Header
+		for k, vv := range r.Header {
+			for _, v := range vv {
+				req.Header.Add(k, v)
+			}
+		}
 	}
 
 	if ctx != nil {

--- a/esapi/api.cat.allocation.go
+++ b/esapi/api.cat.allocation.go
@@ -134,9 +134,13 @@ func (r CatAllocationRequest) Do(ctx context.Context, transport Transport) (*Res
 	}
 
 	if len(r.Header) > 0 {
-		for k, vv := range r.Header {
-			for _, v := range vv {
-				req.Header.Add(k, v)
+		if len(req.Header) == 0 {
+			req.Header = r.Header
+		} else {
+			for k, vv := range r.Header {
+				for _, v := range vv {
+					req.Header.Add(k, v)
+				}
 			}
 		}
 	}

--- a/esapi/api.cat.allocation.go
+++ b/esapi/api.cat.allocation.go
@@ -4,6 +4,7 @@ package esapi
 
 import (
 	"context"
+	"net/http"
 	"strconv"
 	"strings"
 	"time"
@@ -45,6 +46,8 @@ type CatAllocationRequest struct {
 	Human      bool
 	ErrorTrace bool
 	FilterPath []string
+
+	Header http.Header
 
 	ctx context.Context
 }
@@ -128,6 +131,10 @@ func (r CatAllocationRequest) Do(ctx context.Context, transport Transport) (*Res
 			q.Set(k, v)
 		}
 		req.URL.RawQuery = q.Encode()
+	}
+
+	if len(r.Header) > 0 {
+		req.Header = r.Header
 	}
 
 	if ctx != nil {
@@ -257,5 +264,18 @@ func (f CatAllocation) WithErrorTrace() func(*CatAllocationRequest) {
 func (f CatAllocation) WithFilterPath(v ...string) func(*CatAllocationRequest) {
 	return func(r *CatAllocationRequest) {
 		r.FilterPath = v
+	}
+}
+
+// WithHeader adds the headers to the HTTP request
+//
+func (f CatAllocation) WithHeader(h map[string]string) func(*CatAllocationRequest) {
+	return func(r *CatAllocationRequest) {
+		if r.Header == nil {
+			r.Header = make(http.Header)
+		}
+		for k, v := range h {
+			r.Header.Add(k, v)
+		}
 	}
 }

--- a/esapi/api.cat.count.go
+++ b/esapi/api.cat.count.go
@@ -129,7 +129,11 @@ func (r CatCountRequest) Do(ctx context.Context, transport Transport) (*Response
 	}
 
 	if len(r.Header) > 0 {
-		req.Header = r.Header
+		for k, vv := range r.Header {
+			for _, v := range vv {
+				req.Header.Add(k, v)
+			}
+		}
 	}
 
 	if ctx != nil {

--- a/esapi/api.cat.count.go
+++ b/esapi/api.cat.count.go
@@ -129,9 +129,13 @@ func (r CatCountRequest) Do(ctx context.Context, transport Transport) (*Response
 	}
 
 	if len(r.Header) > 0 {
-		for k, vv := range r.Header {
-			for _, v := range vv {
-				req.Header.Add(k, v)
+		if len(req.Header) == 0 {
+			req.Header = r.Header
+		} else {
+			for k, vv := range r.Header {
+				for _, v := range vv {
+					req.Header.Add(k, v)
+				}
 			}
 		}
 	}

--- a/esapi/api.cat.count.go
+++ b/esapi/api.cat.count.go
@@ -4,6 +4,7 @@ package esapi
 
 import (
 	"context"
+	"net/http"
 	"strconv"
 	"strings"
 	"time"
@@ -44,6 +45,8 @@ type CatCountRequest struct {
 	Human      bool
 	ErrorTrace bool
 	FilterPath []string
+
+	Header http.Header
 
 	ctx context.Context
 }
@@ -123,6 +126,10 @@ func (r CatCountRequest) Do(ctx context.Context, transport Transport) (*Response
 			q.Set(k, v)
 		}
 		req.URL.RawQuery = q.Encode()
+	}
+
+	if len(r.Header) > 0 {
+		req.Header = r.Header
 	}
 
 	if ctx != nil {
@@ -244,5 +251,18 @@ func (f CatCount) WithErrorTrace() func(*CatCountRequest) {
 func (f CatCount) WithFilterPath(v ...string) func(*CatCountRequest) {
 	return func(r *CatCountRequest) {
 		r.FilterPath = v
+	}
+}
+
+// WithHeader adds the headers to the HTTP request
+//
+func (f CatCount) WithHeader(h map[string]string) func(*CatCountRequest) {
+	return func(r *CatCountRequest) {
+		if r.Header == nil {
+			r.Header = make(http.Header)
+		}
+		for k, v := range h {
+			r.Header.Add(k, v)
+		}
 	}
 }

--- a/esapi/api.cat.fielddata.go
+++ b/esapi/api.cat.fielddata.go
@@ -4,6 +4,7 @@ package esapi
 
 import (
 	"context"
+	"net/http"
 	"strconv"
 	"strings"
 	"time"
@@ -45,6 +46,8 @@ type CatFielddataRequest struct {
 	Human      bool
 	ErrorTrace bool
 	FilterPath []string
+
+	Header http.Header
 
 	ctx context.Context
 }
@@ -132,6 +135,10 @@ func (r CatFielddataRequest) Do(ctx context.Context, transport Transport) (*Resp
 			q.Set(k, v)
 		}
 		req.URL.RawQuery = q.Encode()
+	}
+
+	if len(r.Header) > 0 {
+		req.Header = r.Header
 	}
 
 	if ctx != nil {
@@ -261,5 +268,18 @@ func (f CatFielddata) WithErrorTrace() func(*CatFielddataRequest) {
 func (f CatFielddata) WithFilterPath(v ...string) func(*CatFielddataRequest) {
 	return func(r *CatFielddataRequest) {
 		r.FilterPath = v
+	}
+}
+
+// WithHeader adds the headers to the HTTP request
+//
+func (f CatFielddata) WithHeader(h map[string]string) func(*CatFielddataRequest) {
+	return func(r *CatFielddataRequest) {
+		if r.Header == nil {
+			r.Header = make(http.Header)
+		}
+		for k, v := range h {
+			r.Header.Add(k, v)
+		}
 	}
 }

--- a/esapi/api.cat.fielddata.go
+++ b/esapi/api.cat.fielddata.go
@@ -138,9 +138,13 @@ func (r CatFielddataRequest) Do(ctx context.Context, transport Transport) (*Resp
 	}
 
 	if len(r.Header) > 0 {
-		for k, vv := range r.Header {
-			for _, v := range vv {
-				req.Header.Add(k, v)
+		if len(req.Header) == 0 {
+			req.Header = r.Header
+		} else {
+			for k, vv := range r.Header {
+				for _, v := range vv {
+					req.Header.Add(k, v)
+				}
 			}
 		}
 	}

--- a/esapi/api.cat.fielddata.go
+++ b/esapi/api.cat.fielddata.go
@@ -138,7 +138,11 @@ func (r CatFielddataRequest) Do(ctx context.Context, transport Transport) (*Resp
 	}
 
 	if len(r.Header) > 0 {
-		req.Header = r.Header
+		for k, vv := range r.Header {
+			for _, v := range vv {
+				req.Header.Add(k, v)
+			}
+		}
 	}
 
 	if ctx != nil {

--- a/esapi/api.cat.health.go
+++ b/esapi/api.cat.health.go
@@ -4,6 +4,7 @@ package esapi
 
 import (
 	"context"
+	"net/http"
 	"strconv"
 	"strings"
 	"time"
@@ -43,6 +44,8 @@ type CatHealthRequest struct {
 	Human      bool
 	ErrorTrace bool
 	FilterPath []string
+
+	Header http.Header
 
 	ctx context.Context
 }
@@ -119,6 +122,10 @@ func (r CatHealthRequest) Do(ctx context.Context, transport Transport) (*Respons
 			q.Set(k, v)
 		}
 		req.URL.RawQuery = q.Encode()
+	}
+
+	if len(r.Header) > 0 {
+		req.Header = r.Header
 	}
 
 	if ctx != nil {
@@ -240,5 +247,18 @@ func (f CatHealth) WithErrorTrace() func(*CatHealthRequest) {
 func (f CatHealth) WithFilterPath(v ...string) func(*CatHealthRequest) {
 	return func(r *CatHealthRequest) {
 		r.FilterPath = v
+	}
+}
+
+// WithHeader adds the headers to the HTTP request
+//
+func (f CatHealth) WithHeader(h map[string]string) func(*CatHealthRequest) {
+	return func(r *CatHealthRequest) {
+		if r.Header == nil {
+			r.Header = make(http.Header)
+		}
+		for k, v := range h {
+			r.Header.Add(k, v)
+		}
 	}
 }

--- a/esapi/api.cat.health.go
+++ b/esapi/api.cat.health.go
@@ -125,9 +125,13 @@ func (r CatHealthRequest) Do(ctx context.Context, transport Transport) (*Respons
 	}
 
 	if len(r.Header) > 0 {
-		for k, vv := range r.Header {
-			for _, v := range vv {
-				req.Header.Add(k, v)
+		if len(req.Header) == 0 {
+			req.Header = r.Header
+		} else {
+			for k, vv := range r.Header {
+				for _, v := range vv {
+					req.Header.Add(k, v)
+				}
 			}
 		}
 	}

--- a/esapi/api.cat.health.go
+++ b/esapi/api.cat.health.go
@@ -125,7 +125,11 @@ func (r CatHealthRequest) Do(ctx context.Context, transport Transport) (*Respons
 	}
 
 	if len(r.Header) > 0 {
-		req.Header = r.Header
+		for k, vv := range r.Header {
+			for _, v := range vv {
+				req.Header.Add(k, v)
+			}
+		}
 	}
 
 	if ctx != nil {

--- a/esapi/api.cat.help.go
+++ b/esapi/api.cat.help.go
@@ -4,6 +4,7 @@ package esapi
 
 import (
 	"context"
+	"net/http"
 	"strconv"
 	"strings"
 )
@@ -36,6 +37,8 @@ type CatHelpRequest struct {
 	Human      bool
 	ErrorTrace bool
 	FilterPath []string
+
+	Header http.Header
 
 	ctx context.Context
 }
@@ -88,6 +91,10 @@ func (r CatHelpRequest) Do(ctx context.Context, transport Transport) (*Response,
 			q.Set(k, v)
 		}
 		req.URL.RawQuery = q.Encode()
+	}
+
+	if len(r.Header) > 0 {
+		req.Header = r.Header
 	}
 
 	if ctx != nil {
@@ -161,5 +168,18 @@ func (f CatHelp) WithErrorTrace() func(*CatHelpRequest) {
 func (f CatHelp) WithFilterPath(v ...string) func(*CatHelpRequest) {
 	return func(r *CatHelpRequest) {
 		r.FilterPath = v
+	}
+}
+
+// WithHeader adds the headers to the HTTP request
+//
+func (f CatHelp) WithHeader(h map[string]string) func(*CatHelpRequest) {
+	return func(r *CatHelpRequest) {
+		if r.Header == nil {
+			r.Header = make(http.Header)
+		}
+		for k, v := range h {
+			r.Header.Add(k, v)
+		}
 	}
 }

--- a/esapi/api.cat.help.go
+++ b/esapi/api.cat.help.go
@@ -94,7 +94,11 @@ func (r CatHelpRequest) Do(ctx context.Context, transport Transport) (*Response,
 	}
 
 	if len(r.Header) > 0 {
-		req.Header = r.Header
+		for k, vv := range r.Header {
+			for _, v := range vv {
+				req.Header.Add(k, v)
+			}
+		}
 	}
 
 	if ctx != nil {

--- a/esapi/api.cat.help.go
+++ b/esapi/api.cat.help.go
@@ -94,9 +94,13 @@ func (r CatHelpRequest) Do(ctx context.Context, transport Transport) (*Response,
 	}
 
 	if len(r.Header) > 0 {
-		for k, vv := range r.Header {
-			for _, v := range vv {
-				req.Header.Add(k, v)
+		if len(req.Header) == 0 {
+			req.Header = r.Header
+		} else {
+			for k, vv := range r.Header {
+				for _, v := range vv {
+					req.Header.Add(k, v)
+				}
 			}
 		}
 	}

--- a/esapi/api.cat.indices.go
+++ b/esapi/api.cat.indices.go
@@ -149,7 +149,11 @@ func (r CatIndicesRequest) Do(ctx context.Context, transport Transport) (*Respon
 	}
 
 	if len(r.Header) > 0 {
-		req.Header = r.Header
+		for k, vv := range r.Header {
+			for _, v := range vv {
+				req.Header.Add(k, v)
+			}
+		}
 	}
 
 	if ctx != nil {

--- a/esapi/api.cat.indices.go
+++ b/esapi/api.cat.indices.go
@@ -4,6 +4,7 @@ package esapi
 
 import (
 	"context"
+	"net/http"
 	"strconv"
 	"strings"
 	"time"
@@ -48,6 +49,8 @@ type CatIndicesRequest struct {
 	Human      bool
 	ErrorTrace bool
 	FilterPath []string
+
+	Header http.Header
 
 	ctx context.Context
 }
@@ -143,6 +146,10 @@ func (r CatIndicesRequest) Do(ctx context.Context, transport Transport) (*Respon
 			q.Set(k, v)
 		}
 		req.URL.RawQuery = q.Encode()
+	}
+
+	if len(r.Header) > 0 {
+		req.Header = r.Header
 	}
 
 	if ctx != nil {
@@ -296,5 +303,18 @@ func (f CatIndices) WithErrorTrace() func(*CatIndicesRequest) {
 func (f CatIndices) WithFilterPath(v ...string) func(*CatIndicesRequest) {
 	return func(r *CatIndicesRequest) {
 		r.FilterPath = v
+	}
+}
+
+// WithHeader adds the headers to the HTTP request
+//
+func (f CatIndices) WithHeader(h map[string]string) func(*CatIndicesRequest) {
+	return func(r *CatIndicesRequest) {
+		if r.Header == nil {
+			r.Header = make(http.Header)
+		}
+		for k, v := range h {
+			r.Header.Add(k, v)
+		}
 	}
 }

--- a/esapi/api.cat.indices.go
+++ b/esapi/api.cat.indices.go
@@ -149,9 +149,13 @@ func (r CatIndicesRequest) Do(ctx context.Context, transport Transport) (*Respon
 	}
 
 	if len(r.Header) > 0 {
-		for k, vv := range r.Header {
-			for _, v := range vv {
-				req.Header.Add(k, v)
+		if len(req.Header) == 0 {
+			req.Header = r.Header
+		} else {
+			for k, vv := range r.Header {
+				for _, v := range vv {
+					req.Header.Add(k, v)
+				}
 			}
 		}
 	}

--- a/esapi/api.cat.master.go
+++ b/esapi/api.cat.master.go
@@ -120,7 +120,11 @@ func (r CatMasterRequest) Do(ctx context.Context, transport Transport) (*Respons
 	}
 
 	if len(r.Header) > 0 {
-		req.Header = r.Header
+		for k, vv := range r.Header {
+			for _, v := range vv {
+				req.Header.Add(k, v)
+			}
+		}
 	}
 
 	if ctx != nil {

--- a/esapi/api.cat.master.go
+++ b/esapi/api.cat.master.go
@@ -4,6 +4,7 @@ package esapi
 
 import (
 	"context"
+	"net/http"
 	"strconv"
 	"strings"
 	"time"
@@ -42,6 +43,8 @@ type CatMasterRequest struct {
 	Human      bool
 	ErrorTrace bool
 	FilterPath []string
+
+	Header http.Header
 
 	ctx context.Context
 }
@@ -114,6 +117,10 @@ func (r CatMasterRequest) Do(ctx context.Context, transport Transport) (*Respons
 			q.Set(k, v)
 		}
 		req.URL.RawQuery = q.Encode()
+	}
+
+	if len(r.Header) > 0 {
+		req.Header = r.Header
 	}
 
 	if ctx != nil {
@@ -227,5 +234,18 @@ func (f CatMaster) WithErrorTrace() func(*CatMasterRequest) {
 func (f CatMaster) WithFilterPath(v ...string) func(*CatMasterRequest) {
 	return func(r *CatMasterRequest) {
 		r.FilterPath = v
+	}
+}
+
+// WithHeader adds the headers to the HTTP request
+//
+func (f CatMaster) WithHeader(h map[string]string) func(*CatMasterRequest) {
+	return func(r *CatMasterRequest) {
+		if r.Header == nil {
+			r.Header = make(http.Header)
+		}
+		for k, v := range h {
+			r.Header.Add(k, v)
+		}
 	}
 }

--- a/esapi/api.cat.master.go
+++ b/esapi/api.cat.master.go
@@ -120,9 +120,13 @@ func (r CatMasterRequest) Do(ctx context.Context, transport Transport) (*Respons
 	}
 
 	if len(r.Header) > 0 {
-		for k, vv := range r.Header {
-			for _, v := range vv {
-				req.Header.Add(k, v)
+		if len(req.Header) == 0 {
+			req.Header = r.Header
+		} else {
+			for k, vv := range r.Header {
+				for _, v := range vv {
+					req.Header.Add(k, v)
+				}
 			}
 		}
 	}

--- a/esapi/api.cat.nodeattrs.go
+++ b/esapi/api.cat.nodeattrs.go
@@ -4,6 +4,7 @@ package esapi
 
 import (
 	"context"
+	"net/http"
 	"strconv"
 	"strings"
 	"time"
@@ -42,6 +43,8 @@ type CatNodeattrsRequest struct {
 	Human      bool
 	ErrorTrace bool
 	FilterPath []string
+
+	Header http.Header
 
 	ctx context.Context
 }
@@ -114,6 +117,10 @@ func (r CatNodeattrsRequest) Do(ctx context.Context, transport Transport) (*Resp
 			q.Set(k, v)
 		}
 		req.URL.RawQuery = q.Encode()
+	}
+
+	if len(r.Header) > 0 {
+		req.Header = r.Header
 	}
 
 	if ctx != nil {
@@ -227,5 +234,18 @@ func (f CatNodeattrs) WithErrorTrace() func(*CatNodeattrsRequest) {
 func (f CatNodeattrs) WithFilterPath(v ...string) func(*CatNodeattrsRequest) {
 	return func(r *CatNodeattrsRequest) {
 		r.FilterPath = v
+	}
+}
+
+// WithHeader adds the headers to the HTTP request
+//
+func (f CatNodeattrs) WithHeader(h map[string]string) func(*CatNodeattrsRequest) {
+	return func(r *CatNodeattrsRequest) {
+		if r.Header == nil {
+			r.Header = make(http.Header)
+		}
+		for k, v := range h {
+			r.Header.Add(k, v)
+		}
 	}
 }

--- a/esapi/api.cat.nodeattrs.go
+++ b/esapi/api.cat.nodeattrs.go
@@ -120,9 +120,13 @@ func (r CatNodeattrsRequest) Do(ctx context.Context, transport Transport) (*Resp
 	}
 
 	if len(r.Header) > 0 {
-		for k, vv := range r.Header {
-			for _, v := range vv {
-				req.Header.Add(k, v)
+		if len(req.Header) == 0 {
+			req.Header = r.Header
+		} else {
+			for k, vv := range r.Header {
+				for _, v := range vv {
+					req.Header.Add(k, v)
+				}
 			}
 		}
 	}

--- a/esapi/api.cat.nodeattrs.go
+++ b/esapi/api.cat.nodeattrs.go
@@ -120,7 +120,11 @@ func (r CatNodeattrsRequest) Do(ctx context.Context, transport Transport) (*Resp
 	}
 
 	if len(r.Header) > 0 {
-		req.Header = r.Header
+		for k, vv := range r.Header {
+			for _, v := range vv {
+				req.Header.Add(k, v)
+			}
+		}
 	}
 
 	if ctx != nil {

--- a/esapi/api.cat.nodes.go
+++ b/esapi/api.cat.nodes.go
@@ -125,7 +125,11 @@ func (r CatNodesRequest) Do(ctx context.Context, transport Transport) (*Response
 	}
 
 	if len(r.Header) > 0 {
-		req.Header = r.Header
+		for k, vv := range r.Header {
+			for _, v := range vv {
+				req.Header.Add(k, v)
+			}
+		}
 	}
 
 	if ctx != nil {

--- a/esapi/api.cat.nodes.go
+++ b/esapi/api.cat.nodes.go
@@ -4,6 +4,7 @@ package esapi
 
 import (
 	"context"
+	"net/http"
 	"strconv"
 	"strings"
 	"time"
@@ -43,6 +44,8 @@ type CatNodesRequest struct {
 	Human      bool
 	ErrorTrace bool
 	FilterPath []string
+
+	Header http.Header
 
 	ctx context.Context
 }
@@ -119,6 +122,10 @@ func (r CatNodesRequest) Do(ctx context.Context, transport Transport) (*Response
 			q.Set(k, v)
 		}
 		req.URL.RawQuery = q.Encode()
+	}
+
+	if len(r.Header) > 0 {
+		req.Header = r.Header
 	}
 
 	if ctx != nil {
@@ -240,5 +247,18 @@ func (f CatNodes) WithErrorTrace() func(*CatNodesRequest) {
 func (f CatNodes) WithFilterPath(v ...string) func(*CatNodesRequest) {
 	return func(r *CatNodesRequest) {
 		r.FilterPath = v
+	}
+}
+
+// WithHeader adds the headers to the HTTP request
+//
+func (f CatNodes) WithHeader(h map[string]string) func(*CatNodesRequest) {
+	return func(r *CatNodesRequest) {
+		if r.Header == nil {
+			r.Header = make(http.Header)
+		}
+		for k, v := range h {
+			r.Header.Add(k, v)
+		}
 	}
 }

--- a/esapi/api.cat.nodes.go
+++ b/esapi/api.cat.nodes.go
@@ -125,9 +125,13 @@ func (r CatNodesRequest) Do(ctx context.Context, transport Transport) (*Response
 	}
 
 	if len(r.Header) > 0 {
-		for k, vv := range r.Header {
-			for _, v := range vv {
-				req.Header.Add(k, v)
+		if len(req.Header) == 0 {
+			req.Header = r.Header
+		} else {
+			for k, vv := range r.Header {
+				for _, v := range vv {
+					req.Header.Add(k, v)
+				}
 			}
 		}
 	}

--- a/esapi/api.cat.pending_tasks.go
+++ b/esapi/api.cat.pending_tasks.go
@@ -120,9 +120,13 @@ func (r CatPendingTasksRequest) Do(ctx context.Context, transport Transport) (*R
 	}
 
 	if len(r.Header) > 0 {
-		for k, vv := range r.Header {
-			for _, v := range vv {
-				req.Header.Add(k, v)
+		if len(req.Header) == 0 {
+			req.Header = r.Header
+		} else {
+			for k, vv := range r.Header {
+				for _, v := range vv {
+					req.Header.Add(k, v)
+				}
 			}
 		}
 	}

--- a/esapi/api.cat.pending_tasks.go
+++ b/esapi/api.cat.pending_tasks.go
@@ -4,6 +4,7 @@ package esapi
 
 import (
 	"context"
+	"net/http"
 	"strconv"
 	"strings"
 	"time"
@@ -42,6 +43,8 @@ type CatPendingTasksRequest struct {
 	Human      bool
 	ErrorTrace bool
 	FilterPath []string
+
+	Header http.Header
 
 	ctx context.Context
 }
@@ -114,6 +117,10 @@ func (r CatPendingTasksRequest) Do(ctx context.Context, transport Transport) (*R
 			q.Set(k, v)
 		}
 		req.URL.RawQuery = q.Encode()
+	}
+
+	if len(r.Header) > 0 {
+		req.Header = r.Header
 	}
 
 	if ctx != nil {
@@ -227,5 +234,18 @@ func (f CatPendingTasks) WithErrorTrace() func(*CatPendingTasksRequest) {
 func (f CatPendingTasks) WithFilterPath(v ...string) func(*CatPendingTasksRequest) {
 	return func(r *CatPendingTasksRequest) {
 		r.FilterPath = v
+	}
+}
+
+// WithHeader adds the headers to the HTTP request
+//
+func (f CatPendingTasks) WithHeader(h map[string]string) func(*CatPendingTasksRequest) {
+	return func(r *CatPendingTasksRequest) {
+		if r.Header == nil {
+			r.Header = make(http.Header)
+		}
+		for k, v := range h {
+			r.Header.Add(k, v)
+		}
 	}
 }

--- a/esapi/api.cat.pending_tasks.go
+++ b/esapi/api.cat.pending_tasks.go
@@ -120,7 +120,11 @@ func (r CatPendingTasksRequest) Do(ctx context.Context, transport Transport) (*R
 	}
 
 	if len(r.Header) > 0 {
-		req.Header = r.Header
+		for k, vv := range r.Header {
+			for _, v := range vv {
+				req.Header.Add(k, v)
+			}
+		}
 	}
 
 	if ctx != nil {

--- a/esapi/api.cat.plugins.go
+++ b/esapi/api.cat.plugins.go
@@ -4,6 +4,7 @@ package esapi
 
 import (
 	"context"
+	"net/http"
 	"strconv"
 	"strings"
 	"time"
@@ -42,6 +43,8 @@ type CatPluginsRequest struct {
 	Human      bool
 	ErrorTrace bool
 	FilterPath []string
+
+	Header http.Header
 
 	ctx context.Context
 }
@@ -114,6 +117,10 @@ func (r CatPluginsRequest) Do(ctx context.Context, transport Transport) (*Respon
 			q.Set(k, v)
 		}
 		req.URL.RawQuery = q.Encode()
+	}
+
+	if len(r.Header) > 0 {
+		req.Header = r.Header
 	}
 
 	if ctx != nil {
@@ -227,5 +234,18 @@ func (f CatPlugins) WithErrorTrace() func(*CatPluginsRequest) {
 func (f CatPlugins) WithFilterPath(v ...string) func(*CatPluginsRequest) {
 	return func(r *CatPluginsRequest) {
 		r.FilterPath = v
+	}
+}
+
+// WithHeader adds the headers to the HTTP request
+//
+func (f CatPlugins) WithHeader(h map[string]string) func(*CatPluginsRequest) {
+	return func(r *CatPluginsRequest) {
+		if r.Header == nil {
+			r.Header = make(http.Header)
+		}
+		for k, v := range h {
+			r.Header.Add(k, v)
+		}
 	}
 }

--- a/esapi/api.cat.plugins.go
+++ b/esapi/api.cat.plugins.go
@@ -120,7 +120,11 @@ func (r CatPluginsRequest) Do(ctx context.Context, transport Transport) (*Respon
 	}
 
 	if len(r.Header) > 0 {
-		req.Header = r.Header
+		for k, vv := range r.Header {
+			for _, v := range vv {
+				req.Header.Add(k, v)
+			}
+		}
 	}
 
 	if ctx != nil {

--- a/esapi/api.cat.plugins.go
+++ b/esapi/api.cat.plugins.go
@@ -120,9 +120,13 @@ func (r CatPluginsRequest) Do(ctx context.Context, transport Transport) (*Respon
 	}
 
 	if len(r.Header) > 0 {
-		for k, vv := range r.Header {
-			for _, v := range vv {
-				req.Header.Add(k, v)
+		if len(req.Header) == 0 {
+			req.Header = r.Header
+		} else {
+			for k, vv := range r.Header {
+				for _, v := range vv {
+					req.Header.Add(k, v)
+				}
 			}
 		}
 	}

--- a/esapi/api.cat.recovery.go
+++ b/esapi/api.cat.recovery.go
@@ -129,9 +129,13 @@ func (r CatRecoveryRequest) Do(ctx context.Context, transport Transport) (*Respo
 	}
 
 	if len(r.Header) > 0 {
-		for k, vv := range r.Header {
-			for _, v := range vv {
-				req.Header.Add(k, v)
+		if len(req.Header) == 0 {
+			req.Header = r.Header
+		} else {
+			for k, vv := range r.Header {
+				for _, v := range vv {
+					req.Header.Add(k, v)
+				}
 			}
 		}
 	}

--- a/esapi/api.cat.recovery.go
+++ b/esapi/api.cat.recovery.go
@@ -129,7 +129,11 @@ func (r CatRecoveryRequest) Do(ctx context.Context, transport Transport) (*Respo
 	}
 
 	if len(r.Header) > 0 {
-		req.Header = r.Header
+		for k, vv := range r.Header {
+			for _, v := range vv {
+				req.Header.Add(k, v)
+			}
+		}
 	}
 
 	if ctx != nil {

--- a/esapi/api.cat.recovery.go
+++ b/esapi/api.cat.recovery.go
@@ -4,6 +4,7 @@ package esapi
 
 import (
 	"context"
+	"net/http"
 	"strconv"
 	"strings"
 	"time"
@@ -44,6 +45,8 @@ type CatRecoveryRequest struct {
 	Human      bool
 	ErrorTrace bool
 	FilterPath []string
+
+	Header http.Header
 
 	ctx context.Context
 }
@@ -123,6 +126,10 @@ func (r CatRecoveryRequest) Do(ctx context.Context, transport Transport) (*Respo
 			q.Set(k, v)
 		}
 		req.URL.RawQuery = q.Encode()
+	}
+
+	if len(r.Header) > 0 {
+		req.Header = r.Header
 	}
 
 	if ctx != nil {
@@ -244,5 +251,18 @@ func (f CatRecovery) WithErrorTrace() func(*CatRecoveryRequest) {
 func (f CatRecovery) WithFilterPath(v ...string) func(*CatRecoveryRequest) {
 	return func(r *CatRecoveryRequest) {
 		r.FilterPath = v
+	}
+}
+
+// WithHeader adds the headers to the HTTP request
+//
+func (f CatRecovery) WithHeader(h map[string]string) func(*CatRecoveryRequest) {
+	return func(r *CatRecoveryRequest) {
+		if r.Header == nil {
+			r.Header = make(http.Header)
+		}
+		for k, v := range h {
+			r.Header.Add(k, v)
+		}
 	}
 }

--- a/esapi/api.cat.repositories.go
+++ b/esapi/api.cat.repositories.go
@@ -4,6 +4,7 @@ package esapi
 
 import (
 	"context"
+	"net/http"
 	"strconv"
 	"strings"
 	"time"
@@ -42,6 +43,8 @@ type CatRepositoriesRequest struct {
 	Human      bool
 	ErrorTrace bool
 	FilterPath []string
+
+	Header http.Header
 
 	ctx context.Context
 }
@@ -114,6 +117,10 @@ func (r CatRepositoriesRequest) Do(ctx context.Context, transport Transport) (*R
 			q.Set(k, v)
 		}
 		req.URL.RawQuery = q.Encode()
+	}
+
+	if len(r.Header) > 0 {
+		req.Header = r.Header
 	}
 
 	if ctx != nil {
@@ -227,5 +234,18 @@ func (f CatRepositories) WithErrorTrace() func(*CatRepositoriesRequest) {
 func (f CatRepositories) WithFilterPath(v ...string) func(*CatRepositoriesRequest) {
 	return func(r *CatRepositoriesRequest) {
 		r.FilterPath = v
+	}
+}
+
+// WithHeader adds the headers to the HTTP request
+//
+func (f CatRepositories) WithHeader(h map[string]string) func(*CatRepositoriesRequest) {
+	return func(r *CatRepositoriesRequest) {
+		if r.Header == nil {
+			r.Header = make(http.Header)
+		}
+		for k, v := range h {
+			r.Header.Add(k, v)
+		}
 	}
 }

--- a/esapi/api.cat.repositories.go
+++ b/esapi/api.cat.repositories.go
@@ -120,9 +120,13 @@ func (r CatRepositoriesRequest) Do(ctx context.Context, transport Transport) (*R
 	}
 
 	if len(r.Header) > 0 {
-		for k, vv := range r.Header {
-			for _, v := range vv {
-				req.Header.Add(k, v)
+		if len(req.Header) == 0 {
+			req.Header = r.Header
+		} else {
+			for k, vv := range r.Header {
+				for _, v := range vv {
+					req.Header.Add(k, v)
+				}
 			}
 		}
 	}

--- a/esapi/api.cat.repositories.go
+++ b/esapi/api.cat.repositories.go
@@ -120,7 +120,11 @@ func (r CatRepositoriesRequest) Do(ctx context.Context, transport Transport) (*R
 	}
 
 	if len(r.Header) > 0 {
-		req.Header = r.Header
+		for k, vv := range r.Header {
+			for _, v := range vv {
+				req.Header.Add(k, v)
+			}
+		}
 	}
 
 	if ctx != nil {

--- a/esapi/api.cat.segments.go
+++ b/esapi/api.cat.segments.go
@@ -123,9 +123,13 @@ func (r CatSegmentsRequest) Do(ctx context.Context, transport Transport) (*Respo
 	}
 
 	if len(r.Header) > 0 {
-		for k, vv := range r.Header {
-			for _, v := range vv {
-				req.Header.Add(k, v)
+		if len(req.Header) == 0 {
+			req.Header = r.Header
+		} else {
+			for k, vv := range r.Header {
+				for _, v := range vv {
+					req.Header.Add(k, v)
+				}
 			}
 		}
 	}

--- a/esapi/api.cat.segments.go
+++ b/esapi/api.cat.segments.go
@@ -123,7 +123,11 @@ func (r CatSegmentsRequest) Do(ctx context.Context, transport Transport) (*Respo
 	}
 
 	if len(r.Header) > 0 {
-		req.Header = r.Header
+		for k, vv := range r.Header {
+			for _, v := range vv {
+				req.Header.Add(k, v)
+			}
+		}
 	}
 
 	if ctx != nil {

--- a/esapi/api.cat.segments.go
+++ b/esapi/api.cat.segments.go
@@ -4,6 +4,7 @@ package esapi
 
 import (
 	"context"
+	"net/http"
 	"strconv"
 	"strings"
 )
@@ -42,6 +43,8 @@ type CatSegmentsRequest struct {
 	Human      bool
 	ErrorTrace bool
 	FilterPath []string
+
+	Header http.Header
 
 	ctx context.Context
 }
@@ -117,6 +120,10 @@ func (r CatSegmentsRequest) Do(ctx context.Context, transport Transport) (*Respo
 			q.Set(k, v)
 		}
 		req.URL.RawQuery = q.Encode()
+	}
+
+	if len(r.Header) > 0 {
+		req.Header = r.Header
 	}
 
 	if ctx != nil {
@@ -230,5 +237,18 @@ func (f CatSegments) WithErrorTrace() func(*CatSegmentsRequest) {
 func (f CatSegments) WithFilterPath(v ...string) func(*CatSegmentsRequest) {
 	return func(r *CatSegmentsRequest) {
 		r.FilterPath = v
+	}
+}
+
+// WithHeader adds the headers to the HTTP request
+//
+func (f CatSegments) WithHeader(h map[string]string) func(*CatSegmentsRequest) {
+	return func(r *CatSegmentsRequest) {
+		if r.Header == nil {
+			r.Header = make(http.Header)
+		}
+		for k, v := range h {
+			r.Header.Add(k, v)
+		}
 	}
 }

--- a/esapi/api.cat.shards.go
+++ b/esapi/api.cat.shards.go
@@ -4,6 +4,7 @@ package esapi
 
 import (
 	"context"
+	"net/http"
 	"strconv"
 	"strings"
 	"time"
@@ -45,6 +46,8 @@ type CatShardsRequest struct {
 	Human      bool
 	ErrorTrace bool
 	FilterPath []string
+
+	Header http.Header
 
 	ctx context.Context
 }
@@ -128,6 +131,10 @@ func (r CatShardsRequest) Do(ctx context.Context, transport Transport) (*Respons
 			q.Set(k, v)
 		}
 		req.URL.RawQuery = q.Encode()
+	}
+
+	if len(r.Header) > 0 {
+		req.Header = r.Header
 	}
 
 	if ctx != nil {
@@ -257,5 +264,18 @@ func (f CatShards) WithErrorTrace() func(*CatShardsRequest) {
 func (f CatShards) WithFilterPath(v ...string) func(*CatShardsRequest) {
 	return func(r *CatShardsRequest) {
 		r.FilterPath = v
+	}
+}
+
+// WithHeader adds the headers to the HTTP request
+//
+func (f CatShards) WithHeader(h map[string]string) func(*CatShardsRequest) {
+	return func(r *CatShardsRequest) {
+		if r.Header == nil {
+			r.Header = make(http.Header)
+		}
+		for k, v := range h {
+			r.Header.Add(k, v)
+		}
 	}
 }

--- a/esapi/api.cat.shards.go
+++ b/esapi/api.cat.shards.go
@@ -134,9 +134,13 @@ func (r CatShardsRequest) Do(ctx context.Context, transport Transport) (*Respons
 	}
 
 	if len(r.Header) > 0 {
-		for k, vv := range r.Header {
-			for _, v := range vv {
-				req.Header.Add(k, v)
+		if len(req.Header) == 0 {
+			req.Header = r.Header
+		} else {
+			for k, vv := range r.Header {
+				for _, v := range vv {
+					req.Header.Add(k, v)
+				}
 			}
 		}
 	}

--- a/esapi/api.cat.shards.go
+++ b/esapi/api.cat.shards.go
@@ -134,7 +134,11 @@ func (r CatShardsRequest) Do(ctx context.Context, transport Transport) (*Respons
 	}
 
 	if len(r.Header) > 0 {
-		req.Header = r.Header
+		for k, vv := range r.Header {
+			for _, v := range vv {
+				req.Header.Add(k, v)
+			}
+		}
 	}
 
 	if ctx != nil {

--- a/esapi/api.cat.snapshots.go
+++ b/esapi/api.cat.snapshots.go
@@ -4,6 +4,7 @@ package esapi
 
 import (
 	"context"
+	"net/http"
 	"strconv"
 	"strings"
 	"time"
@@ -44,6 +45,8 @@ type CatSnapshotsRequest struct {
 	Human      bool
 	ErrorTrace bool
 	FilterPath []string
+
+	Header http.Header
 
 	ctx context.Context
 }
@@ -123,6 +126,10 @@ func (r CatSnapshotsRequest) Do(ctx context.Context, transport Transport) (*Resp
 			q.Set(k, v)
 		}
 		req.URL.RawQuery = q.Encode()
+	}
+
+	if len(r.Header) > 0 {
+		req.Header = r.Header
 	}
 
 	if ctx != nil {
@@ -244,5 +251,18 @@ func (f CatSnapshots) WithErrorTrace() func(*CatSnapshotsRequest) {
 func (f CatSnapshots) WithFilterPath(v ...string) func(*CatSnapshotsRequest) {
 	return func(r *CatSnapshotsRequest) {
 		r.FilterPath = v
+	}
+}
+
+// WithHeader adds the headers to the HTTP request
+//
+func (f CatSnapshots) WithHeader(h map[string]string) func(*CatSnapshotsRequest) {
+	return func(r *CatSnapshotsRequest) {
+		if r.Header == nil {
+			r.Header = make(http.Header)
+		}
+		for k, v := range h {
+			r.Header.Add(k, v)
+		}
 	}
 }

--- a/esapi/api.cat.snapshots.go
+++ b/esapi/api.cat.snapshots.go
@@ -129,9 +129,13 @@ func (r CatSnapshotsRequest) Do(ctx context.Context, transport Transport) (*Resp
 	}
 
 	if len(r.Header) > 0 {
-		for k, vv := range r.Header {
-			for _, v := range vv {
-				req.Header.Add(k, v)
+		if len(req.Header) == 0 {
+			req.Header = r.Header
+		} else {
+			for k, vv := range r.Header {
+				for _, v := range vv {
+					req.Header.Add(k, v)
+				}
 			}
 		}
 	}

--- a/esapi/api.cat.snapshots.go
+++ b/esapi/api.cat.snapshots.go
@@ -129,7 +129,11 @@ func (r CatSnapshotsRequest) Do(ctx context.Context, transport Transport) (*Resp
 	}
 
 	if len(r.Header) > 0 {
-		req.Header = r.Header
+		for k, vv := range r.Header {
+			for _, v := range vv {
+				req.Header.Add(k, v)
+			}
+		}
 	}
 
 	if ctx != nil {

--- a/esapi/api.cat.tasks.go
+++ b/esapi/api.cat.tasks.go
@@ -129,7 +129,11 @@ func (r CatTasksRequest) Do(ctx context.Context, transport Transport) (*Response
 	}
 
 	if len(r.Header) > 0 {
-		req.Header = r.Header
+		for k, vv := range r.Header {
+			for _, v := range vv {
+				req.Header.Add(k, v)
+			}
+		}
 	}
 
 	if ctx != nil {

--- a/esapi/api.cat.tasks.go
+++ b/esapi/api.cat.tasks.go
@@ -4,6 +4,7 @@ package esapi
 
 import (
 	"context"
+	"net/http"
 	"strconv"
 	"strings"
 )
@@ -43,6 +44,8 @@ type CatTasksRequest struct {
 	Human      bool
 	ErrorTrace bool
 	FilterPath []string
+
+	Header http.Header
 
 	ctx context.Context
 }
@@ -123,6 +126,10 @@ func (r CatTasksRequest) Do(ctx context.Context, transport Transport) (*Response
 			q.Set(k, v)
 		}
 		req.URL.RawQuery = q.Encode()
+	}
+
+	if len(r.Header) > 0 {
+		req.Header = r.Header
 	}
 
 	if ctx != nil {
@@ -252,5 +259,18 @@ func (f CatTasks) WithErrorTrace() func(*CatTasksRequest) {
 func (f CatTasks) WithFilterPath(v ...string) func(*CatTasksRequest) {
 	return func(r *CatTasksRequest) {
 		r.FilterPath = v
+	}
+}
+
+// WithHeader adds the headers to the HTTP request
+//
+func (f CatTasks) WithHeader(h map[string]string) func(*CatTasksRequest) {
+	return func(r *CatTasksRequest) {
+		if r.Header == nil {
+			r.Header = make(http.Header)
+		}
+		for k, v := range h {
+			r.Header.Add(k, v)
+		}
 	}
 }

--- a/esapi/api.cat.tasks.go
+++ b/esapi/api.cat.tasks.go
@@ -129,9 +129,13 @@ func (r CatTasksRequest) Do(ctx context.Context, transport Transport) (*Response
 	}
 
 	if len(r.Header) > 0 {
-		for k, vv := range r.Header {
-			for _, v := range vv {
-				req.Header.Add(k, v)
+		if len(req.Header) == 0 {
+			req.Header = r.Header
+		} else {
+			for k, vv := range r.Header {
+				for _, v := range vv {
+					req.Header.Add(k, v)
+				}
 			}
 		}
 	}

--- a/esapi/api.cat.templates.go
+++ b/esapi/api.cat.templates.go
@@ -129,9 +129,13 @@ func (r CatTemplatesRequest) Do(ctx context.Context, transport Transport) (*Resp
 	}
 
 	if len(r.Header) > 0 {
-		for k, vv := range r.Header {
-			for _, v := range vv {
-				req.Header.Add(k, v)
+		if len(req.Header) == 0 {
+			req.Header = r.Header
+		} else {
+			for k, vv := range r.Header {
+				for _, v := range vv {
+					req.Header.Add(k, v)
+				}
 			}
 		}
 	}

--- a/esapi/api.cat.templates.go
+++ b/esapi/api.cat.templates.go
@@ -4,6 +4,7 @@ package esapi
 
 import (
 	"context"
+	"net/http"
 	"strconv"
 	"strings"
 	"time"
@@ -44,6 +45,8 @@ type CatTemplatesRequest struct {
 	Human      bool
 	ErrorTrace bool
 	FilterPath []string
+
+	Header http.Header
 
 	ctx context.Context
 }
@@ -123,6 +126,10 @@ func (r CatTemplatesRequest) Do(ctx context.Context, transport Transport) (*Resp
 			q.Set(k, v)
 		}
 		req.URL.RawQuery = q.Encode()
+	}
+
+	if len(r.Header) > 0 {
+		req.Header = r.Header
 	}
 
 	if ctx != nil {
@@ -244,5 +251,18 @@ func (f CatTemplates) WithErrorTrace() func(*CatTemplatesRequest) {
 func (f CatTemplates) WithFilterPath(v ...string) func(*CatTemplatesRequest) {
 	return func(r *CatTemplatesRequest) {
 		r.FilterPath = v
+	}
+}
+
+// WithHeader adds the headers to the HTTP request
+//
+func (f CatTemplates) WithHeader(h map[string]string) func(*CatTemplatesRequest) {
+	return func(r *CatTemplatesRequest) {
+		if r.Header == nil {
+			r.Header = make(http.Header)
+		}
+		for k, v := range h {
+			r.Header.Add(k, v)
+		}
 	}
 }

--- a/esapi/api.cat.templates.go
+++ b/esapi/api.cat.templates.go
@@ -129,7 +129,11 @@ func (r CatTemplatesRequest) Do(ctx context.Context, transport Transport) (*Resp
 	}
 
 	if len(r.Header) > 0 {
-		req.Header = r.Header
+		for k, vv := range r.Header {
+			for _, v := range vv {
+				req.Header.Add(k, v)
+			}
+		}
 	}
 
 	if ctx != nil {

--- a/esapi/api.cat.thread_pool.go
+++ b/esapi/api.cat.thread_pool.go
@@ -135,9 +135,13 @@ func (r CatThreadPoolRequest) Do(ctx context.Context, transport Transport) (*Res
 	}
 
 	if len(r.Header) > 0 {
-		for k, vv := range r.Header {
-			for _, v := range vv {
-				req.Header.Add(k, v)
+		if len(req.Header) == 0 {
+			req.Header = r.Header
+		} else {
+			for k, vv := range r.Header {
+				for _, v := range vv {
+					req.Header.Add(k, v)
+				}
 			}
 		}
 	}

--- a/esapi/api.cat.thread_pool.go
+++ b/esapi/api.cat.thread_pool.go
@@ -135,7 +135,11 @@ func (r CatThreadPoolRequest) Do(ctx context.Context, transport Transport) (*Res
 	}
 
 	if len(r.Header) > 0 {
-		req.Header = r.Header
+		for k, vv := range r.Header {
+			for _, v := range vv {
+				req.Header.Add(k, v)
+			}
+		}
 	}
 
 	if ctx != nil {

--- a/esapi/api.cat.thread_pool.go
+++ b/esapi/api.cat.thread_pool.go
@@ -4,6 +4,7 @@ package esapi
 
 import (
 	"context"
+	"net/http"
 	"strconv"
 	"strings"
 	"time"
@@ -46,6 +47,8 @@ type CatThreadPoolRequest struct {
 	Human      bool
 	ErrorTrace bool
 	FilterPath []string
+
+	Header http.Header
 
 	ctx context.Context
 }
@@ -129,6 +132,10 @@ func (r CatThreadPoolRequest) Do(ctx context.Context, transport Transport) (*Res
 			q.Set(k, v)
 		}
 		req.URL.RawQuery = q.Encode()
+	}
+
+	if len(r.Header) > 0 {
+		req.Header = r.Header
 	}
 
 	if ctx != nil {
@@ -258,5 +265,18 @@ func (f CatThreadPool) WithErrorTrace() func(*CatThreadPoolRequest) {
 func (f CatThreadPool) WithFilterPath(v ...string) func(*CatThreadPoolRequest) {
 	return func(r *CatThreadPoolRequest) {
 		r.FilterPath = v
+	}
+}
+
+// WithHeader adds the headers to the HTTP request
+//
+func (f CatThreadPool) WithHeader(h map[string]string) func(*CatThreadPoolRequest) {
+	return func(r *CatThreadPoolRequest) {
+		if r.Header == nil {
+			r.Header = make(http.Header)
+		}
+		for k, v := range h {
+			r.Header.Add(k, v)
+		}
 	}
 }

--- a/esapi/api.clear_scroll.go
+++ b/esapi/api.clear_scroll.go
@@ -98,9 +98,13 @@ func (r ClearScrollRequest) Do(ctx context.Context, transport Transport) (*Respo
 	}
 
 	if len(r.Header) > 0 {
-		for k, vv := range r.Header {
-			for _, v := range vv {
-				req.Header.Add(k, v)
+		if len(req.Header) == 0 {
+			req.Header = r.Header
+		} else {
+			for k, vv := range r.Header {
+				for _, v := range vv {
+					req.Header.Add(k, v)
+				}
 			}
 		}
 	}

--- a/esapi/api.clear_scroll.go
+++ b/esapi/api.clear_scroll.go
@@ -98,7 +98,11 @@ func (r ClearScrollRequest) Do(ctx context.Context, transport Transport) (*Respo
 	}
 
 	if len(r.Header) > 0 {
-		req.Header = r.Header
+		for k, vv := range r.Header {
+			for _, v := range vv {
+				req.Header.Add(k, v)
+			}
+		}
 	}
 
 	if ctx != nil {

--- a/esapi/api.clear_scroll.go
+++ b/esapi/api.clear_scroll.go
@@ -5,6 +5,7 @@ package esapi
 import (
 	"context"
 	"io"
+	"net/http"
 	"strings"
 )
 
@@ -37,6 +38,8 @@ type ClearScrollRequest struct {
 	Human      bool
 	ErrorTrace bool
 	FilterPath []string
+
+	Header http.Header
 
 	ctx context.Context
 }
@@ -92,6 +95,10 @@ func (r ClearScrollRequest) Do(ctx context.Context, transport Transport) (*Respo
 
 	if r.Body != nil {
 		req.Header[headerContentType] = headerContentTypeJSON
+	}
+
+	if len(r.Header) > 0 {
+		req.Header = r.Header
 	}
 
 	if ctx != nil {
@@ -165,5 +172,18 @@ func (f ClearScroll) WithErrorTrace() func(*ClearScrollRequest) {
 func (f ClearScroll) WithFilterPath(v ...string) func(*ClearScrollRequest) {
 	return func(r *ClearScrollRequest) {
 		r.FilterPath = v
+	}
+}
+
+// WithHeader adds the headers to the HTTP request
+//
+func (f ClearScroll) WithHeader(h map[string]string) func(*ClearScrollRequest) {
+	return func(r *ClearScrollRequest) {
+		if r.Header == nil {
+			r.Header = make(http.Header)
+		}
+		for k, v := range h {
+			r.Header.Add(k, v)
+		}
 	}
 }

--- a/esapi/api.cluster.allocation_explain.go
+++ b/esapi/api.cluster.allocation_explain.go
@@ -101,7 +101,11 @@ func (r ClusterAllocationExplainRequest) Do(ctx context.Context, transport Trans
 	}
 
 	if len(r.Header) > 0 {
-		req.Header = r.Header
+		for k, vv := range r.Header {
+			for _, v := range vv {
+				req.Header.Add(k, v)
+			}
+		}
 	}
 
 	if ctx != nil {

--- a/esapi/api.cluster.allocation_explain.go
+++ b/esapi/api.cluster.allocation_explain.go
@@ -101,9 +101,13 @@ func (r ClusterAllocationExplainRequest) Do(ctx context.Context, transport Trans
 	}
 
 	if len(r.Header) > 0 {
-		for k, vv := range r.Header {
-			for _, v := range vv {
-				req.Header.Add(k, v)
+		if len(req.Header) == 0 {
+			req.Header = r.Header
+		} else {
+			for k, vv := range r.Header {
+				for _, v := range vv {
+					req.Header.Add(k, v)
+				}
 			}
 		}
 	}

--- a/esapi/api.cluster.allocation_explain.go
+++ b/esapi/api.cluster.allocation_explain.go
@@ -5,6 +5,7 @@ package esapi
 import (
 	"context"
 	"io"
+	"net/http"
 	"strconv"
 	"strings"
 )
@@ -39,6 +40,8 @@ type ClusterAllocationExplainRequest struct {
 	Human      bool
 	ErrorTrace bool
 	FilterPath []string
+
+	Header http.Header
 
 	ctx context.Context
 }
@@ -95,6 +98,10 @@ func (r ClusterAllocationExplainRequest) Do(ctx context.Context, transport Trans
 
 	if r.Body != nil {
 		req.Header[headerContentType] = headerContentTypeJSON
+	}
+
+	if len(r.Header) > 0 {
+		req.Header = r.Header
 	}
 
 	if ctx != nil {
@@ -176,5 +183,18 @@ func (f ClusterAllocationExplain) WithErrorTrace() func(*ClusterAllocationExplai
 func (f ClusterAllocationExplain) WithFilterPath(v ...string) func(*ClusterAllocationExplainRequest) {
 	return func(r *ClusterAllocationExplainRequest) {
 		r.FilterPath = v
+	}
+}
+
+// WithHeader adds the headers to the HTTP request
+//
+func (f ClusterAllocationExplain) WithHeader(h map[string]string) func(*ClusterAllocationExplainRequest) {
+	return func(r *ClusterAllocationExplainRequest) {
+		if r.Header == nil {
+			r.Header = make(http.Header)
+		}
+		for k, v := range h {
+			r.Header.Add(k, v)
+		}
 	}
 }

--- a/esapi/api.cluster.get_settings.go
+++ b/esapi/api.cluster.get_settings.go
@@ -105,7 +105,11 @@ func (r ClusterGetSettingsRequest) Do(ctx context.Context, transport Transport) 
 	}
 
 	if len(r.Header) > 0 {
-		req.Header = r.Header
+		for k, vv := range r.Header {
+			for _, v := range vv {
+				req.Header.Add(k, v)
+			}
+		}
 	}
 
 	if ctx != nil {

--- a/esapi/api.cluster.get_settings.go
+++ b/esapi/api.cluster.get_settings.go
@@ -105,9 +105,13 @@ func (r ClusterGetSettingsRequest) Do(ctx context.Context, transport Transport) 
 	}
 
 	if len(r.Header) > 0 {
-		for k, vv := range r.Header {
-			for _, v := range vv {
-				req.Header.Add(k, v)
+		if len(req.Header) == 0 {
+			req.Header = r.Header
+		} else {
+			for k, vv := range r.Header {
+				for _, v := range vv {
+					req.Header.Add(k, v)
+				}
 			}
 		}
 	}

--- a/esapi/api.cluster.get_settings.go
+++ b/esapi/api.cluster.get_settings.go
@@ -4,6 +4,7 @@ package esapi
 
 import (
 	"context"
+	"net/http"
 	"strconv"
 	"strings"
 	"time"
@@ -39,6 +40,8 @@ type ClusterGetSettingsRequest struct {
 	Human      bool
 	ErrorTrace bool
 	FilterPath []string
+
+	Header http.Header
 
 	ctx context.Context
 }
@@ -99,6 +102,10 @@ func (r ClusterGetSettingsRequest) Do(ctx context.Context, transport Transport) 
 			q.Set(k, v)
 		}
 		req.URL.RawQuery = q.Encode()
+	}
+
+	if len(r.Header) > 0 {
+		req.Header = r.Header
 	}
 
 	if ctx != nil {
@@ -188,5 +195,18 @@ func (f ClusterGetSettings) WithErrorTrace() func(*ClusterGetSettingsRequest) {
 func (f ClusterGetSettings) WithFilterPath(v ...string) func(*ClusterGetSettingsRequest) {
 	return func(r *ClusterGetSettingsRequest) {
 		r.FilterPath = v
+	}
+}
+
+// WithHeader adds the headers to the HTTP request
+//
+func (f ClusterGetSettings) WithHeader(h map[string]string) func(*ClusterGetSettingsRequest) {
+	return func(r *ClusterGetSettingsRequest) {
+		if r.Header == nil {
+			r.Header = make(http.Header)
+		}
+		for k, v := range h {
+			r.Header.Add(k, v)
+		}
 	}
 }

--- a/esapi/api.cluster.health.go
+++ b/esapi/api.cluster.health.go
@@ -149,7 +149,11 @@ func (r ClusterHealthRequest) Do(ctx context.Context, transport Transport) (*Res
 	}
 
 	if len(r.Header) > 0 {
-		req.Header = r.Header
+		for k, vv := range r.Header {
+			for _, v := range vv {
+				req.Header.Add(k, v)
+			}
+		}
 	}
 
 	if ctx != nil {

--- a/esapi/api.cluster.health.go
+++ b/esapi/api.cluster.health.go
@@ -4,6 +4,7 @@ package esapi
 
 import (
 	"context"
+	"net/http"
 	"strconv"
 	"strings"
 	"time"
@@ -48,6 +49,8 @@ type ClusterHealthRequest struct {
 	Human      bool
 	ErrorTrace bool
 	FilterPath []string
+
+	Header http.Header
 
 	ctx context.Context
 }
@@ -143,6 +146,10 @@ func (r ClusterHealthRequest) Do(ctx context.Context, transport Transport) (*Res
 			q.Set(k, v)
 		}
 		req.URL.RawQuery = q.Encode()
+	}
+
+	if len(r.Header) > 0 {
+		req.Header = r.Header
 	}
 
 	if ctx != nil {
@@ -296,5 +303,18 @@ func (f ClusterHealth) WithErrorTrace() func(*ClusterHealthRequest) {
 func (f ClusterHealth) WithFilterPath(v ...string) func(*ClusterHealthRequest) {
 	return func(r *ClusterHealthRequest) {
 		r.FilterPath = v
+	}
+}
+
+// WithHeader adds the headers to the HTTP request
+//
+func (f ClusterHealth) WithHeader(h map[string]string) func(*ClusterHealthRequest) {
+	return func(r *ClusterHealthRequest) {
+		if r.Header == nil {
+			r.Header = make(http.Header)
+		}
+		for k, v := range h {
+			r.Header.Add(k, v)
+		}
 	}
 }

--- a/esapi/api.cluster.health.go
+++ b/esapi/api.cluster.health.go
@@ -149,9 +149,13 @@ func (r ClusterHealthRequest) Do(ctx context.Context, transport Transport) (*Res
 	}
 
 	if len(r.Header) > 0 {
-		for k, vv := range r.Header {
-			for _, v := range vv {
-				req.Header.Add(k, v)
+		if len(req.Header) == 0 {
+			req.Header = r.Header
+		} else {
+			for k, vv := range r.Header {
+				for _, v := range vv {
+					req.Header.Add(k, v)
+				}
 			}
 		}
 	}

--- a/esapi/api.cluster.pending_tasks.go
+++ b/esapi/api.cluster.pending_tasks.go
@@ -4,6 +4,7 @@ package esapi
 
 import (
 	"context"
+	"net/http"
 	"strconv"
 	"strings"
 	"time"
@@ -38,6 +39,8 @@ type ClusterPendingTasksRequest struct {
 	Human      bool
 	ErrorTrace bool
 	FilterPath []string
+
+	Header http.Header
 
 	ctx context.Context
 }
@@ -90,6 +93,10 @@ func (r ClusterPendingTasksRequest) Do(ctx context.Context, transport Transport)
 			q.Set(k, v)
 		}
 		req.URL.RawQuery = q.Encode()
+	}
+
+	if len(r.Header) > 0 {
+		req.Header = r.Header
 	}
 
 	if ctx != nil {
@@ -163,5 +170,18 @@ func (f ClusterPendingTasks) WithErrorTrace() func(*ClusterPendingTasksRequest) 
 func (f ClusterPendingTasks) WithFilterPath(v ...string) func(*ClusterPendingTasksRequest) {
 	return func(r *ClusterPendingTasksRequest) {
 		r.FilterPath = v
+	}
+}
+
+// WithHeader adds the headers to the HTTP request
+//
+func (f ClusterPendingTasks) WithHeader(h map[string]string) func(*ClusterPendingTasksRequest) {
+	return func(r *ClusterPendingTasksRequest) {
+		if r.Header == nil {
+			r.Header = make(http.Header)
+		}
+		for k, v := range h {
+			r.Header.Add(k, v)
+		}
 	}
 }

--- a/esapi/api.cluster.pending_tasks.go
+++ b/esapi/api.cluster.pending_tasks.go
@@ -96,7 +96,11 @@ func (r ClusterPendingTasksRequest) Do(ctx context.Context, transport Transport)
 	}
 
 	if len(r.Header) > 0 {
-		req.Header = r.Header
+		for k, vv := range r.Header {
+			for _, v := range vv {
+				req.Header.Add(k, v)
+			}
+		}
 	}
 
 	if ctx != nil {

--- a/esapi/api.cluster.pending_tasks.go
+++ b/esapi/api.cluster.pending_tasks.go
@@ -96,9 +96,13 @@ func (r ClusterPendingTasksRequest) Do(ctx context.Context, transport Transport)
 	}
 
 	if len(r.Header) > 0 {
-		for k, vv := range r.Header {
-			for _, v := range vv {
-				req.Header.Add(k, v)
+		if len(req.Header) == 0 {
+			req.Header = r.Header
+		} else {
+			for k, vv := range r.Header {
+				for _, v := range vv {
+					req.Header.Add(k, v)
+				}
 			}
 		}
 	}

--- a/esapi/api.cluster.put_settings.go
+++ b/esapi/api.cluster.put_settings.go
@@ -5,6 +5,7 @@ package esapi
 import (
 	"context"
 	"io"
+	"net/http"
 	"strconv"
 	"strings"
 	"time"
@@ -41,6 +42,8 @@ type ClusterPutSettingsRequest struct {
 	Human      bool
 	ErrorTrace bool
 	FilterPath []string
+
+	Header http.Header
 
 	ctx context.Context
 }
@@ -101,6 +104,10 @@ func (r ClusterPutSettingsRequest) Do(ctx context.Context, transport Transport) 
 
 	if r.Body != nil {
 		req.Header[headerContentType] = headerContentTypeJSON
+	}
+
+	if len(r.Header) > 0 {
+		req.Header = r.Header
 	}
 
 	if ctx != nil {
@@ -182,5 +189,18 @@ func (f ClusterPutSettings) WithErrorTrace() func(*ClusterPutSettingsRequest) {
 func (f ClusterPutSettings) WithFilterPath(v ...string) func(*ClusterPutSettingsRequest) {
 	return func(r *ClusterPutSettingsRequest) {
 		r.FilterPath = v
+	}
+}
+
+// WithHeader adds the headers to the HTTP request
+//
+func (f ClusterPutSettings) WithHeader(h map[string]string) func(*ClusterPutSettingsRequest) {
+	return func(r *ClusterPutSettingsRequest) {
+		if r.Header == nil {
+			r.Header = make(http.Header)
+		}
+		for k, v := range h {
+			r.Header.Add(k, v)
+		}
 	}
 }

--- a/esapi/api.cluster.put_settings.go
+++ b/esapi/api.cluster.put_settings.go
@@ -107,7 +107,11 @@ func (r ClusterPutSettingsRequest) Do(ctx context.Context, transport Transport) 
 	}
 
 	if len(r.Header) > 0 {
-		req.Header = r.Header
+		for k, vv := range r.Header {
+			for _, v := range vv {
+				req.Header.Add(k, v)
+			}
+		}
 	}
 
 	if ctx != nil {

--- a/esapi/api.cluster.put_settings.go
+++ b/esapi/api.cluster.put_settings.go
@@ -107,9 +107,13 @@ func (r ClusterPutSettingsRequest) Do(ctx context.Context, transport Transport) 
 	}
 
 	if len(r.Header) > 0 {
-		for k, vv := range r.Header {
-			for _, v := range vv {
-				req.Header.Add(k, v)
+		if len(req.Header) == 0 {
+			req.Header = r.Header
+		} else {
+			for k, vv := range r.Header {
+				for _, v := range vv {
+					req.Header.Add(k, v)
+				}
 			}
 		}
 	}

--- a/esapi/api.cluster.remote_info.go
+++ b/esapi/api.cluster.remote_info.go
@@ -82,9 +82,13 @@ func (r ClusterRemoteInfoRequest) Do(ctx context.Context, transport Transport) (
 	}
 
 	if len(r.Header) > 0 {
-		for k, vv := range r.Header {
-			for _, v := range vv {
-				req.Header.Add(k, v)
+		if len(req.Header) == 0 {
+			req.Header = r.Header
+		} else {
+			for k, vv := range r.Header {
+				for _, v := range vv {
+					req.Header.Add(k, v)
+				}
 			}
 		}
 	}

--- a/esapi/api.cluster.remote_info.go
+++ b/esapi/api.cluster.remote_info.go
@@ -4,6 +4,7 @@ package esapi
 
 import (
 	"context"
+	"net/http"
 	"strings"
 )
 
@@ -32,6 +33,8 @@ type ClusterRemoteInfoRequest struct {
 	Human      bool
 	ErrorTrace bool
 	FilterPath []string
+
+	Header http.Header
 
 	ctx context.Context
 }
@@ -76,6 +79,10 @@ func (r ClusterRemoteInfoRequest) Do(ctx context.Context, transport Transport) (
 			q.Set(k, v)
 		}
 		req.URL.RawQuery = q.Encode()
+	}
+
+	if len(r.Header) > 0 {
+		req.Header = r.Header
 	}
 
 	if ctx != nil {
@@ -133,5 +140,18 @@ func (f ClusterRemoteInfo) WithErrorTrace() func(*ClusterRemoteInfoRequest) {
 func (f ClusterRemoteInfo) WithFilterPath(v ...string) func(*ClusterRemoteInfoRequest) {
 	return func(r *ClusterRemoteInfoRequest) {
 		r.FilterPath = v
+	}
+}
+
+// WithHeader adds the headers to the HTTP request
+//
+func (f ClusterRemoteInfo) WithHeader(h map[string]string) func(*ClusterRemoteInfoRequest) {
+	return func(r *ClusterRemoteInfoRequest) {
+		if r.Header == nil {
+			r.Header = make(http.Header)
+		}
+		for k, v := range h {
+			r.Header.Add(k, v)
+		}
 	}
 }

--- a/esapi/api.cluster.remote_info.go
+++ b/esapi/api.cluster.remote_info.go
@@ -82,7 +82,11 @@ func (r ClusterRemoteInfoRequest) Do(ctx context.Context, transport Transport) (
 	}
 
 	if len(r.Header) > 0 {
-		req.Header = r.Header
+		for k, vv := range r.Header {
+			for _, v := range vv {
+				req.Header.Add(k, v)
+			}
+		}
 	}
 
 	if ctx != nil {

--- a/esapi/api.cluster.reroute.go
+++ b/esapi/api.cluster.reroute.go
@@ -122,7 +122,11 @@ func (r ClusterRerouteRequest) Do(ctx context.Context, transport Transport) (*Re
 	}
 
 	if len(r.Header) > 0 {
-		req.Header = r.Header
+		for k, vv := range r.Header {
+			for _, v := range vv {
+				req.Header.Add(k, v)
+			}
+		}
 	}
 
 	if ctx != nil {

--- a/esapi/api.cluster.reroute.go
+++ b/esapi/api.cluster.reroute.go
@@ -5,6 +5,7 @@ package esapi
 import (
 	"context"
 	"io"
+	"net/http"
 	"strconv"
 	"strings"
 	"time"
@@ -44,6 +45,8 @@ type ClusterRerouteRequest struct {
 	Human      bool
 	ErrorTrace bool
 	FilterPath []string
+
+	Header http.Header
 
 	ctx context.Context
 }
@@ -116,6 +119,10 @@ func (r ClusterRerouteRequest) Do(ctx context.Context, transport Transport) (*Re
 
 	if r.Body != nil {
 		req.Header[headerContentType] = headerContentTypeJSON
+	}
+
+	if len(r.Header) > 0 {
+		req.Header = r.Header
 	}
 
 	if ctx != nil {
@@ -229,5 +236,18 @@ func (f ClusterReroute) WithErrorTrace() func(*ClusterRerouteRequest) {
 func (f ClusterReroute) WithFilterPath(v ...string) func(*ClusterRerouteRequest) {
 	return func(r *ClusterRerouteRequest) {
 		r.FilterPath = v
+	}
+}
+
+// WithHeader adds the headers to the HTTP request
+//
+func (f ClusterReroute) WithHeader(h map[string]string) func(*ClusterRerouteRequest) {
+	return func(r *ClusterRerouteRequest) {
+		if r.Header == nil {
+			r.Header = make(http.Header)
+		}
+		for k, v := range h {
+			r.Header.Add(k, v)
+		}
 	}
 }

--- a/esapi/api.cluster.reroute.go
+++ b/esapi/api.cluster.reroute.go
@@ -122,9 +122,13 @@ func (r ClusterRerouteRequest) Do(ctx context.Context, transport Transport) (*Re
 	}
 
 	if len(r.Header) > 0 {
-		for k, vv := range r.Header {
-			for _, v := range vv {
-				req.Header.Add(k, v)
+		if len(req.Header) == 0 {
+			req.Header = r.Header
+		} else {
+			for k, vv := range r.Header {
+				for _, v := range vv {
+					req.Header.Add(k, v)
+				}
 			}
 		}
 	}

--- a/esapi/api.cluster.state.go
+++ b/esapi/api.cluster.state.go
@@ -140,9 +140,13 @@ func (r ClusterStateRequest) Do(ctx context.Context, transport Transport) (*Resp
 	}
 
 	if len(r.Header) > 0 {
-		for k, vv := range r.Header {
-			for _, v := range vv {
-				req.Header.Add(k, v)
+		if len(req.Header) == 0 {
+			req.Header = r.Header
+		} else {
+			for k, vv := range r.Header {
+				for _, v := range vv {
+					req.Header.Add(k, v)
+				}
 			}
 		}
 	}

--- a/esapi/api.cluster.state.go
+++ b/esapi/api.cluster.state.go
@@ -140,7 +140,11 @@ func (r ClusterStateRequest) Do(ctx context.Context, transport Transport) (*Resp
 	}
 
 	if len(r.Header) > 0 {
-		req.Header = r.Header
+		for k, vv := range r.Header {
+			for _, v := range vv {
+				req.Header.Add(k, v)
+			}
+		}
 	}
 
 	if ctx != nil {

--- a/esapi/api.cluster.state.go
+++ b/esapi/api.cluster.state.go
@@ -4,6 +4,7 @@ package esapi
 
 import (
 	"context"
+	"net/http"
 	"strconv"
 	"strings"
 	"time"
@@ -47,6 +48,8 @@ type ClusterStateRequest struct {
 	Human      bool
 	ErrorTrace bool
 	FilterPath []string
+
+	Header http.Header
 
 	ctx context.Context
 }
@@ -134,6 +137,10 @@ func (r ClusterStateRequest) Do(ctx context.Context, transport Transport) (*Resp
 			q.Set(k, v)
 		}
 		req.URL.RawQuery = q.Encode()
+	}
+
+	if len(r.Header) > 0 {
+		req.Header = r.Header
 	}
 
 	if ctx != nil {
@@ -271,5 +278,18 @@ func (f ClusterState) WithErrorTrace() func(*ClusterStateRequest) {
 func (f ClusterState) WithFilterPath(v ...string) func(*ClusterStateRequest) {
 	return func(r *ClusterStateRequest) {
 		r.FilterPath = v
+	}
+}
+
+// WithHeader adds the headers to the HTTP request
+//
+func (f ClusterState) WithHeader(h map[string]string) func(*ClusterStateRequest) {
+	return func(r *ClusterStateRequest) {
+		if r.Header == nil {
+			r.Header = make(http.Header)
+		}
+		for k, v := range h {
+			r.Header.Add(k, v)
+		}
 	}
 }

--- a/esapi/api.cluster.stats.go
+++ b/esapi/api.cluster.stats.go
@@ -4,6 +4,7 @@ package esapi
 
 import (
 	"context"
+	"net/http"
 	"strconv"
 	"strings"
 	"time"
@@ -39,6 +40,8 @@ type ClusterStatsRequest struct {
 	Human      bool
 	ErrorTrace bool
 	FilterPath []string
+
+	Header http.Header
 
 	ctx context.Context
 }
@@ -100,6 +103,10 @@ func (r ClusterStatsRequest) Do(ctx context.Context, transport Transport) (*Resp
 			q.Set(k, v)
 		}
 		req.URL.RawQuery = q.Encode()
+	}
+
+	if len(r.Header) > 0 {
+		req.Header = r.Header
 	}
 
 	if ctx != nil {
@@ -181,5 +188,18 @@ func (f ClusterStats) WithErrorTrace() func(*ClusterStatsRequest) {
 func (f ClusterStats) WithFilterPath(v ...string) func(*ClusterStatsRequest) {
 	return func(r *ClusterStatsRequest) {
 		r.FilterPath = v
+	}
+}
+
+// WithHeader adds the headers to the HTTP request
+//
+func (f ClusterStats) WithHeader(h map[string]string) func(*ClusterStatsRequest) {
+	return func(r *ClusterStatsRequest) {
+		if r.Header == nil {
+			r.Header = make(http.Header)
+		}
+		for k, v := range h {
+			r.Header.Add(k, v)
+		}
 	}
 }

--- a/esapi/api.cluster.stats.go
+++ b/esapi/api.cluster.stats.go
@@ -106,9 +106,13 @@ func (r ClusterStatsRequest) Do(ctx context.Context, transport Transport) (*Resp
 	}
 
 	if len(r.Header) > 0 {
-		for k, vv := range r.Header {
-			for _, v := range vv {
-				req.Header.Add(k, v)
+		if len(req.Header) == 0 {
+			req.Header = r.Header
+		} else {
+			for k, vv := range r.Header {
+				for _, v := range vv {
+					req.Header.Add(k, v)
+				}
 			}
 		}
 	}

--- a/esapi/api.cluster.stats.go
+++ b/esapi/api.cluster.stats.go
@@ -106,7 +106,11 @@ func (r ClusterStatsRequest) Do(ctx context.Context, transport Transport) (*Resp
 	}
 
 	if len(r.Header) > 0 {
-		req.Header = r.Header
+		for k, vv := range r.Header {
+			for _, v := range vv {
+				req.Header.Add(k, v)
+			}
+		}
 	}
 
 	if ctx != nil {

--- a/esapi/api.count.go
+++ b/esapi/api.count.go
@@ -169,9 +169,13 @@ func (r CountRequest) Do(ctx context.Context, transport Transport) (*Response, e
 	}
 
 	if len(r.Header) > 0 {
-		for k, vv := range r.Header {
-			for _, v := range vv {
-				req.Header.Add(k, v)
+		if len(req.Header) == 0 {
+			req.Header = r.Header
+		} else {
+			for k, vv := range r.Header {
+				for _, v := range vv {
+					req.Header.Add(k, v)
+				}
 			}
 		}
 	}

--- a/esapi/api.count.go
+++ b/esapi/api.count.go
@@ -169,7 +169,11 @@ func (r CountRequest) Do(ctx context.Context, transport Transport) (*Response, e
 	}
 
 	if len(r.Header) > 0 {
-		req.Header = r.Header
+		for k, vv := range r.Header {
+			for _, v := range vv {
+				req.Header.Add(k, v)
+			}
+		}
 	}
 
 	if ctx != nil {

--- a/esapi/api.count.go
+++ b/esapi/api.count.go
@@ -5,6 +5,7 @@ package esapi
 import (
 	"context"
 	"io"
+	"net/http"
 	"strconv"
 	"strings"
 )
@@ -54,6 +55,8 @@ type CountRequest struct {
 	Human      bool
 	ErrorTrace bool
 	FilterPath []string
+
+	Header http.Header
 
 	ctx context.Context
 }
@@ -163,6 +166,10 @@ func (r CountRequest) Do(ctx context.Context, transport Transport) (*Response, e
 
 	if r.Body != nil {
 		req.Header[headerContentType] = headerContentTypeJSON
+	}
+
+	if len(r.Header) > 0 {
+		req.Header = r.Header
 	}
 
 	if ctx != nil {
@@ -356,5 +363,18 @@ func (f Count) WithErrorTrace() func(*CountRequest) {
 func (f Count) WithFilterPath(v ...string) func(*CountRequest) {
 	return func(r *CountRequest) {
 		r.FilterPath = v
+	}
+}
+
+// WithHeader adds the headers to the HTTP request
+//
+func (f Count) WithHeader(h map[string]string) func(*CountRequest) {
+	return func(r *CountRequest) {
+		if r.Header == nil {
+			r.Header = make(http.Header)
+		}
+		for k, v := range h {
+			r.Header.Add(k, v)
+		}
 	}
 }

--- a/esapi/api.create.go
+++ b/esapi/api.create.go
@@ -5,6 +5,7 @@ package esapi
 import (
 	"context"
 	"io"
+	"net/http"
 	"strconv"
 	"strings"
 	"time"
@@ -51,6 +52,8 @@ type CreateRequest struct {
 	Human      bool
 	ErrorTrace bool
 	FilterPath []string
+
+	Header http.Header
 
 	ctx context.Context
 }
@@ -138,6 +141,10 @@ func (r CreateRequest) Do(ctx context.Context, transport Transport) (*Response, 
 
 	if r.Body != nil {
 		req.Header[headerContentType] = headerContentTypeJSON
+	}
+
+	if len(r.Header) > 0 {
+		req.Header = r.Header
 	}
 
 	if ctx != nil {
@@ -259,5 +266,18 @@ func (f Create) WithErrorTrace() func(*CreateRequest) {
 func (f Create) WithFilterPath(v ...string) func(*CreateRequest) {
 	return func(r *CreateRequest) {
 		r.FilterPath = v
+	}
+}
+
+// WithHeader adds the headers to the HTTP request
+//
+func (f Create) WithHeader(h map[string]string) func(*CreateRequest) {
+	return func(r *CreateRequest) {
+		if r.Header == nil {
+			r.Header = make(http.Header)
+		}
+		for k, v := range h {
+			r.Header.Add(k, v)
+		}
 	}
 }

--- a/esapi/api.create.go
+++ b/esapi/api.create.go
@@ -144,7 +144,11 @@ func (r CreateRequest) Do(ctx context.Context, transport Transport) (*Response, 
 	}
 
 	if len(r.Header) > 0 {
-		req.Header = r.Header
+		for k, vv := range r.Header {
+			for _, v := range vv {
+				req.Header.Add(k, v)
+			}
+		}
 	}
 
 	if ctx != nil {

--- a/esapi/api.create.go
+++ b/esapi/api.create.go
@@ -144,9 +144,13 @@ func (r CreateRequest) Do(ctx context.Context, transport Transport) (*Response, 
 	}
 
 	if len(r.Header) > 0 {
-		for k, vv := range r.Header {
-			for _, v := range vv {
-				req.Header.Add(k, v)
+		if len(req.Header) == 0 {
+			req.Header = r.Header
+		} else {
+			for k, vv := range r.Header {
+				for _, v := range vv {
+					req.Header.Add(k, v)
+				}
 			}
 		}
 	}

--- a/esapi/api.delete.go
+++ b/esapi/api.delete.go
@@ -140,7 +140,11 @@ func (r DeleteRequest) Do(ctx context.Context, transport Transport) (*Response, 
 	}
 
 	if len(r.Header) > 0 {
-		req.Header = r.Header
+		for k, vv := range r.Header {
+			for _, v := range vv {
+				req.Header.Add(k, v)
+			}
+		}
 	}
 
 	if ctx != nil {

--- a/esapi/api.delete.go
+++ b/esapi/api.delete.go
@@ -4,6 +4,7 @@ package esapi
 
 import (
 	"context"
+	"net/http"
 	"strconv"
 	"strings"
 	"time"
@@ -47,6 +48,8 @@ type DeleteRequest struct {
 	Human      bool
 	ErrorTrace bool
 	FilterPath []string
+
+	Header http.Header
 
 	ctx context.Context
 }
@@ -134,6 +137,10 @@ func (r DeleteRequest) Do(ctx context.Context, transport Transport) (*Response, 
 			q.Set(k, v)
 		}
 		req.URL.RawQuery = q.Encode()
+	}
+
+	if len(r.Header) > 0 {
+		req.Header = r.Header
 	}
 
 	if ctx != nil {
@@ -263,5 +270,18 @@ func (f Delete) WithErrorTrace() func(*DeleteRequest) {
 func (f Delete) WithFilterPath(v ...string) func(*DeleteRequest) {
 	return func(r *DeleteRequest) {
 		r.FilterPath = v
+	}
+}
+
+// WithHeader adds the headers to the HTTP request
+//
+func (f Delete) WithHeader(h map[string]string) func(*DeleteRequest) {
+	return func(r *DeleteRequest) {
+		if r.Header == nil {
+			r.Header = make(http.Header)
+		}
+		for k, v := range h {
+			r.Header.Add(k, v)
+		}
 	}
 }

--- a/esapi/api.delete.go
+++ b/esapi/api.delete.go
@@ -140,9 +140,13 @@ func (r DeleteRequest) Do(ctx context.Context, transport Transport) (*Response, 
 	}
 
 	if len(r.Header) > 0 {
-		for k, vv := range r.Header {
-			for _, v := range vv {
-				req.Header.Add(k, v)
+		if len(req.Header) == 0 {
+			req.Header = r.Header
+		} else {
+			for k, vv := range r.Header {
+				for _, v := range vv {
+					req.Header.Add(k, v)
+				}
 			}
 		}
 	}

--- a/esapi/api.delete_by_query.go
+++ b/esapi/api.delete_by_query.go
@@ -5,6 +5,7 @@ package esapi
 import (
 	"context"
 	"io"
+	"net/http"
 	"strconv"
 	"strings"
 	"time"
@@ -72,6 +73,8 @@ type DeleteByQueryRequest struct {
 	Human      bool
 	ErrorTrace bool
 	FilterPath []string
+
+	Header http.Header
 
 	ctx context.Context
 }
@@ -251,6 +254,10 @@ func (r DeleteByQueryRequest) Do(ctx context.Context, transport Transport) (*Res
 
 	if r.Body != nil {
 		req.Header[headerContentType] = headerContentTypeJSON
+	}
+
+	if len(r.Header) > 0 {
+		req.Header = r.Header
 	}
 
 	if ctx != nil {
@@ -564,5 +571,18 @@ func (f DeleteByQuery) WithErrorTrace() func(*DeleteByQueryRequest) {
 func (f DeleteByQuery) WithFilterPath(v ...string) func(*DeleteByQueryRequest) {
 	return func(r *DeleteByQueryRequest) {
 		r.FilterPath = v
+	}
+}
+
+// WithHeader adds the headers to the HTTP request
+//
+func (f DeleteByQuery) WithHeader(h map[string]string) func(*DeleteByQueryRequest) {
+	return func(r *DeleteByQueryRequest) {
+		if r.Header == nil {
+			r.Header = make(http.Header)
+		}
+		for k, v := range h {
+			r.Header.Add(k, v)
+		}
 	}
 }

--- a/esapi/api.delete_by_query.go
+++ b/esapi/api.delete_by_query.go
@@ -257,9 +257,13 @@ func (r DeleteByQueryRequest) Do(ctx context.Context, transport Transport) (*Res
 	}
 
 	if len(r.Header) > 0 {
-		for k, vv := range r.Header {
-			for _, v := range vv {
-				req.Header.Add(k, v)
+		if len(req.Header) == 0 {
+			req.Header = r.Header
+		} else {
+			for k, vv := range r.Header {
+				for _, v := range vv {
+					req.Header.Add(k, v)
+				}
 			}
 		}
 	}

--- a/esapi/api.delete_by_query.go
+++ b/esapi/api.delete_by_query.go
@@ -257,7 +257,11 @@ func (r DeleteByQueryRequest) Do(ctx context.Context, transport Transport) (*Res
 	}
 
 	if len(r.Header) > 0 {
-		req.Header = r.Header
+		for k, vv := range r.Header {
+			for _, v := range vv {
+				req.Header.Add(k, v)
+			}
+		}
 	}
 
 	if ctx != nil {

--- a/esapi/api.delete_by_query_rethrottle.go
+++ b/esapi/api.delete_by_query_rethrottle.go
@@ -96,7 +96,11 @@ func (r DeleteByQueryRethrottleRequest) Do(ctx context.Context, transport Transp
 	}
 
 	if len(r.Header) > 0 {
-		req.Header = r.Header
+		for k, vv := range r.Header {
+			for _, v := range vv {
+				req.Header.Add(k, v)
+			}
+		}
 	}
 
 	if ctx != nil {

--- a/esapi/api.delete_by_query_rethrottle.go
+++ b/esapi/api.delete_by_query_rethrottle.go
@@ -96,9 +96,13 @@ func (r DeleteByQueryRethrottleRequest) Do(ctx context.Context, transport Transp
 	}
 
 	if len(r.Header) > 0 {
-		for k, vv := range r.Header {
-			for _, v := range vv {
-				req.Header.Add(k, v)
+		if len(req.Header) == 0 {
+			req.Header = r.Header
+		} else {
+			for k, vv := range r.Header {
+				for _, v := range vv {
+					req.Header.Add(k, v)
+				}
 			}
 		}
 	}

--- a/esapi/api.delete_by_query_rethrottle.go
+++ b/esapi/api.delete_by_query_rethrottle.go
@@ -4,6 +4,7 @@ package esapi
 
 import (
 	"context"
+	"net/http"
 	"strconv"
 	"strings"
 )
@@ -37,6 +38,8 @@ type DeleteByQueryRethrottleRequest struct {
 	Human      bool
 	ErrorTrace bool
 	FilterPath []string
+
+	Header http.Header
 
 	ctx context.Context
 }
@@ -90,6 +93,10 @@ func (r DeleteByQueryRethrottleRequest) Do(ctx context.Context, transport Transp
 			q.Set(k, v)
 		}
 		req.URL.RawQuery = q.Encode()
+	}
+
+	if len(r.Header) > 0 {
+		req.Header = r.Header
 	}
 
 	if ctx != nil {
@@ -155,5 +162,18 @@ func (f DeleteByQueryRethrottle) WithErrorTrace() func(*DeleteByQueryRethrottleR
 func (f DeleteByQueryRethrottle) WithFilterPath(v ...string) func(*DeleteByQueryRethrottleRequest) {
 	return func(r *DeleteByQueryRethrottleRequest) {
 		r.FilterPath = v
+	}
+}
+
+// WithHeader adds the headers to the HTTP request
+//
+func (f DeleteByQueryRethrottle) WithHeader(h map[string]string) func(*DeleteByQueryRethrottleRequest) {
+	return func(r *DeleteByQueryRethrottleRequest) {
+		if r.Header == nil {
+			r.Header = make(http.Header)
+		}
+		for k, v := range h {
+			r.Header.Add(k, v)
+		}
 	}
 }

--- a/esapi/api.delete_script.go
+++ b/esapi/api.delete_script.go
@@ -99,7 +99,11 @@ func (r DeleteScriptRequest) Do(ctx context.Context, transport Transport) (*Resp
 	}
 
 	if len(r.Header) > 0 {
-		req.Header = r.Header
+		for k, vv := range r.Header {
+			for _, v := range vv {
+				req.Header.Add(k, v)
+			}
+		}
 	}
 
 	if ctx != nil {

--- a/esapi/api.delete_script.go
+++ b/esapi/api.delete_script.go
@@ -99,9 +99,13 @@ func (r DeleteScriptRequest) Do(ctx context.Context, transport Transport) (*Resp
 	}
 
 	if len(r.Header) > 0 {
-		for k, vv := range r.Header {
-			for _, v := range vv {
-				req.Header.Add(k, v)
+		if len(req.Header) == 0 {
+			req.Header = r.Header
+		} else {
+			for k, vv := range r.Header {
+				for _, v := range vv {
+					req.Header.Add(k, v)
+				}
 			}
 		}
 	}

--- a/esapi/api.delete_script.go
+++ b/esapi/api.delete_script.go
@@ -4,6 +4,7 @@ package esapi
 
 import (
 	"context"
+	"net/http"
 	"strings"
 	"time"
 )
@@ -38,6 +39,8 @@ type DeleteScriptRequest struct {
 	Human      bool
 	ErrorTrace bool
 	FilterPath []string
+
+	Header http.Header
 
 	ctx context.Context
 }
@@ -93,6 +96,10 @@ func (r DeleteScriptRequest) Do(ctx context.Context, transport Transport) (*Resp
 			q.Set(k, v)
 		}
 		req.URL.RawQuery = q.Encode()
+	}
+
+	if len(r.Header) > 0 {
+		req.Header = r.Header
 	}
 
 	if ctx != nil {
@@ -166,5 +173,18 @@ func (f DeleteScript) WithErrorTrace() func(*DeleteScriptRequest) {
 func (f DeleteScript) WithFilterPath(v ...string) func(*DeleteScriptRequest) {
 	return func(r *DeleteScriptRequest) {
 		r.FilterPath = v
+	}
+}
+
+// WithHeader adds the headers to the HTTP request
+//
+func (f DeleteScript) WithHeader(h map[string]string) func(*DeleteScriptRequest) {
+	return func(r *DeleteScriptRequest) {
+		if r.Header == nil {
+			r.Header = make(http.Header)
+		}
+		for k, v := range h {
+			r.Header.Add(k, v)
+		}
 	}
 }

--- a/esapi/api.exists.go
+++ b/esapi/api.exists.go
@@ -4,6 +4,7 @@ package esapi
 
 import (
 	"context"
+	"net/http"
 	"strconv"
 	"strings"
 )
@@ -48,6 +49,8 @@ type ExistsRequest struct {
 	Human      bool
 	ErrorTrace bool
 	FilterPath []string
+
+	Header http.Header
 
 	ctx context.Context
 }
@@ -143,6 +146,10 @@ func (r ExistsRequest) Do(ctx context.Context, transport Transport) (*Response, 
 			q.Set(k, v)
 		}
 		req.URL.RawQuery = q.Encode()
+	}
+
+	if len(r.Header) > 0 {
+		req.Header = r.Header
 	}
 
 	if ctx != nil {
@@ -288,5 +295,18 @@ func (f Exists) WithErrorTrace() func(*ExistsRequest) {
 func (f Exists) WithFilterPath(v ...string) func(*ExistsRequest) {
 	return func(r *ExistsRequest) {
 		r.FilterPath = v
+	}
+}
+
+// WithHeader adds the headers to the HTTP request
+//
+func (f Exists) WithHeader(h map[string]string) func(*ExistsRequest) {
+	return func(r *ExistsRequest) {
+		if r.Header == nil {
+			r.Header = make(http.Header)
+		}
+		for k, v := range h {
+			r.Header.Add(k, v)
+		}
 	}
 }

--- a/esapi/api.exists.go
+++ b/esapi/api.exists.go
@@ -149,7 +149,11 @@ func (r ExistsRequest) Do(ctx context.Context, transport Transport) (*Response, 
 	}
 
 	if len(r.Header) > 0 {
-		req.Header = r.Header
+		for k, vv := range r.Header {
+			for _, v := range vv {
+				req.Header.Add(k, v)
+			}
+		}
 	}
 
 	if ctx != nil {

--- a/esapi/api.exists.go
+++ b/esapi/api.exists.go
@@ -149,9 +149,13 @@ func (r ExistsRequest) Do(ctx context.Context, transport Transport) (*Response, 
 	}
 
 	if len(r.Header) > 0 {
-		for k, vv := range r.Header {
-			for _, v := range vv {
-				req.Header.Add(k, v)
+		if len(req.Header) == 0 {
+			req.Header = r.Header
+		} else {
+			for k, vv := range r.Header {
+				for _, v := range vv {
+					req.Header.Add(k, v)
+				}
 			}
 		}
 	}

--- a/esapi/api.exists_source.go
+++ b/esapi/api.exists_source.go
@@ -142,9 +142,13 @@ func (r ExistsSourceRequest) Do(ctx context.Context, transport Transport) (*Resp
 	}
 
 	if len(r.Header) > 0 {
-		for k, vv := range r.Header {
-			for _, v := range vv {
-				req.Header.Add(k, v)
+		if len(req.Header) == 0 {
+			req.Header = r.Header
+		} else {
+			for k, vv := range r.Header {
+				for _, v := range vv {
+					req.Header.Add(k, v)
+				}
 			}
 		}
 	}

--- a/esapi/api.exists_source.go
+++ b/esapi/api.exists_source.go
@@ -4,6 +4,7 @@ package esapi
 
 import (
 	"context"
+	"net/http"
 	"strconv"
 	"strings"
 )
@@ -47,6 +48,8 @@ type ExistsSourceRequest struct {
 	Human      bool
 	ErrorTrace bool
 	FilterPath []string
+
+	Header http.Header
 
 	ctx context.Context
 }
@@ -136,6 +139,10 @@ func (r ExistsSourceRequest) Do(ctx context.Context, transport Transport) (*Resp
 			q.Set(k, v)
 		}
 		req.URL.RawQuery = q.Encode()
+	}
+
+	if len(r.Header) > 0 {
+		req.Header = r.Header
 	}
 
 	if ctx != nil {
@@ -273,5 +280,18 @@ func (f ExistsSource) WithErrorTrace() func(*ExistsSourceRequest) {
 func (f ExistsSource) WithFilterPath(v ...string) func(*ExistsSourceRequest) {
 	return func(r *ExistsSourceRequest) {
 		r.FilterPath = v
+	}
+}
+
+// WithHeader adds the headers to the HTTP request
+//
+func (f ExistsSource) WithHeader(h map[string]string) func(*ExistsSourceRequest) {
+	return func(r *ExistsSourceRequest) {
+		if r.Header == nil {
+			r.Header = make(http.Header)
+		}
+		for k, v := range h {
+			r.Header.Add(k, v)
+		}
 	}
 }

--- a/esapi/api.exists_source.go
+++ b/esapi/api.exists_source.go
@@ -142,7 +142,11 @@ func (r ExistsSourceRequest) Do(ctx context.Context, transport Transport) (*Resp
 	}
 
 	if len(r.Header) > 0 {
-		req.Header = r.Header
+		for k, vv := range r.Header {
+			for _, v := range vv {
+				req.Header.Add(k, v)
+			}
+		}
 	}
 
 	if ctx != nil {

--- a/esapi/api.explain.go
+++ b/esapi/api.explain.go
@@ -5,6 +5,7 @@ package esapi
 import (
 	"context"
 	"io"
+	"net/http"
 	"strconv"
 	"strings"
 )
@@ -53,6 +54,8 @@ type ExplainRequest struct {
 	Human      bool
 	ErrorTrace bool
 	FilterPath []string
+
+	Header http.Header
 
 	ctx context.Context
 }
@@ -162,6 +165,10 @@ func (r ExplainRequest) Do(ctx context.Context, transport Transport) (*Response,
 
 	if r.Body != nil {
 		req.Header[headerContentType] = headerContentTypeJSON
+	}
+
+	if len(r.Header) > 0 {
+		req.Header = r.Header
 	}
 
 	if ctx != nil {
@@ -331,5 +338,18 @@ func (f Explain) WithErrorTrace() func(*ExplainRequest) {
 func (f Explain) WithFilterPath(v ...string) func(*ExplainRequest) {
 	return func(r *ExplainRequest) {
 		r.FilterPath = v
+	}
+}
+
+// WithHeader adds the headers to the HTTP request
+//
+func (f Explain) WithHeader(h map[string]string) func(*ExplainRequest) {
+	return func(r *ExplainRequest) {
+		if r.Header == nil {
+			r.Header = make(http.Header)
+		}
+		for k, v := range h {
+			r.Header.Add(k, v)
+		}
 	}
 }

--- a/esapi/api.explain.go
+++ b/esapi/api.explain.go
@@ -168,7 +168,11 @@ func (r ExplainRequest) Do(ctx context.Context, transport Transport) (*Response,
 	}
 
 	if len(r.Header) > 0 {
-		req.Header = r.Header
+		for k, vv := range r.Header {
+			for _, v := range vv {
+				req.Header.Add(k, v)
+			}
+		}
 	}
 
 	if ctx != nil {

--- a/esapi/api.explain.go
+++ b/esapi/api.explain.go
@@ -168,9 +168,13 @@ func (r ExplainRequest) Do(ctx context.Context, transport Transport) (*Response,
 	}
 
 	if len(r.Header) > 0 {
-		for k, vv := range r.Header {
-			for _, v := range vv {
-				req.Header.Add(k, v)
+		if len(req.Header) == 0 {
+			req.Header = r.Header
+		} else {
+			for k, vv := range r.Header {
+				for _, v := range vv {
+					req.Header.Add(k, v)
+				}
 			}
 		}
 	}

--- a/esapi/api.field_caps.go
+++ b/esapi/api.field_caps.go
@@ -116,7 +116,11 @@ func (r FieldCapsRequest) Do(ctx context.Context, transport Transport) (*Respons
 	}
 
 	if len(r.Header) > 0 {
-		req.Header = r.Header
+		for k, vv := range r.Header {
+			for _, v := range vv {
+				req.Header.Add(k, v)
+			}
+		}
 	}
 
 	if ctx != nil {

--- a/esapi/api.field_caps.go
+++ b/esapi/api.field_caps.go
@@ -116,9 +116,13 @@ func (r FieldCapsRequest) Do(ctx context.Context, transport Transport) (*Respons
 	}
 
 	if len(r.Header) > 0 {
-		for k, vv := range r.Header {
-			for _, v := range vv {
-				req.Header.Add(k, v)
+		if len(req.Header) == 0 {
+			req.Header = r.Header
+		} else {
+			for k, vv := range r.Header {
+				for _, v := range vv {
+					req.Header.Add(k, v)
+				}
 			}
 		}
 	}

--- a/esapi/api.field_caps.go
+++ b/esapi/api.field_caps.go
@@ -4,6 +4,7 @@ package esapi
 
 import (
 	"context"
+	"net/http"
 	"strconv"
 	"strings"
 )
@@ -41,6 +42,8 @@ type FieldCapsRequest struct {
 	Human      bool
 	ErrorTrace bool
 	FilterPath []string
+
+	Header http.Header
 
 	ctx context.Context
 }
@@ -110,6 +113,10 @@ func (r FieldCapsRequest) Do(ctx context.Context, transport Transport) (*Respons
 			q.Set(k, v)
 		}
 		req.URL.RawQuery = q.Encode()
+	}
+
+	if len(r.Header) > 0 {
+		req.Header = r.Header
 	}
 
 	if ctx != nil {
@@ -215,5 +222,18 @@ func (f FieldCaps) WithErrorTrace() func(*FieldCapsRequest) {
 func (f FieldCaps) WithFilterPath(v ...string) func(*FieldCapsRequest) {
 	return func(r *FieldCapsRequest) {
 		r.FilterPath = v
+	}
+}
+
+// WithHeader adds the headers to the HTTP request
+//
+func (f FieldCaps) WithHeader(h map[string]string) func(*FieldCapsRequest) {
+	return func(r *FieldCapsRequest) {
+		if r.Header == nil {
+			r.Header = make(http.Header)
+		}
+		for k, v := range h {
+			r.Header.Add(k, v)
+		}
 	}
 }

--- a/esapi/api.get.go
+++ b/esapi/api.get.go
@@ -4,6 +4,7 @@ package esapi
 
 import (
 	"context"
+	"net/http"
 	"strconv"
 	"strings"
 )
@@ -48,6 +49,8 @@ type GetRequest struct {
 	Human      bool
 	ErrorTrace bool
 	FilterPath []string
+
+	Header http.Header
 
 	ctx context.Context
 }
@@ -143,6 +146,10 @@ func (r GetRequest) Do(ctx context.Context, transport Transport) (*Response, err
 			q.Set(k, v)
 		}
 		req.URL.RawQuery = q.Encode()
+	}
+
+	if len(r.Header) > 0 {
+		req.Header = r.Header
 	}
 
 	if ctx != nil {
@@ -288,5 +295,18 @@ func (f Get) WithErrorTrace() func(*GetRequest) {
 func (f Get) WithFilterPath(v ...string) func(*GetRequest) {
 	return func(r *GetRequest) {
 		r.FilterPath = v
+	}
+}
+
+// WithHeader adds the headers to the HTTP request
+//
+func (f Get) WithHeader(h map[string]string) func(*GetRequest) {
+	return func(r *GetRequest) {
+		if r.Header == nil {
+			r.Header = make(http.Header)
+		}
+		for k, v := range h {
+			r.Header.Add(k, v)
+		}
 	}
 }

--- a/esapi/api.get.go
+++ b/esapi/api.get.go
@@ -149,7 +149,11 @@ func (r GetRequest) Do(ctx context.Context, transport Transport) (*Response, err
 	}
 
 	if len(r.Header) > 0 {
-		req.Header = r.Header
+		for k, vv := range r.Header {
+			for _, v := range vv {
+				req.Header.Add(k, v)
+			}
+		}
 	}
 
 	if ctx != nil {

--- a/esapi/api.get.go
+++ b/esapi/api.get.go
@@ -149,9 +149,13 @@ func (r GetRequest) Do(ctx context.Context, transport Transport) (*Response, err
 	}
 
 	if len(r.Header) > 0 {
-		for k, vv := range r.Header {
-			for _, v := range vv {
-				req.Header.Add(k, v)
+		if len(req.Header) == 0 {
+			req.Header = r.Header
+		} else {
+			for k, vv := range r.Header {
+				for _, v := range vv {
+					req.Header.Add(k, v)
+				}
 			}
 		}
 	}

--- a/esapi/api.get_script.go
+++ b/esapi/api.get_script.go
@@ -94,9 +94,13 @@ func (r GetScriptRequest) Do(ctx context.Context, transport Transport) (*Respons
 	}
 
 	if len(r.Header) > 0 {
-		for k, vv := range r.Header {
-			for _, v := range vv {
-				req.Header.Add(k, v)
+		if len(req.Header) == 0 {
+			req.Header = r.Header
+		} else {
+			for k, vv := range r.Header {
+				for _, v := range vv {
+					req.Header.Add(k, v)
+				}
 			}
 		}
 	}

--- a/esapi/api.get_script.go
+++ b/esapi/api.get_script.go
@@ -4,6 +4,7 @@ package esapi
 
 import (
 	"context"
+	"net/http"
 	"strings"
 	"time"
 )
@@ -37,6 +38,8 @@ type GetScriptRequest struct {
 	Human      bool
 	ErrorTrace bool
 	FilterPath []string
+
+	Header http.Header
 
 	ctx context.Context
 }
@@ -88,6 +91,10 @@ func (r GetScriptRequest) Do(ctx context.Context, transport Transport) (*Respons
 			q.Set(k, v)
 		}
 		req.URL.RawQuery = q.Encode()
+	}
+
+	if len(r.Header) > 0 {
+		req.Header = r.Header
 	}
 
 	if ctx != nil {
@@ -153,5 +160,18 @@ func (f GetScript) WithErrorTrace() func(*GetScriptRequest) {
 func (f GetScript) WithFilterPath(v ...string) func(*GetScriptRequest) {
 	return func(r *GetScriptRequest) {
 		r.FilterPath = v
+	}
+}
+
+// WithHeader adds the headers to the HTTP request
+//
+func (f GetScript) WithHeader(h map[string]string) func(*GetScriptRequest) {
+	return func(r *GetScriptRequest) {
+		if r.Header == nil {
+			r.Header = make(http.Header)
+		}
+		for k, v := range h {
+			r.Header.Add(k, v)
+		}
 	}
 }

--- a/esapi/api.get_script.go
+++ b/esapi/api.get_script.go
@@ -94,7 +94,11 @@ func (r GetScriptRequest) Do(ctx context.Context, transport Transport) (*Respons
 	}
 
 	if len(r.Header) > 0 {
-		req.Header = r.Header
+		for k, vv := range r.Header {
+			for _, v := range vv {
+				req.Header.Add(k, v)
+			}
+		}
 	}
 
 	if ctx != nil {

--- a/esapi/api.get_source.go
+++ b/esapi/api.get_source.go
@@ -146,7 +146,11 @@ func (r GetSourceRequest) Do(ctx context.Context, transport Transport) (*Respons
 	}
 
 	if len(r.Header) > 0 {
-		req.Header = r.Header
+		for k, vv := range r.Header {
+			for _, v := range vv {
+				req.Header.Add(k, v)
+			}
+		}
 	}
 
 	if ctx != nil {

--- a/esapi/api.get_source.go
+++ b/esapi/api.get_source.go
@@ -146,9 +146,13 @@ func (r GetSourceRequest) Do(ctx context.Context, transport Transport) (*Respons
 	}
 
 	if len(r.Header) > 0 {
-		for k, vv := range r.Header {
-			for _, v := range vv {
-				req.Header.Add(k, v)
+		if len(req.Header) == 0 {
+			req.Header = r.Header
+		} else {
+			for k, vv := range r.Header {
+				for _, v := range vv {
+					req.Header.Add(k, v)
+				}
 			}
 		}
 	}

--- a/esapi/api.get_source.go
+++ b/esapi/api.get_source.go
@@ -4,6 +4,7 @@ package esapi
 
 import (
 	"context"
+	"net/http"
 	"strconv"
 	"strings"
 )
@@ -47,6 +48,8 @@ type GetSourceRequest struct {
 	Human      bool
 	ErrorTrace bool
 	FilterPath []string
+
+	Header http.Header
 
 	ctx context.Context
 }
@@ -140,6 +143,10 @@ func (r GetSourceRequest) Do(ctx context.Context, transport Transport) (*Respons
 			q.Set(k, v)
 		}
 		req.URL.RawQuery = q.Encode()
+	}
+
+	if len(r.Header) > 0 {
+		req.Header = r.Header
 	}
 
 	if ctx != nil {
@@ -277,5 +284,18 @@ func (f GetSource) WithErrorTrace() func(*GetSourceRequest) {
 func (f GetSource) WithFilterPath(v ...string) func(*GetSourceRequest) {
 	return func(r *GetSourceRequest) {
 		r.FilterPath = v
+	}
+}
+
+// WithHeader adds the headers to the HTTP request
+//
+func (f GetSource) WithHeader(h map[string]string) func(*GetSourceRequest) {
+	return func(r *GetSourceRequest) {
+		if r.Header == nil {
+			r.Header = make(http.Header)
+		}
+		for k, v := range h {
+			r.Header.Add(k, v)
+		}
 	}
 }

--- a/esapi/api.index.go
+++ b/esapi/api.index.go
@@ -161,7 +161,11 @@ func (r IndexRequest) Do(ctx context.Context, transport Transport) (*Response, e
 	}
 
 	if len(r.Header) > 0 {
-		req.Header = r.Header
+		for k, vv := range r.Header {
+			for _, v := range vv {
+				req.Header.Add(k, v)
+			}
+		}
 	}
 
 	if ctx != nil {

--- a/esapi/api.index.go
+++ b/esapi/api.index.go
@@ -161,9 +161,13 @@ func (r IndexRequest) Do(ctx context.Context, transport Transport) (*Response, e
 	}
 
 	if len(r.Header) > 0 {
-		for k, vv := range r.Header {
-			for _, v := range vv {
-				req.Header.Add(k, v)
+		if len(req.Header) == 0 {
+			req.Header = r.Header
+		} else {
+			for k, vv := range r.Header {
+				for _, v := range vv {
+					req.Header.Add(k, v)
+				}
 			}
 		}
 	}

--- a/esapi/api.index.go
+++ b/esapi/api.index.go
@@ -5,6 +5,7 @@ package esapi
 import (
 	"context"
 	"io"
+	"net/http"
 	"strconv"
 	"strings"
 	"time"
@@ -52,6 +53,8 @@ type IndexRequest struct {
 	Human      bool
 	ErrorTrace bool
 	FilterPath []string
+
+	Header http.Header
 
 	ctx context.Context
 }
@@ -155,6 +158,10 @@ func (r IndexRequest) Do(ctx context.Context, transport Transport) (*Response, e
 
 	if r.Body != nil {
 		req.Header[headerContentType] = headerContentTypeJSON
+	}
+
+	if len(r.Header) > 0 {
+		req.Header = r.Header
 	}
 
 	if ctx != nil {
@@ -308,5 +315,18 @@ func (f Index) WithErrorTrace() func(*IndexRequest) {
 func (f Index) WithFilterPath(v ...string) func(*IndexRequest) {
 	return func(r *IndexRequest) {
 		r.FilterPath = v
+	}
+}
+
+// WithHeader adds the headers to the HTTP request
+//
+func (f Index) WithHeader(h map[string]string) func(*IndexRequest) {
+	return func(r *IndexRequest) {
+		if r.Header == nil {
+			r.Header = make(http.Header)
+		}
+		for k, v := range h {
+			r.Header.Add(k, v)
+		}
 	}
 }

--- a/esapi/api.indices.analyze.go
+++ b/esapi/api.indices.analyze.go
@@ -100,9 +100,13 @@ func (r IndicesAnalyzeRequest) Do(ctx context.Context, transport Transport) (*Re
 	}
 
 	if len(r.Header) > 0 {
-		for k, vv := range r.Header {
-			for _, v := range vv {
-				req.Header.Add(k, v)
+		if len(req.Header) == 0 {
+			req.Header = r.Header
+		} else {
+			for k, vv := range r.Header {
+				for _, v := range vv {
+					req.Header.Add(k, v)
+				}
 			}
 		}
 	}

--- a/esapi/api.indices.analyze.go
+++ b/esapi/api.indices.analyze.go
@@ -5,6 +5,7 @@ package esapi
 import (
 	"context"
 	"io"
+	"net/http"
 	"strings"
 )
 
@@ -37,6 +38,8 @@ type IndicesAnalyzeRequest struct {
 	Human      bool
 	ErrorTrace bool
 	FilterPath []string
+
+	Header http.Header
 
 	ctx context.Context
 }
@@ -94,6 +97,10 @@ func (r IndicesAnalyzeRequest) Do(ctx context.Context, transport Transport) (*Re
 
 	if r.Body != nil {
 		req.Header[headerContentType] = headerContentTypeJSON
+	}
+
+	if len(r.Header) > 0 {
+		req.Header = r.Header
 	}
 
 	if ctx != nil {
@@ -167,5 +174,18 @@ func (f IndicesAnalyze) WithErrorTrace() func(*IndicesAnalyzeRequest) {
 func (f IndicesAnalyze) WithFilterPath(v ...string) func(*IndicesAnalyzeRequest) {
 	return func(r *IndicesAnalyzeRequest) {
 		r.FilterPath = v
+	}
+}
+
+// WithHeader adds the headers to the HTTP request
+//
+func (f IndicesAnalyze) WithHeader(h map[string]string) func(*IndicesAnalyzeRequest) {
+	return func(r *IndicesAnalyzeRequest) {
+		if r.Header == nil {
+			r.Header = make(http.Header)
+		}
+		for k, v := range h {
+			r.Header.Add(k, v)
+		}
 	}
 }

--- a/esapi/api.indices.analyze.go
+++ b/esapi/api.indices.analyze.go
@@ -100,7 +100,11 @@ func (r IndicesAnalyzeRequest) Do(ctx context.Context, transport Transport) (*Re
 	}
 
 	if len(r.Header) > 0 {
-		req.Header = r.Header
+		for k, vv := range r.Header {
+			for _, v := range vv {
+				req.Header.Add(k, v)
+			}
+		}
 	}
 
 	if ctx != nil {

--- a/esapi/api.indices.clear_cache.go
+++ b/esapi/api.indices.clear_cache.go
@@ -132,9 +132,13 @@ func (r IndicesClearCacheRequest) Do(ctx context.Context, transport Transport) (
 	}
 
 	if len(r.Header) > 0 {
-		for k, vv := range r.Header {
-			for _, v := range vv {
-				req.Header.Add(k, v)
+		if len(req.Header) == 0 {
+			req.Header = r.Header
+		} else {
+			for k, vv := range r.Header {
+				for _, v := range vv {
+					req.Header.Add(k, v)
+				}
 			}
 		}
 	}

--- a/esapi/api.indices.clear_cache.go
+++ b/esapi/api.indices.clear_cache.go
@@ -132,7 +132,11 @@ func (r IndicesClearCacheRequest) Do(ctx context.Context, transport Transport) (
 	}
 
 	if len(r.Header) > 0 {
-		req.Header = r.Header
+		for k, vv := range r.Header {
+			for _, v := range vv {
+				req.Header.Add(k, v)
+			}
+		}
 	}
 
 	if ctx != nil {

--- a/esapi/api.indices.clear_cache.go
+++ b/esapi/api.indices.clear_cache.go
@@ -4,6 +4,7 @@ package esapi
 
 import (
 	"context"
+	"net/http"
 	"strconv"
 	"strings"
 )
@@ -43,6 +44,8 @@ type IndicesClearCacheRequest struct {
 	Human      bool
 	ErrorTrace bool
 	FilterPath []string
+
+	Header http.Header
 
 	ctx context.Context
 }
@@ -126,6 +129,10 @@ func (r IndicesClearCacheRequest) Do(ctx context.Context, transport Transport) (
 			q.Set(k, v)
 		}
 		req.URL.RawQuery = q.Encode()
+	}
+
+	if len(r.Header) > 0 {
+		req.Header = r.Header
 	}
 
 	if ctx != nil {
@@ -247,5 +254,18 @@ func (f IndicesClearCache) WithErrorTrace() func(*IndicesClearCacheRequest) {
 func (f IndicesClearCache) WithFilterPath(v ...string) func(*IndicesClearCacheRequest) {
 	return func(r *IndicesClearCacheRequest) {
 		r.FilterPath = v
+	}
+}
+
+// WithHeader adds the headers to the HTTP request
+//
+func (f IndicesClearCache) WithHeader(h map[string]string) func(*IndicesClearCacheRequest) {
+	return func(r *IndicesClearCacheRequest) {
+		if r.Header == nil {
+			r.Header = make(http.Header)
+		}
+		for k, v := range h {
+			r.Header.Add(k, v)
+		}
 	}
 }

--- a/esapi/api.indices.close.go
+++ b/esapi/api.indices.close.go
@@ -120,9 +120,13 @@ func (r IndicesCloseRequest) Do(ctx context.Context, transport Transport) (*Resp
 	}
 
 	if len(r.Header) > 0 {
-		for k, vv := range r.Header {
-			for _, v := range vv {
-				req.Header.Add(k, v)
+		if len(req.Header) == 0 {
+			req.Header = r.Header
+		} else {
+			for k, vv := range r.Header {
+				for _, v := range vv {
+					req.Header.Add(k, v)
+				}
 			}
 		}
 	}

--- a/esapi/api.indices.close.go
+++ b/esapi/api.indices.close.go
@@ -120,7 +120,11 @@ func (r IndicesCloseRequest) Do(ctx context.Context, transport Transport) (*Resp
 	}
 
 	if len(r.Header) > 0 {
-		req.Header = r.Header
+		for k, vv := range r.Header {
+			for _, v := range vv {
+				req.Header.Add(k, v)
+			}
+		}
 	}
 
 	if ctx != nil {

--- a/esapi/api.indices.close.go
+++ b/esapi/api.indices.close.go
@@ -4,6 +4,7 @@ package esapi
 
 import (
 	"context"
+	"net/http"
 	"strconv"
 	"strings"
 	"time"
@@ -43,6 +44,8 @@ type IndicesCloseRequest struct {
 	Human      bool
 	ErrorTrace bool
 	FilterPath []string
+
+	Header http.Header
 
 	ctx context.Context
 }
@@ -114,6 +117,10 @@ func (r IndicesCloseRequest) Do(ctx context.Context, transport Transport) (*Resp
 			q.Set(k, v)
 		}
 		req.URL.RawQuery = q.Encode()
+	}
+
+	if len(r.Header) > 0 {
+		req.Header = r.Header
 	}
 
 	if ctx != nil {
@@ -219,5 +226,18 @@ func (f IndicesClose) WithErrorTrace() func(*IndicesCloseRequest) {
 func (f IndicesClose) WithFilterPath(v ...string) func(*IndicesCloseRequest) {
 	return func(r *IndicesCloseRequest) {
 		r.FilterPath = v
+	}
+}
+
+// WithHeader adds the headers to the HTTP request
+//
+func (f IndicesClose) WithHeader(h map[string]string) func(*IndicesCloseRequest) {
+	return func(r *IndicesCloseRequest) {
+		if r.Header == nil {
+			r.Header = make(http.Header)
+		}
+		for k, v := range h {
+			r.Header.Add(k, v)
+		}
 	}
 }

--- a/esapi/api.indices.create.go
+++ b/esapi/api.indices.create.go
@@ -5,6 +5,7 @@ package esapi
 import (
 	"context"
 	"io"
+	"net/http"
 	"strconv"
 	"strings"
 	"time"
@@ -44,6 +45,8 @@ type IndicesCreateRequest struct {
 	Human      bool
 	ErrorTrace bool
 	FilterPath []string
+
+	Header http.Header
 
 	ctx context.Context
 }
@@ -109,6 +112,10 @@ func (r IndicesCreateRequest) Do(ctx context.Context, transport Transport) (*Res
 
 	if r.Body != nil {
 		req.Header[headerContentType] = headerContentTypeJSON
+	}
+
+	if len(r.Header) > 0 {
+		req.Header = r.Header
 	}
 
 	if ctx != nil {
@@ -206,5 +213,18 @@ func (f IndicesCreate) WithErrorTrace() func(*IndicesCreateRequest) {
 func (f IndicesCreate) WithFilterPath(v ...string) func(*IndicesCreateRequest) {
 	return func(r *IndicesCreateRequest) {
 		r.FilterPath = v
+	}
+}
+
+// WithHeader adds the headers to the HTTP request
+//
+func (f IndicesCreate) WithHeader(h map[string]string) func(*IndicesCreateRequest) {
+	return func(r *IndicesCreateRequest) {
+		if r.Header == nil {
+			r.Header = make(http.Header)
+		}
+		for k, v := range h {
+			r.Header.Add(k, v)
+		}
 	}
 }

--- a/esapi/api.indices.create.go
+++ b/esapi/api.indices.create.go
@@ -115,9 +115,13 @@ func (r IndicesCreateRequest) Do(ctx context.Context, transport Transport) (*Res
 	}
 
 	if len(r.Header) > 0 {
-		for k, vv := range r.Header {
-			for _, v := range vv {
-				req.Header.Add(k, v)
+		if len(req.Header) == 0 {
+			req.Header = r.Header
+		} else {
+			for k, vv := range r.Header {
+				for _, v := range vv {
+					req.Header.Add(k, v)
+				}
 			}
 		}
 	}

--- a/esapi/api.indices.create.go
+++ b/esapi/api.indices.create.go
@@ -115,7 +115,11 @@ func (r IndicesCreateRequest) Do(ctx context.Context, transport Transport) (*Res
 	}
 
 	if len(r.Header) > 0 {
-		req.Header = r.Header
+		for k, vv := range r.Header {
+			for _, v := range vv {
+				req.Header.Add(k, v)
+			}
+		}
 	}
 
 	if ctx != nil {

--- a/esapi/api.indices.delete.go
+++ b/esapi/api.indices.delete.go
@@ -113,9 +113,13 @@ func (r IndicesDeleteRequest) Do(ctx context.Context, transport Transport) (*Res
 	}
 
 	if len(r.Header) > 0 {
-		for k, vv := range r.Header {
-			for _, v := range vv {
-				req.Header.Add(k, v)
+		if len(req.Header) == 0 {
+			req.Header = r.Header
+		} else {
+			for k, vv := range r.Header {
+				for _, v := range vv {
+					req.Header.Add(k, v)
+				}
 			}
 		}
 	}

--- a/esapi/api.indices.delete.go
+++ b/esapi/api.indices.delete.go
@@ -4,6 +4,7 @@ package esapi
 
 import (
 	"context"
+	"net/http"
 	"strconv"
 	"strings"
 	"time"
@@ -42,6 +43,8 @@ type IndicesDeleteRequest struct {
 	Human      bool
 	ErrorTrace bool
 	FilterPath []string
+
+	Header http.Header
 
 	ctx context.Context
 }
@@ -107,6 +110,10 @@ func (r IndicesDeleteRequest) Do(ctx context.Context, transport Transport) (*Res
 			q.Set(k, v)
 		}
 		req.URL.RawQuery = q.Encode()
+	}
+
+	if len(r.Header) > 0 {
+		req.Header = r.Header
 	}
 
 	if ctx != nil {
@@ -204,5 +211,18 @@ func (f IndicesDelete) WithErrorTrace() func(*IndicesDeleteRequest) {
 func (f IndicesDelete) WithFilterPath(v ...string) func(*IndicesDeleteRequest) {
 	return func(r *IndicesDeleteRequest) {
 		r.FilterPath = v
+	}
+}
+
+// WithHeader adds the headers to the HTTP request
+//
+func (f IndicesDelete) WithHeader(h map[string]string) func(*IndicesDeleteRequest) {
+	return func(r *IndicesDeleteRequest) {
+		if r.Header == nil {
+			r.Header = make(http.Header)
+		}
+		for k, v := range h {
+			r.Header.Add(k, v)
+		}
 	}
 }

--- a/esapi/api.indices.delete.go
+++ b/esapi/api.indices.delete.go
@@ -113,7 +113,11 @@ func (r IndicesDeleteRequest) Do(ctx context.Context, transport Transport) (*Res
 	}
 
 	if len(r.Header) > 0 {
-		req.Header = r.Header
+		for k, vv := range r.Header {
+			for _, v := range vv {
+				req.Header.Add(k, v)
+			}
+		}
 	}
 
 	if ctx != nil {

--- a/esapi/api.indices.delete_alias.go
+++ b/esapi/api.indices.delete_alias.go
@@ -103,7 +103,11 @@ func (r IndicesDeleteAliasRequest) Do(ctx context.Context, transport Transport) 
 	}
 
 	if len(r.Header) > 0 {
-		req.Header = r.Header
+		for k, vv := range r.Header {
+			for _, v := range vv {
+				req.Header.Add(k, v)
+			}
+		}
 	}
 
 	if ctx != nil {

--- a/esapi/api.indices.delete_alias.go
+++ b/esapi/api.indices.delete_alias.go
@@ -4,6 +4,7 @@ package esapi
 
 import (
 	"context"
+	"net/http"
 	"strings"
 	"time"
 )
@@ -40,6 +41,8 @@ type IndicesDeleteAliasRequest struct {
 	Human      bool
 	ErrorTrace bool
 	FilterPath []string
+
+	Header http.Header
 
 	ctx context.Context
 }
@@ -97,6 +100,10 @@ func (r IndicesDeleteAliasRequest) Do(ctx context.Context, transport Transport) 
 			q.Set(k, v)
 		}
 		req.URL.RawQuery = q.Encode()
+	}
+
+	if len(r.Header) > 0 {
+		req.Header = r.Header
 	}
 
 	if ctx != nil {
@@ -170,5 +177,18 @@ func (f IndicesDeleteAlias) WithErrorTrace() func(*IndicesDeleteAliasRequest) {
 func (f IndicesDeleteAlias) WithFilterPath(v ...string) func(*IndicesDeleteAliasRequest) {
 	return func(r *IndicesDeleteAliasRequest) {
 		r.FilterPath = v
+	}
+}
+
+// WithHeader adds the headers to the HTTP request
+//
+func (f IndicesDeleteAlias) WithHeader(h map[string]string) func(*IndicesDeleteAliasRequest) {
+	return func(r *IndicesDeleteAliasRequest) {
+		if r.Header == nil {
+			r.Header = make(http.Header)
+		}
+		for k, v := range h {
+			r.Header.Add(k, v)
+		}
 	}
 }

--- a/esapi/api.indices.delete_alias.go
+++ b/esapi/api.indices.delete_alias.go
@@ -103,9 +103,13 @@ func (r IndicesDeleteAliasRequest) Do(ctx context.Context, transport Transport) 
 	}
 
 	if len(r.Header) > 0 {
-		for k, vv := range r.Header {
-			for _, v := range vv {
-				req.Header.Add(k, v)
+		if len(req.Header) == 0 {
+			req.Header = r.Header
+		} else {
+			for k, vv := range r.Header {
+				for _, v := range vv {
+					req.Header.Add(k, v)
+				}
 			}
 		}
 	}

--- a/esapi/api.indices.delete_template.go
+++ b/esapi/api.indices.delete_template.go
@@ -99,9 +99,13 @@ func (r IndicesDeleteTemplateRequest) Do(ctx context.Context, transport Transpor
 	}
 
 	if len(r.Header) > 0 {
-		for k, vv := range r.Header {
-			for _, v := range vv {
-				req.Header.Add(k, v)
+		if len(req.Header) == 0 {
+			req.Header = r.Header
+		} else {
+			for k, vv := range r.Header {
+				for _, v := range vv {
+					req.Header.Add(k, v)
+				}
 			}
 		}
 	}

--- a/esapi/api.indices.delete_template.go
+++ b/esapi/api.indices.delete_template.go
@@ -4,6 +4,7 @@ package esapi
 
 import (
 	"context"
+	"net/http"
 	"strings"
 	"time"
 )
@@ -38,6 +39,8 @@ type IndicesDeleteTemplateRequest struct {
 	Human      bool
 	ErrorTrace bool
 	FilterPath []string
+
+	Header http.Header
 
 	ctx context.Context
 }
@@ -93,6 +96,10 @@ func (r IndicesDeleteTemplateRequest) Do(ctx context.Context, transport Transpor
 			q.Set(k, v)
 		}
 		req.URL.RawQuery = q.Encode()
+	}
+
+	if len(r.Header) > 0 {
+		req.Header = r.Header
 	}
 
 	if ctx != nil {
@@ -166,5 +173,18 @@ func (f IndicesDeleteTemplate) WithErrorTrace() func(*IndicesDeleteTemplateReque
 func (f IndicesDeleteTemplate) WithFilterPath(v ...string) func(*IndicesDeleteTemplateRequest) {
 	return func(r *IndicesDeleteTemplateRequest) {
 		r.FilterPath = v
+	}
+}
+
+// WithHeader adds the headers to the HTTP request
+//
+func (f IndicesDeleteTemplate) WithHeader(h map[string]string) func(*IndicesDeleteTemplateRequest) {
+	return func(r *IndicesDeleteTemplateRequest) {
+		if r.Header == nil {
+			r.Header = make(http.Header)
+		}
+		for k, v := range h {
+			r.Header.Add(k, v)
+		}
 	}
 }

--- a/esapi/api.indices.delete_template.go
+++ b/esapi/api.indices.delete_template.go
@@ -99,7 +99,11 @@ func (r IndicesDeleteTemplateRequest) Do(ctx context.Context, transport Transpor
 	}
 
 	if len(r.Header) > 0 {
-		req.Header = r.Header
+		for k, vv := range r.Header {
+			for _, v := range vv {
+				req.Header.Add(k, v)
+			}
+		}
 	}
 
 	if ctx != nil {

--- a/esapi/api.indices.exists.go
+++ b/esapi/api.indices.exists.go
@@ -4,6 +4,7 @@ package esapi
 
 import (
 	"context"
+	"net/http"
 	"strconv"
 	"strings"
 )
@@ -42,6 +43,8 @@ type IndicesExistsRequest struct {
 	Human      bool
 	ErrorTrace bool
 	FilterPath []string
+
+	Header http.Header
 
 	ctx context.Context
 }
@@ -111,6 +114,10 @@ func (r IndicesExistsRequest) Do(ctx context.Context, transport Transport) (*Res
 			q.Set(k, v)
 		}
 		req.URL.RawQuery = q.Encode()
+	}
+
+	if len(r.Header) > 0 {
+		req.Header = r.Header
 	}
 
 	if ctx != nil {
@@ -216,5 +223,18 @@ func (f IndicesExists) WithErrorTrace() func(*IndicesExistsRequest) {
 func (f IndicesExists) WithFilterPath(v ...string) func(*IndicesExistsRequest) {
 	return func(r *IndicesExistsRequest) {
 		r.FilterPath = v
+	}
+}
+
+// WithHeader adds the headers to the HTTP request
+//
+func (f IndicesExists) WithHeader(h map[string]string) func(*IndicesExistsRequest) {
+	return func(r *IndicesExistsRequest) {
+		if r.Header == nil {
+			r.Header = make(http.Header)
+		}
+		for k, v := range h {
+			r.Header.Add(k, v)
+		}
 	}
 }

--- a/esapi/api.indices.exists.go
+++ b/esapi/api.indices.exists.go
@@ -117,7 +117,11 @@ func (r IndicesExistsRequest) Do(ctx context.Context, transport Transport) (*Res
 	}
 
 	if len(r.Header) > 0 {
-		req.Header = r.Header
+		for k, vv := range r.Header {
+			for _, v := range vv {
+				req.Header.Add(k, v)
+			}
+		}
 	}
 
 	if ctx != nil {

--- a/esapi/api.indices.exists.go
+++ b/esapi/api.indices.exists.go
@@ -117,9 +117,13 @@ func (r IndicesExistsRequest) Do(ctx context.Context, transport Transport) (*Res
 	}
 
 	if len(r.Header) > 0 {
-		for k, vv := range r.Header {
-			for _, v := range vv {
-				req.Header.Add(k, v)
+		if len(req.Header) == 0 {
+			req.Header = r.Header
+		} else {
+			for k, vv := range r.Header {
+				for _, v := range vv {
+					req.Header.Add(k, v)
+				}
 			}
 		}
 	}

--- a/esapi/api.indices.exists_alias.go
+++ b/esapi/api.indices.exists_alias.go
@@ -115,7 +115,11 @@ func (r IndicesExistsAliasRequest) Do(ctx context.Context, transport Transport) 
 	}
 
 	if len(r.Header) > 0 {
-		req.Header = r.Header
+		for k, vv := range r.Header {
+			for _, v := range vv {
+				req.Header.Add(k, v)
+			}
+		}
 	}
 
 	if ctx != nil {

--- a/esapi/api.indices.exists_alias.go
+++ b/esapi/api.indices.exists_alias.go
@@ -4,6 +4,7 @@ package esapi
 
 import (
 	"context"
+	"net/http"
 	"strconv"
 	"strings"
 )
@@ -42,6 +43,8 @@ type IndicesExistsAliasRequest struct {
 	Human      bool
 	ErrorTrace bool
 	FilterPath []string
+
+	Header http.Header
 
 	ctx context.Context
 }
@@ -109,6 +112,10 @@ func (r IndicesExistsAliasRequest) Do(ctx context.Context, transport Transport) 
 			q.Set(k, v)
 		}
 		req.URL.RawQuery = q.Encode()
+	}
+
+	if len(r.Header) > 0 {
+		req.Header = r.Header
 	}
 
 	if ctx != nil {
@@ -206,5 +213,18 @@ func (f IndicesExistsAlias) WithErrorTrace() func(*IndicesExistsAliasRequest) {
 func (f IndicesExistsAlias) WithFilterPath(v ...string) func(*IndicesExistsAliasRequest) {
 	return func(r *IndicesExistsAliasRequest) {
 		r.FilterPath = v
+	}
+}
+
+// WithHeader adds the headers to the HTTP request
+//
+func (f IndicesExistsAlias) WithHeader(h map[string]string) func(*IndicesExistsAliasRequest) {
+	return func(r *IndicesExistsAliasRequest) {
+		if r.Header == nil {
+			r.Header = make(http.Header)
+		}
+		for k, v := range h {
+			r.Header.Add(k, v)
+		}
 	}
 }

--- a/esapi/api.indices.exists_alias.go
+++ b/esapi/api.indices.exists_alias.go
@@ -115,9 +115,13 @@ func (r IndicesExistsAliasRequest) Do(ctx context.Context, transport Transport) 
 	}
 
 	if len(r.Header) > 0 {
-		for k, vv := range r.Header {
-			for _, v := range vv {
-				req.Header.Add(k, v)
+		if len(req.Header) == 0 {
+			req.Header = r.Header
+		} else {
+			for k, vv := range r.Header {
+				for _, v := range vv {
+					req.Header.Add(k, v)
+				}
 			}
 		}
 	}

--- a/esapi/api.indices.exists_template.go
+++ b/esapi/api.indices.exists_template.go
@@ -4,6 +4,7 @@ package esapi
 
 import (
 	"context"
+	"net/http"
 	"strconv"
 	"strings"
 	"time"
@@ -40,6 +41,8 @@ type IndicesExistsTemplateRequest struct {
 	Human      bool
 	ErrorTrace bool
 	FilterPath []string
+
+	Header http.Header
 
 	ctx context.Context
 }
@@ -99,6 +102,10 @@ func (r IndicesExistsTemplateRequest) Do(ctx context.Context, transport Transpor
 			q.Set(k, v)
 		}
 		req.URL.RawQuery = q.Encode()
+	}
+
+	if len(r.Header) > 0 {
+		req.Header = r.Header
 	}
 
 	if ctx != nil {
@@ -180,5 +187,18 @@ func (f IndicesExistsTemplate) WithErrorTrace() func(*IndicesExistsTemplateReque
 func (f IndicesExistsTemplate) WithFilterPath(v ...string) func(*IndicesExistsTemplateRequest) {
 	return func(r *IndicesExistsTemplateRequest) {
 		r.FilterPath = v
+	}
+}
+
+// WithHeader adds the headers to the HTTP request
+//
+func (f IndicesExistsTemplate) WithHeader(h map[string]string) func(*IndicesExistsTemplateRequest) {
+	return func(r *IndicesExistsTemplateRequest) {
+		if r.Header == nil {
+			r.Header = make(http.Header)
+		}
+		for k, v := range h {
+			r.Header.Add(k, v)
+		}
 	}
 }

--- a/esapi/api.indices.exists_template.go
+++ b/esapi/api.indices.exists_template.go
@@ -105,7 +105,11 @@ func (r IndicesExistsTemplateRequest) Do(ctx context.Context, transport Transpor
 	}
 
 	if len(r.Header) > 0 {
-		req.Header = r.Header
+		for k, vv := range r.Header {
+			for _, v := range vv {
+				req.Header.Add(k, v)
+			}
+		}
 	}
 
 	if ctx != nil {

--- a/esapi/api.indices.exists_template.go
+++ b/esapi/api.indices.exists_template.go
@@ -105,9 +105,13 @@ func (r IndicesExistsTemplateRequest) Do(ctx context.Context, transport Transpor
 	}
 
 	if len(r.Header) > 0 {
-		for k, vv := range r.Header {
-			for _, v := range vv {
-				req.Header.Add(k, v)
+		if len(req.Header) == 0 {
+			req.Header = r.Header
+		} else {
+			for k, vv := range r.Header {
+				for _, v := range vv {
+					req.Header.Add(k, v)
+				}
 			}
 		}
 	}

--- a/esapi/api.indices.exists_type.go
+++ b/esapi/api.indices.exists_type.go
@@ -112,7 +112,11 @@ func (r IndicesExistsTypeRequest) Do(ctx context.Context, transport Transport) (
 	}
 
 	if len(r.Header) > 0 {
-		req.Header = r.Header
+		for k, vv := range r.Header {
+			for _, v := range vv {
+				req.Header.Add(k, v)
+			}
+		}
 	}
 
 	if ctx != nil {

--- a/esapi/api.indices.exists_type.go
+++ b/esapi/api.indices.exists_type.go
@@ -112,9 +112,13 @@ func (r IndicesExistsTypeRequest) Do(ctx context.Context, transport Transport) (
 	}
 
 	if len(r.Header) > 0 {
-		for k, vv := range r.Header {
-			for _, v := range vv {
-				req.Header.Add(k, v)
+		if len(req.Header) == 0 {
+			req.Header = r.Header
+		} else {
+			for k, vv := range r.Header {
+				for _, v := range vv {
+					req.Header.Add(k, v)
+				}
 			}
 		}
 	}

--- a/esapi/api.indices.exists_type.go
+++ b/esapi/api.indices.exists_type.go
@@ -4,6 +4,7 @@ package esapi
 
 import (
 	"context"
+	"net/http"
 	"strconv"
 	"strings"
 )
@@ -41,6 +42,8 @@ type IndicesExistsTypeRequest struct {
 	Human      bool
 	ErrorTrace bool
 	FilterPath []string
+
+	Header http.Header
 
 	ctx context.Context
 }
@@ -106,6 +109,10 @@ func (r IndicesExistsTypeRequest) Do(ctx context.Context, transport Transport) (
 			q.Set(k, v)
 		}
 		req.URL.RawQuery = q.Encode()
+	}
+
+	if len(r.Header) > 0 {
+		req.Header = r.Header
 	}
 
 	if ctx != nil {
@@ -203,5 +210,18 @@ func (f IndicesExistsType) WithErrorTrace() func(*IndicesExistsTypeRequest) {
 func (f IndicesExistsType) WithFilterPath(v ...string) func(*IndicesExistsTypeRequest) {
 	return func(r *IndicesExistsTypeRequest) {
 		r.FilterPath = v
+	}
+}
+
+// WithHeader adds the headers to the HTTP request
+//
+func (f IndicesExistsType) WithHeader(h map[string]string) func(*IndicesExistsTypeRequest) {
+	return func(r *IndicesExistsTypeRequest) {
+		if r.Header == nil {
+			r.Header = make(http.Header)
+		}
+		for k, v := range h {
+			r.Header.Add(k, v)
+		}
 	}
 }

--- a/esapi/api.indices.flush.go
+++ b/esapi/api.indices.flush.go
@@ -116,7 +116,11 @@ func (r IndicesFlushRequest) Do(ctx context.Context, transport Transport) (*Resp
 	}
 
 	if len(r.Header) > 0 {
-		req.Header = r.Header
+		for k, vv := range r.Header {
+			for _, v := range vv {
+				req.Header.Add(k, v)
+			}
+		}
 	}
 
 	if ctx != nil {

--- a/esapi/api.indices.flush.go
+++ b/esapi/api.indices.flush.go
@@ -4,6 +4,7 @@ package esapi
 
 import (
 	"context"
+	"net/http"
 	"strconv"
 	"strings"
 )
@@ -41,6 +42,8 @@ type IndicesFlushRequest struct {
 	Human      bool
 	ErrorTrace bool
 	FilterPath []string
+
+	Header http.Header
 
 	ctx context.Context
 }
@@ -110,6 +113,10 @@ func (r IndicesFlushRequest) Do(ctx context.Context, transport Transport) (*Resp
 			q.Set(k, v)
 		}
 		req.URL.RawQuery = q.Encode()
+	}
+
+	if len(r.Header) > 0 {
+		req.Header = r.Header
 	}
 
 	if ctx != nil {
@@ -215,5 +222,18 @@ func (f IndicesFlush) WithErrorTrace() func(*IndicesFlushRequest) {
 func (f IndicesFlush) WithFilterPath(v ...string) func(*IndicesFlushRequest) {
 	return func(r *IndicesFlushRequest) {
 		r.FilterPath = v
+	}
+}
+
+// WithHeader adds the headers to the HTTP request
+//
+func (f IndicesFlush) WithHeader(h map[string]string) func(*IndicesFlushRequest) {
+	return func(r *IndicesFlushRequest) {
+		if r.Header == nil {
+			r.Header = make(http.Header)
+		}
+		for k, v := range h {
+			r.Header.Add(k, v)
+		}
 	}
 }

--- a/esapi/api.indices.flush.go
+++ b/esapi/api.indices.flush.go
@@ -116,9 +116,13 @@ func (r IndicesFlushRequest) Do(ctx context.Context, transport Transport) (*Resp
 	}
 
 	if len(r.Header) > 0 {
-		for k, vv := range r.Header {
-			for _, v := range vv {
-				req.Header.Add(k, v)
+		if len(req.Header) == 0 {
+			req.Header = r.Header
+		} else {
+			for k, vv := range r.Header {
+				for _, v := range vv {
+					req.Header.Add(k, v)
+				}
 			}
 		}
 	}

--- a/esapi/api.indices.flush_synced.go
+++ b/esapi/api.indices.flush_synced.go
@@ -108,9 +108,13 @@ func (r IndicesFlushSyncedRequest) Do(ctx context.Context, transport Transport) 
 	}
 
 	if len(r.Header) > 0 {
-		for k, vv := range r.Header {
-			for _, v := range vv {
-				req.Header.Add(k, v)
+		if len(req.Header) == 0 {
+			req.Header = r.Header
+		} else {
+			for k, vv := range r.Header {
+				for _, v := range vv {
+					req.Header.Add(k, v)
+				}
 			}
 		}
 	}

--- a/esapi/api.indices.flush_synced.go
+++ b/esapi/api.indices.flush_synced.go
@@ -4,6 +4,7 @@ package esapi
 
 import (
 	"context"
+	"net/http"
 	"strconv"
 	"strings"
 )
@@ -39,6 +40,8 @@ type IndicesFlushSyncedRequest struct {
 	Human      bool
 	ErrorTrace bool
 	FilterPath []string
+
+	Header http.Header
 
 	ctx context.Context
 }
@@ -102,6 +105,10 @@ func (r IndicesFlushSyncedRequest) Do(ctx context.Context, transport Transport) 
 			q.Set(k, v)
 		}
 		req.URL.RawQuery = q.Encode()
+	}
+
+	if len(r.Header) > 0 {
+		req.Header = r.Header
 	}
 
 	if ctx != nil {
@@ -191,5 +198,18 @@ func (f IndicesFlushSynced) WithErrorTrace() func(*IndicesFlushSyncedRequest) {
 func (f IndicesFlushSynced) WithFilterPath(v ...string) func(*IndicesFlushSyncedRequest) {
 	return func(r *IndicesFlushSyncedRequest) {
 		r.FilterPath = v
+	}
+}
+
+// WithHeader adds the headers to the HTTP request
+//
+func (f IndicesFlushSynced) WithHeader(h map[string]string) func(*IndicesFlushSyncedRequest) {
+	return func(r *IndicesFlushSyncedRequest) {
+		if r.Header == nil {
+			r.Header = make(http.Header)
+		}
+		for k, v := range h {
+			r.Header.Add(k, v)
+		}
 	}
 }

--- a/esapi/api.indices.flush_synced.go
+++ b/esapi/api.indices.flush_synced.go
@@ -108,7 +108,11 @@ func (r IndicesFlushSyncedRequest) Do(ctx context.Context, transport Transport) 
 	}
 
 	if len(r.Header) > 0 {
-		req.Header = r.Header
+		for k, vv := range r.Header {
+			for _, v := range vv {
+				req.Header.Add(k, v)
+			}
+		}
 	}
 
 	if ctx != nil {

--- a/esapi/api.indices.forcemerge.go
+++ b/esapi/api.indices.forcemerge.go
@@ -121,9 +121,13 @@ func (r IndicesForcemergeRequest) Do(ctx context.Context, transport Transport) (
 	}
 
 	if len(r.Header) > 0 {
-		for k, vv := range r.Header {
-			for _, v := range vv {
-				req.Header.Add(k, v)
+		if len(req.Header) == 0 {
+			req.Header = r.Header
+		} else {
+			for k, vv := range r.Header {
+				for _, v := range vv {
+					req.Header.Add(k, v)
+				}
 			}
 		}
 	}

--- a/esapi/api.indices.forcemerge.go
+++ b/esapi/api.indices.forcemerge.go
@@ -4,6 +4,7 @@ package esapi
 
 import (
 	"context"
+	"net/http"
 	"strconv"
 	"strings"
 )
@@ -42,6 +43,8 @@ type IndicesForcemergeRequest struct {
 	Human      bool
 	ErrorTrace bool
 	FilterPath []string
+
+	Header http.Header
 
 	ctx context.Context
 }
@@ -115,6 +118,10 @@ func (r IndicesForcemergeRequest) Do(ctx context.Context, transport Transport) (
 			q.Set(k, v)
 		}
 		req.URL.RawQuery = q.Encode()
+	}
+
+	if len(r.Header) > 0 {
+		req.Header = r.Header
 	}
 
 	if ctx != nil {
@@ -228,5 +235,18 @@ func (f IndicesForcemerge) WithErrorTrace() func(*IndicesForcemergeRequest) {
 func (f IndicesForcemerge) WithFilterPath(v ...string) func(*IndicesForcemergeRequest) {
 	return func(r *IndicesForcemergeRequest) {
 		r.FilterPath = v
+	}
+}
+
+// WithHeader adds the headers to the HTTP request
+//
+func (f IndicesForcemerge) WithHeader(h map[string]string) func(*IndicesForcemergeRequest) {
+	return func(r *IndicesForcemergeRequest) {
+		if r.Header == nil {
+			r.Header = make(http.Header)
+		}
+		for k, v := range h {
+			r.Header.Add(k, v)
+		}
 	}
 }

--- a/esapi/api.indices.forcemerge.go
+++ b/esapi/api.indices.forcemerge.go
@@ -121,7 +121,11 @@ func (r IndicesForcemergeRequest) Do(ctx context.Context, transport Transport) (
 	}
 
 	if len(r.Header) > 0 {
-		req.Header = r.Header
+		for k, vv := range r.Header {
+			for _, v := range vv {
+				req.Header.Add(k, v)
+			}
+		}
 	}
 
 	if ctx != nil {

--- a/esapi/api.indices.get.go
+++ b/esapi/api.indices.get.go
@@ -128,7 +128,11 @@ func (r IndicesGetRequest) Do(ctx context.Context, transport Transport) (*Respon
 	}
 
 	if len(r.Header) > 0 {
-		req.Header = r.Header
+		for k, vv := range r.Header {
+			for _, v := range vv {
+				req.Header.Add(k, v)
+			}
+		}
 	}
 
 	if ctx != nil {

--- a/esapi/api.indices.get.go
+++ b/esapi/api.indices.get.go
@@ -128,9 +128,13 @@ func (r IndicesGetRequest) Do(ctx context.Context, transport Transport) (*Respon
 	}
 
 	if len(r.Header) > 0 {
-		for k, vv := range r.Header {
-			for _, v := range vv {
-				req.Header.Add(k, v)
+		if len(req.Header) == 0 {
+			req.Header = r.Header
+		} else {
+			for k, vv := range r.Header {
+				for _, v := range vv {
+					req.Header.Add(k, v)
+				}
 			}
 		}
 	}

--- a/esapi/api.indices.get.go
+++ b/esapi/api.indices.get.go
@@ -4,6 +4,7 @@ package esapi
 
 import (
 	"context"
+	"net/http"
 	"strconv"
 	"strings"
 	"time"
@@ -45,6 +46,8 @@ type IndicesGetRequest struct {
 	Human      bool
 	ErrorTrace bool
 	FilterPath []string
+
+	Header http.Header
 
 	ctx context.Context
 }
@@ -122,6 +125,10 @@ func (r IndicesGetRequest) Do(ctx context.Context, transport Transport) (*Respon
 			q.Set(k, v)
 		}
 		req.URL.RawQuery = q.Encode()
+	}
+
+	if len(r.Header) > 0 {
+		req.Header = r.Header
 	}
 
 	if ctx != nil {
@@ -243,5 +250,18 @@ func (f IndicesGet) WithErrorTrace() func(*IndicesGetRequest) {
 func (f IndicesGet) WithFilterPath(v ...string) func(*IndicesGetRequest) {
 	return func(r *IndicesGetRequest) {
 		r.FilterPath = v
+	}
+}
+
+// WithHeader adds the headers to the HTTP request
+//
+func (f IndicesGet) WithHeader(h map[string]string) func(*IndicesGetRequest) {
+	return func(r *IndicesGetRequest) {
+		if r.Header == nil {
+			r.Header = make(http.Header)
+		}
+		for k, v := range h {
+			r.Header.Add(k, v)
+		}
 	}
 }

--- a/esapi/api.indices.get_alias.go
+++ b/esapi/api.indices.get_alias.go
@@ -4,6 +4,7 @@ package esapi
 
 import (
 	"context"
+	"net/http"
 	"strconv"
 	"strings"
 )
@@ -42,6 +43,8 @@ type IndicesGetAliasRequest struct {
 	Human      bool
 	ErrorTrace bool
 	FilterPath []string
+
+	Header http.Header
 
 	ctx context.Context
 }
@@ -111,6 +114,10 @@ func (r IndicesGetAliasRequest) Do(ctx context.Context, transport Transport) (*R
 			q.Set(k, v)
 		}
 		req.URL.RawQuery = q.Encode()
+	}
+
+	if len(r.Header) > 0 {
+		req.Header = r.Header
 	}
 
 	if ctx != nil {
@@ -216,5 +223,18 @@ func (f IndicesGetAlias) WithErrorTrace() func(*IndicesGetAliasRequest) {
 func (f IndicesGetAlias) WithFilterPath(v ...string) func(*IndicesGetAliasRequest) {
 	return func(r *IndicesGetAliasRequest) {
 		r.FilterPath = v
+	}
+}
+
+// WithHeader adds the headers to the HTTP request
+//
+func (f IndicesGetAlias) WithHeader(h map[string]string) func(*IndicesGetAliasRequest) {
+	return func(r *IndicesGetAliasRequest) {
+		if r.Header == nil {
+			r.Header = make(http.Header)
+		}
+		for k, v := range h {
+			r.Header.Add(k, v)
+		}
 	}
 }

--- a/esapi/api.indices.get_alias.go
+++ b/esapi/api.indices.get_alias.go
@@ -117,9 +117,13 @@ func (r IndicesGetAliasRequest) Do(ctx context.Context, transport Transport) (*R
 	}
 
 	if len(r.Header) > 0 {
-		for k, vv := range r.Header {
-			for _, v := range vv {
-				req.Header.Add(k, v)
+		if len(req.Header) == 0 {
+			req.Header = r.Header
+		} else {
+			for k, vv := range r.Header {
+				for _, v := range vv {
+					req.Header.Add(k, v)
+				}
 			}
 		}
 	}

--- a/esapi/api.indices.get_alias.go
+++ b/esapi/api.indices.get_alias.go
@@ -117,7 +117,11 @@ func (r IndicesGetAliasRequest) Do(ctx context.Context, transport Transport) (*R
 	}
 
 	if len(r.Header) > 0 {
-		req.Header = r.Header
+		for k, vv := range r.Header {
+			for _, v := range vv {
+				req.Header.Add(k, v)
+			}
+		}
 	}
 
 	if ctx != nil {

--- a/esapi/api.indices.get_field_mapping.go
+++ b/esapi/api.indices.get_field_mapping.go
@@ -4,6 +4,7 @@ package esapi
 
 import (
 	"context"
+	"net/http"
 	"strconv"
 	"strings"
 )
@@ -45,6 +46,8 @@ type IndicesGetFieldMappingRequest struct {
 	Human      bool
 	ErrorTrace bool
 	FilterPath []string
+
+	Header http.Header
 
 	ctx context.Context
 }
@@ -126,6 +129,10 @@ func (r IndicesGetFieldMappingRequest) Do(ctx context.Context, transport Transpo
 			q.Set(k, v)
 		}
 		req.URL.RawQuery = q.Encode()
+	}
+
+	if len(r.Header) > 0 {
+		req.Header = r.Header
 	}
 
 	if ctx != nil {
@@ -247,5 +254,18 @@ func (f IndicesGetFieldMapping) WithErrorTrace() func(*IndicesGetFieldMappingReq
 func (f IndicesGetFieldMapping) WithFilterPath(v ...string) func(*IndicesGetFieldMappingRequest) {
 	return func(r *IndicesGetFieldMappingRequest) {
 		r.FilterPath = v
+	}
+}
+
+// WithHeader adds the headers to the HTTP request
+//
+func (f IndicesGetFieldMapping) WithHeader(h map[string]string) func(*IndicesGetFieldMappingRequest) {
+	return func(r *IndicesGetFieldMappingRequest) {
+		if r.Header == nil {
+			r.Header = make(http.Header)
+		}
+		for k, v := range h {
+			r.Header.Add(k, v)
+		}
 	}
 }

--- a/esapi/api.indices.get_field_mapping.go
+++ b/esapi/api.indices.get_field_mapping.go
@@ -132,7 +132,11 @@ func (r IndicesGetFieldMappingRequest) Do(ctx context.Context, transport Transpo
 	}
 
 	if len(r.Header) > 0 {
-		req.Header = r.Header
+		for k, vv := range r.Header {
+			for _, v := range vv {
+				req.Header.Add(k, v)
+			}
+		}
 	}
 
 	if ctx != nil {

--- a/esapi/api.indices.get_field_mapping.go
+++ b/esapi/api.indices.get_field_mapping.go
@@ -132,9 +132,13 @@ func (r IndicesGetFieldMappingRequest) Do(ctx context.Context, transport Transpo
 	}
 
 	if len(r.Header) > 0 {
-		for k, vv := range r.Header {
-			for _, v := range vv {
-				req.Header.Add(k, v)
+		if len(req.Header) == 0 {
+			req.Header = r.Header
+		} else {
+			for k, vv := range r.Header {
+				for _, v := range vv {
+					req.Header.Add(k, v)
+				}
 			}
 		}
 	}

--- a/esapi/api.indices.get_mapping.go
+++ b/esapi/api.indices.get_mapping.go
@@ -4,6 +4,7 @@ package esapi
 
 import (
 	"context"
+	"net/http"
 	"strconv"
 	"strings"
 	"time"
@@ -44,6 +45,8 @@ type IndicesGetMappingRequest struct {
 	Human      bool
 	ErrorTrace bool
 	FilterPath []string
+
+	Header http.Header
 
 	ctx context.Context
 }
@@ -121,6 +124,10 @@ func (r IndicesGetMappingRequest) Do(ctx context.Context, transport Transport) (
 			q.Set(k, v)
 		}
 		req.URL.RawQuery = q.Encode()
+	}
+
+	if len(r.Header) > 0 {
+		req.Header = r.Header
 	}
 
 	if ctx != nil {
@@ -242,5 +249,18 @@ func (f IndicesGetMapping) WithErrorTrace() func(*IndicesGetMappingRequest) {
 func (f IndicesGetMapping) WithFilterPath(v ...string) func(*IndicesGetMappingRequest) {
 	return func(r *IndicesGetMappingRequest) {
 		r.FilterPath = v
+	}
+}
+
+// WithHeader adds the headers to the HTTP request
+//
+func (f IndicesGetMapping) WithHeader(h map[string]string) func(*IndicesGetMappingRequest) {
+	return func(r *IndicesGetMappingRequest) {
+		if r.Header == nil {
+			r.Header = make(http.Header)
+		}
+		for k, v := range h {
+			r.Header.Add(k, v)
+		}
 	}
 }

--- a/esapi/api.indices.get_mapping.go
+++ b/esapi/api.indices.get_mapping.go
@@ -127,7 +127,11 @@ func (r IndicesGetMappingRequest) Do(ctx context.Context, transport Transport) (
 	}
 
 	if len(r.Header) > 0 {
-		req.Header = r.Header
+		for k, vv := range r.Header {
+			for _, v := range vv {
+				req.Header.Add(k, v)
+			}
+		}
 	}
 
 	if ctx != nil {

--- a/esapi/api.indices.get_mapping.go
+++ b/esapi/api.indices.get_mapping.go
@@ -127,9 +127,13 @@ func (r IndicesGetMappingRequest) Do(ctx context.Context, transport Transport) (
 	}
 
 	if len(r.Header) > 0 {
-		for k, vv := range r.Header {
-			for _, v := range vv {
-				req.Header.Add(k, v)
+		if len(req.Header) == 0 {
+			req.Header = r.Header
+		} else {
+			for k, vv := range r.Header {
+				for _, v := range vv {
+					req.Header.Add(k, v)
+				}
 			}
 		}
 	}

--- a/esapi/api.indices.get_settings.go
+++ b/esapi/api.indices.get_settings.go
@@ -133,7 +133,11 @@ func (r IndicesGetSettingsRequest) Do(ctx context.Context, transport Transport) 
 	}
 
 	if len(r.Header) > 0 {
-		req.Header = r.Header
+		for k, vv := range r.Header {
+			for _, v := range vv {
+				req.Header.Add(k, v)
+			}
+		}
 	}
 
 	if ctx != nil {

--- a/esapi/api.indices.get_settings.go
+++ b/esapi/api.indices.get_settings.go
@@ -4,6 +4,7 @@ package esapi
 
 import (
 	"context"
+	"net/http"
 	"strconv"
 	"strings"
 	"time"
@@ -46,6 +47,8 @@ type IndicesGetSettingsRequest struct {
 	Human      bool
 	ErrorTrace bool
 	FilterPath []string
+
+	Header http.Header
 
 	ctx context.Context
 }
@@ -127,6 +130,10 @@ func (r IndicesGetSettingsRequest) Do(ctx context.Context, transport Transport) 
 			q.Set(k, v)
 		}
 		req.URL.RawQuery = q.Encode()
+	}
+
+	if len(r.Header) > 0 {
+		req.Header = r.Header
 	}
 
 	if ctx != nil {
@@ -256,5 +263,18 @@ func (f IndicesGetSettings) WithErrorTrace() func(*IndicesGetSettingsRequest) {
 func (f IndicesGetSettings) WithFilterPath(v ...string) func(*IndicesGetSettingsRequest) {
 	return func(r *IndicesGetSettingsRequest) {
 		r.FilterPath = v
+	}
+}
+
+// WithHeader adds the headers to the HTTP request
+//
+func (f IndicesGetSettings) WithHeader(h map[string]string) func(*IndicesGetSettingsRequest) {
+	return func(r *IndicesGetSettingsRequest) {
+		if r.Header == nil {
+			r.Header = make(http.Header)
+		}
+		for k, v := range h {
+			r.Header.Add(k, v)
+		}
 	}
 }

--- a/esapi/api.indices.get_settings.go
+++ b/esapi/api.indices.get_settings.go
@@ -133,9 +133,13 @@ func (r IndicesGetSettingsRequest) Do(ctx context.Context, transport Transport) 
 	}
 
 	if len(r.Header) > 0 {
-		for k, vv := range r.Header {
-			for _, v := range vv {
-				req.Header.Add(k, v)
+		if len(req.Header) == 0 {
+			req.Header = r.Header
+		} else {
+			for k, vv := range r.Header {
+				for _, v := range vv {
+					req.Header.Add(k, v)
+				}
 			}
 		}
 	}

--- a/esapi/api.indices.get_template.go
+++ b/esapi/api.indices.get_template.go
@@ -112,7 +112,11 @@ func (r IndicesGetTemplateRequest) Do(ctx context.Context, transport Transport) 
 	}
 
 	if len(r.Header) > 0 {
-		req.Header = r.Header
+		for k, vv := range r.Header {
+			for _, v := range vv {
+				req.Header.Add(k, v)
+			}
+		}
 	}
 
 	if ctx != nil {

--- a/esapi/api.indices.get_template.go
+++ b/esapi/api.indices.get_template.go
@@ -4,6 +4,7 @@ package esapi
 
 import (
 	"context"
+	"net/http"
 	"strconv"
 	"strings"
 	"time"
@@ -41,6 +42,8 @@ type IndicesGetTemplateRequest struct {
 	Human      bool
 	ErrorTrace bool
 	FilterPath []string
+
+	Header http.Header
 
 	ctx context.Context
 }
@@ -106,6 +109,10 @@ func (r IndicesGetTemplateRequest) Do(ctx context.Context, transport Transport) 
 			q.Set(k, v)
 		}
 		req.URL.RawQuery = q.Encode()
+	}
+
+	if len(r.Header) > 0 {
+		req.Header = r.Header
 	}
 
 	if ctx != nil {
@@ -203,5 +210,18 @@ func (f IndicesGetTemplate) WithErrorTrace() func(*IndicesGetTemplateRequest) {
 func (f IndicesGetTemplate) WithFilterPath(v ...string) func(*IndicesGetTemplateRequest) {
 	return func(r *IndicesGetTemplateRequest) {
 		r.FilterPath = v
+	}
+}
+
+// WithHeader adds the headers to the HTTP request
+//
+func (f IndicesGetTemplate) WithHeader(h map[string]string) func(*IndicesGetTemplateRequest) {
+	return func(r *IndicesGetTemplateRequest) {
+		if r.Header == nil {
+			r.Header = make(http.Header)
+		}
+		for k, v := range h {
+			r.Header.Add(k, v)
+		}
 	}
 }

--- a/esapi/api.indices.get_template.go
+++ b/esapi/api.indices.get_template.go
@@ -112,9 +112,13 @@ func (r IndicesGetTemplateRequest) Do(ctx context.Context, transport Transport) 
 	}
 
 	if len(r.Header) > 0 {
-		for k, vv := range r.Header {
-			for _, v := range vv {
-				req.Header.Add(k, v)
+		if len(req.Header) == 0 {
+			req.Header = r.Header
+		} else {
+			for k, vv := range r.Header {
+				for _, v := range vv {
+					req.Header.Add(k, v)
+				}
 			}
 		}
 	}

--- a/esapi/api.indices.get_upgrade.go
+++ b/esapi/api.indices.get_upgrade.go
@@ -4,6 +4,7 @@ package esapi
 
 import (
 	"context"
+	"net/http"
 	"strconv"
 	"strings"
 )
@@ -39,6 +40,8 @@ type IndicesGetUpgradeRequest struct {
 	Human      bool
 	ErrorTrace bool
 	FilterPath []string
+
+	Header http.Header
 
 	ctx context.Context
 }
@@ -100,6 +103,10 @@ func (r IndicesGetUpgradeRequest) Do(ctx context.Context, transport Transport) (
 			q.Set(k, v)
 		}
 		req.URL.RawQuery = q.Encode()
+	}
+
+	if len(r.Header) > 0 {
+		req.Header = r.Header
 	}
 
 	if ctx != nil {
@@ -189,5 +196,18 @@ func (f IndicesGetUpgrade) WithErrorTrace() func(*IndicesGetUpgradeRequest) {
 func (f IndicesGetUpgrade) WithFilterPath(v ...string) func(*IndicesGetUpgradeRequest) {
 	return func(r *IndicesGetUpgradeRequest) {
 		r.FilterPath = v
+	}
+}
+
+// WithHeader adds the headers to the HTTP request
+//
+func (f IndicesGetUpgrade) WithHeader(h map[string]string) func(*IndicesGetUpgradeRequest) {
+	return func(r *IndicesGetUpgradeRequest) {
+		if r.Header == nil {
+			r.Header = make(http.Header)
+		}
+		for k, v := range h {
+			r.Header.Add(k, v)
+		}
 	}
 }

--- a/esapi/api.indices.get_upgrade.go
+++ b/esapi/api.indices.get_upgrade.go
@@ -106,9 +106,13 @@ func (r IndicesGetUpgradeRequest) Do(ctx context.Context, transport Transport) (
 	}
 
 	if len(r.Header) > 0 {
-		for k, vv := range r.Header {
-			for _, v := range vv {
-				req.Header.Add(k, v)
+		if len(req.Header) == 0 {
+			req.Header = r.Header
+		} else {
+			for k, vv := range r.Header {
+				for _, v := range vv {
+					req.Header.Add(k, v)
+				}
 			}
 		}
 	}

--- a/esapi/api.indices.get_upgrade.go
+++ b/esapi/api.indices.get_upgrade.go
@@ -106,7 +106,11 @@ func (r IndicesGetUpgradeRequest) Do(ctx context.Context, transport Transport) (
 	}
 
 	if len(r.Header) > 0 {
-		req.Header = r.Header
+		for k, vv := range r.Header {
+			for _, v := range vv {
+				req.Header.Add(k, v)
+			}
+		}
 	}
 
 	if ctx != nil {

--- a/esapi/api.indices.open.go
+++ b/esapi/api.indices.open.go
@@ -120,9 +120,13 @@ func (r IndicesOpenRequest) Do(ctx context.Context, transport Transport) (*Respo
 	}
 
 	if len(r.Header) > 0 {
-		for k, vv := range r.Header {
-			for _, v := range vv {
-				req.Header.Add(k, v)
+		if len(req.Header) == 0 {
+			req.Header = r.Header
+		} else {
+			for k, vv := range r.Header {
+				for _, v := range vv {
+					req.Header.Add(k, v)
+				}
 			}
 		}
 	}

--- a/esapi/api.indices.open.go
+++ b/esapi/api.indices.open.go
@@ -120,7 +120,11 @@ func (r IndicesOpenRequest) Do(ctx context.Context, transport Transport) (*Respo
 	}
 
 	if len(r.Header) > 0 {
-		req.Header = r.Header
+		for k, vv := range r.Header {
+			for _, v := range vv {
+				req.Header.Add(k, v)
+			}
+		}
 	}
 
 	if ctx != nil {

--- a/esapi/api.indices.open.go
+++ b/esapi/api.indices.open.go
@@ -4,6 +4,7 @@ package esapi
 
 import (
 	"context"
+	"net/http"
 	"strconv"
 	"strings"
 	"time"
@@ -43,6 +44,8 @@ type IndicesOpenRequest struct {
 	Human      bool
 	ErrorTrace bool
 	FilterPath []string
+
+	Header http.Header
 
 	ctx context.Context
 }
@@ -114,6 +117,10 @@ func (r IndicesOpenRequest) Do(ctx context.Context, transport Transport) (*Respo
 			q.Set(k, v)
 		}
 		req.URL.RawQuery = q.Encode()
+	}
+
+	if len(r.Header) > 0 {
+		req.Header = r.Header
 	}
 
 	if ctx != nil {
@@ -219,5 +226,18 @@ func (f IndicesOpen) WithErrorTrace() func(*IndicesOpenRequest) {
 func (f IndicesOpen) WithFilterPath(v ...string) func(*IndicesOpenRequest) {
 	return func(r *IndicesOpenRequest) {
 		r.FilterPath = v
+	}
+}
+
+// WithHeader adds the headers to the HTTP request
+//
+func (f IndicesOpen) WithHeader(h map[string]string) func(*IndicesOpenRequest) {
+	return func(r *IndicesOpenRequest) {
+		if r.Header == nil {
+			r.Header = make(http.Header)
+		}
+		for k, v := range h {
+			r.Header.Add(k, v)
+		}
 	}
 }

--- a/esapi/api.indices.put_alias.go
+++ b/esapi/api.indices.put_alias.go
@@ -5,6 +5,7 @@ package esapi
 import (
 	"context"
 	"io"
+	"net/http"
 	"strings"
 	"time"
 )
@@ -43,6 +44,8 @@ type IndicesPutAliasRequest struct {
 	Human      bool
 	ErrorTrace bool
 	FilterPath []string
+
+	Header http.Header
 
 	ctx context.Context
 }
@@ -104,6 +107,10 @@ func (r IndicesPutAliasRequest) Do(ctx context.Context, transport Transport) (*R
 
 	if r.Body != nil {
 		req.Header[headerContentType] = headerContentTypeJSON
+	}
+
+	if len(r.Header) > 0 {
+		req.Header = r.Header
 	}
 
 	if ctx != nil {
@@ -185,5 +192,18 @@ func (f IndicesPutAlias) WithErrorTrace() func(*IndicesPutAliasRequest) {
 func (f IndicesPutAlias) WithFilterPath(v ...string) func(*IndicesPutAliasRequest) {
 	return func(r *IndicesPutAliasRequest) {
 		r.FilterPath = v
+	}
+}
+
+// WithHeader adds the headers to the HTTP request
+//
+func (f IndicesPutAlias) WithHeader(h map[string]string) func(*IndicesPutAliasRequest) {
+	return func(r *IndicesPutAliasRequest) {
+		if r.Header == nil {
+			r.Header = make(http.Header)
+		}
+		for k, v := range h {
+			r.Header.Add(k, v)
+		}
 	}
 }

--- a/esapi/api.indices.put_alias.go
+++ b/esapi/api.indices.put_alias.go
@@ -110,9 +110,13 @@ func (r IndicesPutAliasRequest) Do(ctx context.Context, transport Transport) (*R
 	}
 
 	if len(r.Header) > 0 {
-		for k, vv := range r.Header {
-			for _, v := range vv {
-				req.Header.Add(k, v)
+		if len(req.Header) == 0 {
+			req.Header = r.Header
+		} else {
+			for k, vv := range r.Header {
+				for _, v := range vv {
+					req.Header.Add(k, v)
+				}
 			}
 		}
 	}

--- a/esapi/api.indices.put_alias.go
+++ b/esapi/api.indices.put_alias.go
@@ -110,7 +110,11 @@ func (r IndicesPutAliasRequest) Do(ctx context.Context, transport Transport) (*R
 	}
 
 	if len(r.Header) > 0 {
-		req.Header = r.Header
+		for k, vv := range r.Header {
+			for _, v := range vv {
+				req.Header.Add(k, v)
+			}
+		}
 	}
 
 	if ctx != nil {

--- a/esapi/api.indices.put_mapping.go
+++ b/esapi/api.indices.put_mapping.go
@@ -134,9 +134,13 @@ func (r IndicesPutMappingRequest) Do(ctx context.Context, transport Transport) (
 	}
 
 	if len(r.Header) > 0 {
-		for k, vv := range r.Header {
-			for _, v := range vv {
-				req.Header.Add(k, v)
+		if len(req.Header) == 0 {
+			req.Header = r.Header
+		} else {
+			for k, vv := range r.Header {
+				for _, v := range vv {
+					req.Header.Add(k, v)
+				}
 			}
 		}
 	}

--- a/esapi/api.indices.put_mapping.go
+++ b/esapi/api.indices.put_mapping.go
@@ -134,7 +134,11 @@ func (r IndicesPutMappingRequest) Do(ctx context.Context, transport Transport) (
 	}
 
 	if len(r.Header) > 0 {
-		req.Header = r.Header
+		for k, vv := range r.Header {
+			for _, v := range vv {
+				req.Header.Add(k, v)
+			}
+		}
 	}
 
 	if ctx != nil {

--- a/esapi/api.indices.put_mapping.go
+++ b/esapi/api.indices.put_mapping.go
@@ -5,6 +5,7 @@ package esapi
 import (
 	"context"
 	"io"
+	"net/http"
 	"strconv"
 	"strings"
 	"time"
@@ -47,6 +48,8 @@ type IndicesPutMappingRequest struct {
 	Human      bool
 	ErrorTrace bool
 	FilterPath []string
+
+	Header http.Header
 
 	ctx context.Context
 }
@@ -128,6 +131,10 @@ func (r IndicesPutMappingRequest) Do(ctx context.Context, transport Transport) (
 
 	if r.Body != nil {
 		req.Header[headerContentType] = headerContentTypeJSON
+	}
+
+	if len(r.Header) > 0 {
+		req.Header = r.Header
 	}
 
 	if ctx != nil {
@@ -249,5 +256,18 @@ func (f IndicesPutMapping) WithErrorTrace() func(*IndicesPutMappingRequest) {
 func (f IndicesPutMapping) WithFilterPath(v ...string) func(*IndicesPutMappingRequest) {
 	return func(r *IndicesPutMappingRequest) {
 		r.FilterPath = v
+	}
+}
+
+// WithHeader adds the headers to the HTTP request
+//
+func (f IndicesPutMapping) WithHeader(h map[string]string) func(*IndicesPutMappingRequest) {
+	return func(r *IndicesPutMappingRequest) {
+		if r.Header == nil {
+			r.Header = make(http.Header)
+		}
+		for k, v := range h {
+			r.Header.Add(k, v)
+		}
 	}
 }

--- a/esapi/api.indices.put_settings.go
+++ b/esapi/api.indices.put_settings.go
@@ -134,9 +134,13 @@ func (r IndicesPutSettingsRequest) Do(ctx context.Context, transport Transport) 
 	}
 
 	if len(r.Header) > 0 {
-		for k, vv := range r.Header {
-			for _, v := range vv {
-				req.Header.Add(k, v)
+		if len(req.Header) == 0 {
+			req.Header = r.Header
+		} else {
+			for k, vv := range r.Header {
+				for _, v := range vv {
+					req.Header.Add(k, v)
+				}
 			}
 		}
 	}

--- a/esapi/api.indices.put_settings.go
+++ b/esapi/api.indices.put_settings.go
@@ -5,6 +5,7 @@ package esapi
 import (
 	"context"
 	"io"
+	"net/http"
 	"strconv"
 	"strings"
 	"time"
@@ -47,6 +48,8 @@ type IndicesPutSettingsRequest struct {
 	Human      bool
 	ErrorTrace bool
 	FilterPath []string
+
+	Header http.Header
 
 	ctx context.Context
 }
@@ -128,6 +131,10 @@ func (r IndicesPutSettingsRequest) Do(ctx context.Context, transport Transport) 
 
 	if r.Body != nil {
 		req.Header[headerContentType] = headerContentTypeJSON
+	}
+
+	if len(r.Header) > 0 {
+		req.Header = r.Header
 	}
 
 	if ctx != nil {
@@ -249,5 +256,18 @@ func (f IndicesPutSettings) WithErrorTrace() func(*IndicesPutSettingsRequest) {
 func (f IndicesPutSettings) WithFilterPath(v ...string) func(*IndicesPutSettingsRequest) {
 	return func(r *IndicesPutSettingsRequest) {
 		r.FilterPath = v
+	}
+}
+
+// WithHeader adds the headers to the HTTP request
+//
+func (f IndicesPutSettings) WithHeader(h map[string]string) func(*IndicesPutSettingsRequest) {
+	return func(r *IndicesPutSettingsRequest) {
+		if r.Header == nil {
+			r.Header = make(http.Header)
+		}
+		for k, v := range h {
+			r.Header.Add(k, v)
+		}
 	}
 }

--- a/esapi/api.indices.put_settings.go
+++ b/esapi/api.indices.put_settings.go
@@ -134,7 +134,11 @@ func (r IndicesPutSettingsRequest) Do(ctx context.Context, transport Transport) 
 	}
 
 	if len(r.Header) > 0 {
-		req.Header = r.Header
+		for k, vv := range r.Header {
+			for _, v := range vv {
+				req.Header.Add(k, v)
+			}
+		}
 	}
 
 	if ctx != nil {

--- a/esapi/api.indices.put_template.go
+++ b/esapi/api.indices.put_template.go
@@ -5,6 +5,7 @@ package esapi
 import (
 	"context"
 	"io"
+	"net/http"
 	"strconv"
 	"strings"
 	"time"
@@ -46,6 +47,8 @@ type IndicesPutTemplateRequest struct {
 	Human      bool
 	ErrorTrace bool
 	FilterPath []string
+
+	Header http.Header
 
 	ctx context.Context
 }
@@ -121,6 +124,10 @@ func (r IndicesPutTemplateRequest) Do(ctx context.Context, transport Transport) 
 
 	if r.Body != nil {
 		req.Header[headerContentType] = headerContentTypeJSON
+	}
+
+	if len(r.Header) > 0 {
+		req.Header = r.Header
 	}
 
 	if ctx != nil {
@@ -226,5 +233,18 @@ func (f IndicesPutTemplate) WithErrorTrace() func(*IndicesPutTemplateRequest) {
 func (f IndicesPutTemplate) WithFilterPath(v ...string) func(*IndicesPutTemplateRequest) {
 	return func(r *IndicesPutTemplateRequest) {
 		r.FilterPath = v
+	}
+}
+
+// WithHeader adds the headers to the HTTP request
+//
+func (f IndicesPutTemplate) WithHeader(h map[string]string) func(*IndicesPutTemplateRequest) {
+	return func(r *IndicesPutTemplateRequest) {
+		if r.Header == nil {
+			r.Header = make(http.Header)
+		}
+		for k, v := range h {
+			r.Header.Add(k, v)
+		}
 	}
 }

--- a/esapi/api.indices.put_template.go
+++ b/esapi/api.indices.put_template.go
@@ -127,7 +127,11 @@ func (r IndicesPutTemplateRequest) Do(ctx context.Context, transport Transport) 
 	}
 
 	if len(r.Header) > 0 {
-		req.Header = r.Header
+		for k, vv := range r.Header {
+			for _, v := range vv {
+				req.Header.Add(k, v)
+			}
+		}
 	}
 
 	if ctx != nil {

--- a/esapi/api.indices.put_template.go
+++ b/esapi/api.indices.put_template.go
@@ -127,9 +127,13 @@ func (r IndicesPutTemplateRequest) Do(ctx context.Context, transport Transport) 
 	}
 
 	if len(r.Header) > 0 {
-		for k, vv := range r.Header {
-			for _, v := range vv {
-				req.Header.Add(k, v)
+		if len(req.Header) == 0 {
+			req.Header = r.Header
+		} else {
+			for k, vv := range r.Header {
+				for _, v := range vv {
+					req.Header.Add(k, v)
+				}
 			}
 		}
 	}

--- a/esapi/api.indices.recovery.go
+++ b/esapi/api.indices.recovery.go
@@ -101,9 +101,13 @@ func (r IndicesRecoveryRequest) Do(ctx context.Context, transport Transport) (*R
 	}
 
 	if len(r.Header) > 0 {
-		for k, vv := range r.Header {
-			for _, v := range vv {
-				req.Header.Add(k, v)
+		if len(req.Header) == 0 {
+			req.Header = r.Header
+		} else {
+			for k, vv := range r.Header {
+				for _, v := range vv {
+					req.Header.Add(k, v)
+				}
 			}
 		}
 	}

--- a/esapi/api.indices.recovery.go
+++ b/esapi/api.indices.recovery.go
@@ -101,7 +101,11 @@ func (r IndicesRecoveryRequest) Do(ctx context.Context, transport Transport) (*R
 	}
 
 	if len(r.Header) > 0 {
-		req.Header = r.Header
+		for k, vv := range r.Header {
+			for _, v := range vv {
+				req.Header.Add(k, v)
+			}
+		}
 	}
 
 	if ctx != nil {

--- a/esapi/api.indices.recovery.go
+++ b/esapi/api.indices.recovery.go
@@ -4,6 +4,7 @@ package esapi
 
 import (
 	"context"
+	"net/http"
 	"strconv"
 	"strings"
 )
@@ -38,6 +39,8 @@ type IndicesRecoveryRequest struct {
 	Human      bool
 	ErrorTrace bool
 	FilterPath []string
+
+	Header http.Header
 
 	ctx context.Context
 }
@@ -95,6 +98,10 @@ func (r IndicesRecoveryRequest) Do(ctx context.Context, transport Transport) (*R
 			q.Set(k, v)
 		}
 		req.URL.RawQuery = q.Encode()
+	}
+
+	if len(r.Header) > 0 {
+		req.Header = r.Header
 	}
 
 	if ctx != nil {
@@ -176,5 +183,18 @@ func (f IndicesRecovery) WithErrorTrace() func(*IndicesRecoveryRequest) {
 func (f IndicesRecovery) WithFilterPath(v ...string) func(*IndicesRecoveryRequest) {
 	return func(r *IndicesRecoveryRequest) {
 		r.FilterPath = v
+	}
+}
+
+// WithHeader adds the headers to the HTTP request
+//
+func (f IndicesRecovery) WithHeader(h map[string]string) func(*IndicesRecoveryRequest) {
+	return func(r *IndicesRecoveryRequest) {
+		if r.Header == nil {
+			r.Header = make(http.Header)
+		}
+		for k, v := range h {
+			r.Header.Add(k, v)
+		}
 	}
 }

--- a/esapi/api.indices.refresh.go
+++ b/esapi/api.indices.refresh.go
@@ -106,7 +106,11 @@ func (r IndicesRefreshRequest) Do(ctx context.Context, transport Transport) (*Re
 	}
 
 	if len(r.Header) > 0 {
-		req.Header = r.Header
+		for k, vv := range r.Header {
+			for _, v := range vv {
+				req.Header.Add(k, v)
+			}
+		}
 	}
 
 	if ctx != nil {

--- a/esapi/api.indices.refresh.go
+++ b/esapi/api.indices.refresh.go
@@ -4,6 +4,7 @@ package esapi
 
 import (
 	"context"
+	"net/http"
 	"strconv"
 	"strings"
 )
@@ -39,6 +40,8 @@ type IndicesRefreshRequest struct {
 	Human      bool
 	ErrorTrace bool
 	FilterPath []string
+
+	Header http.Header
 
 	ctx context.Context
 }
@@ -100,6 +103,10 @@ func (r IndicesRefreshRequest) Do(ctx context.Context, transport Transport) (*Re
 			q.Set(k, v)
 		}
 		req.URL.RawQuery = q.Encode()
+	}
+
+	if len(r.Header) > 0 {
+		req.Header = r.Header
 	}
 
 	if ctx != nil {
@@ -189,5 +196,18 @@ func (f IndicesRefresh) WithErrorTrace() func(*IndicesRefreshRequest) {
 func (f IndicesRefresh) WithFilterPath(v ...string) func(*IndicesRefreshRequest) {
 	return func(r *IndicesRefreshRequest) {
 		r.FilterPath = v
+	}
+}
+
+// WithHeader adds the headers to the HTTP request
+//
+func (f IndicesRefresh) WithHeader(h map[string]string) func(*IndicesRefreshRequest) {
+	return func(r *IndicesRefreshRequest) {
+		if r.Header == nil {
+			r.Header = make(http.Header)
+		}
+		for k, v := range h {
+			r.Header.Add(k, v)
+		}
 	}
 }

--- a/esapi/api.indices.refresh.go
+++ b/esapi/api.indices.refresh.go
@@ -106,9 +106,13 @@ func (r IndicesRefreshRequest) Do(ctx context.Context, transport Transport) (*Re
 	}
 
 	if len(r.Header) > 0 {
-		for k, vv := range r.Header {
-			for _, v := range vv {
-				req.Header.Add(k, v)
+		if len(req.Header) == 0 {
+			req.Header = r.Header
+		} else {
+			for k, vv := range r.Header {
+				for _, v := range vv {
+					req.Header.Add(k, v)
+				}
 			}
 		}
 	}

--- a/esapi/api.indices.rollover.go
+++ b/esapi/api.indices.rollover.go
@@ -128,7 +128,11 @@ func (r IndicesRolloverRequest) Do(ctx context.Context, transport Transport) (*R
 	}
 
 	if len(r.Header) > 0 {
-		req.Header = r.Header
+		for k, vv := range r.Header {
+			for _, v := range vv {
+				req.Header.Add(k, v)
+			}
+		}
 	}
 
 	if ctx != nil {

--- a/esapi/api.indices.rollover.go
+++ b/esapi/api.indices.rollover.go
@@ -5,6 +5,7 @@ package esapi
 import (
 	"context"
 	"io"
+	"net/http"
 	"strconv"
 	"strings"
 	"time"
@@ -47,6 +48,8 @@ type IndicesRolloverRequest struct {
 	Human      bool
 	ErrorTrace bool
 	FilterPath []string
+
+	Header http.Header
 
 	ctx context.Context
 }
@@ -122,6 +125,10 @@ func (r IndicesRolloverRequest) Do(ctx context.Context, transport Transport) (*R
 
 	if r.Body != nil {
 		req.Header[headerContentType] = headerContentTypeJSON
+	}
+
+	if len(r.Header) > 0 {
+		req.Header = r.Header
 	}
 
 	if ctx != nil {
@@ -235,5 +242,18 @@ func (f IndicesRollover) WithErrorTrace() func(*IndicesRolloverRequest) {
 func (f IndicesRollover) WithFilterPath(v ...string) func(*IndicesRolloverRequest) {
 	return func(r *IndicesRolloverRequest) {
 		r.FilterPath = v
+	}
+}
+
+// WithHeader adds the headers to the HTTP request
+//
+func (f IndicesRollover) WithHeader(h map[string]string) func(*IndicesRolloverRequest) {
+	return func(r *IndicesRolloverRequest) {
+		if r.Header == nil {
+			r.Header = make(http.Header)
+		}
+		for k, v := range h {
+			r.Header.Add(k, v)
+		}
 	}
 }

--- a/esapi/api.indices.rollover.go
+++ b/esapi/api.indices.rollover.go
@@ -128,9 +128,13 @@ func (r IndicesRolloverRequest) Do(ctx context.Context, transport Transport) (*R
 	}
 
 	if len(r.Header) > 0 {
-		for k, vv := range r.Header {
-			for _, v := range vv {
-				req.Header.Add(k, v)
+		if len(req.Header) == 0 {
+			req.Header = r.Header
+		} else {
+			for k, vv := range r.Header {
+				for _, v := range vv {
+					req.Header.Add(k, v)
+				}
 			}
 		}
 	}

--- a/esapi/api.indices.segments.go
+++ b/esapi/api.indices.segments.go
@@ -111,9 +111,13 @@ func (r IndicesSegmentsRequest) Do(ctx context.Context, transport Transport) (*R
 	}
 
 	if len(r.Header) > 0 {
-		for k, vv := range r.Header {
-			for _, v := range vv {
-				req.Header.Add(k, v)
+		if len(req.Header) == 0 {
+			req.Header = r.Header
+		} else {
+			for k, vv := range r.Header {
+				for _, v := range vv {
+					req.Header.Add(k, v)
+				}
 			}
 		}
 	}

--- a/esapi/api.indices.segments.go
+++ b/esapi/api.indices.segments.go
@@ -4,6 +4,7 @@ package esapi
 
 import (
 	"context"
+	"net/http"
 	"strconv"
 	"strings"
 )
@@ -40,6 +41,8 @@ type IndicesSegmentsRequest struct {
 	Human      bool
 	ErrorTrace bool
 	FilterPath []string
+
+	Header http.Header
 
 	ctx context.Context
 }
@@ -105,6 +108,10 @@ func (r IndicesSegmentsRequest) Do(ctx context.Context, transport Transport) (*R
 			q.Set(k, v)
 		}
 		req.URL.RawQuery = q.Encode()
+	}
+
+	if len(r.Header) > 0 {
+		req.Header = r.Header
 	}
 
 	if ctx != nil {
@@ -202,5 +209,18 @@ func (f IndicesSegments) WithErrorTrace() func(*IndicesSegmentsRequest) {
 func (f IndicesSegments) WithFilterPath(v ...string) func(*IndicesSegmentsRequest) {
 	return func(r *IndicesSegmentsRequest) {
 		r.FilterPath = v
+	}
+}
+
+// WithHeader adds the headers to the HTTP request
+//
+func (f IndicesSegments) WithHeader(h map[string]string) func(*IndicesSegmentsRequest) {
+	return func(r *IndicesSegmentsRequest) {
+		if r.Header == nil {
+			r.Header = make(http.Header)
+		}
+		for k, v := range h {
+			r.Header.Add(k, v)
+		}
 	}
 }

--- a/esapi/api.indices.segments.go
+++ b/esapi/api.indices.segments.go
@@ -111,7 +111,11 @@ func (r IndicesSegmentsRequest) Do(ctx context.Context, transport Transport) (*R
 	}
 
 	if len(r.Header) > 0 {
-		req.Header = r.Header
+		for k, vv := range r.Header {
+			for _, v := range vv {
+				req.Header.Add(k, v)
+			}
+		}
 	}
 
 	if ctx != nil {

--- a/esapi/api.indices.shard_stores.go
+++ b/esapi/api.indices.shard_stores.go
@@ -4,6 +4,7 @@ package esapi
 
 import (
 	"context"
+	"net/http"
 	"strconv"
 	"strings"
 )
@@ -40,6 +41,8 @@ type IndicesShardStoresRequest struct {
 	Human      bool
 	ErrorTrace bool
 	FilterPath []string
+
+	Header http.Header
 
 	ctx context.Context
 }
@@ -105,6 +108,10 @@ func (r IndicesShardStoresRequest) Do(ctx context.Context, transport Transport) 
 			q.Set(k, v)
 		}
 		req.URL.RawQuery = q.Encode()
+	}
+
+	if len(r.Header) > 0 {
+		req.Header = r.Header
 	}
 
 	if ctx != nil {
@@ -202,5 +209,18 @@ func (f IndicesShardStores) WithErrorTrace() func(*IndicesShardStoresRequest) {
 func (f IndicesShardStores) WithFilterPath(v ...string) func(*IndicesShardStoresRequest) {
 	return func(r *IndicesShardStoresRequest) {
 		r.FilterPath = v
+	}
+}
+
+// WithHeader adds the headers to the HTTP request
+//
+func (f IndicesShardStores) WithHeader(h map[string]string) func(*IndicesShardStoresRequest) {
+	return func(r *IndicesShardStoresRequest) {
+		if r.Header == nil {
+			r.Header = make(http.Header)
+		}
+		for k, v := range h {
+			r.Header.Add(k, v)
+		}
 	}
 }

--- a/esapi/api.indices.shard_stores.go
+++ b/esapi/api.indices.shard_stores.go
@@ -111,9 +111,13 @@ func (r IndicesShardStoresRequest) Do(ctx context.Context, transport Transport) 
 	}
 
 	if len(r.Header) > 0 {
-		for k, vv := range r.Header {
-			for _, v := range vv {
-				req.Header.Add(k, v)
+		if len(req.Header) == 0 {
+			req.Header = r.Header
+		} else {
+			for k, vv := range r.Header {
+				for _, v := range vv {
+					req.Header.Add(k, v)
+				}
 			}
 		}
 	}

--- a/esapi/api.indices.shard_stores.go
+++ b/esapi/api.indices.shard_stores.go
@@ -111,7 +111,11 @@ func (r IndicesShardStoresRequest) Do(ctx context.Context, transport Transport) 
 	}
 
 	if len(r.Header) > 0 {
-		req.Header = r.Header
+		for k, vv := range r.Header {
+			for _, v := range vv {
+				req.Header.Add(k, v)
+			}
+		}
 	}
 
 	if ctx != nil {

--- a/esapi/api.indices.shrink.go
+++ b/esapi/api.indices.shrink.go
@@ -115,9 +115,13 @@ func (r IndicesShrinkRequest) Do(ctx context.Context, transport Transport) (*Res
 	}
 
 	if len(r.Header) > 0 {
-		for k, vv := range r.Header {
-			for _, v := range vv {
-				req.Header.Add(k, v)
+		if len(req.Header) == 0 {
+			req.Header = r.Header
+		} else {
+			for k, vv := range r.Header {
+				for _, v := range vv {
+					req.Header.Add(k, v)
+				}
 			}
 		}
 	}

--- a/esapi/api.indices.shrink.go
+++ b/esapi/api.indices.shrink.go
@@ -115,7 +115,11 @@ func (r IndicesShrinkRequest) Do(ctx context.Context, transport Transport) (*Res
 	}
 
 	if len(r.Header) > 0 {
-		req.Header = r.Header
+		for k, vv := range r.Header {
+			for _, v := range vv {
+				req.Header.Add(k, v)
+			}
+		}
 	}
 
 	if ctx != nil {

--- a/esapi/api.indices.shrink.go
+++ b/esapi/api.indices.shrink.go
@@ -5,6 +5,7 @@ package esapi
 import (
 	"context"
 	"io"
+	"net/http"
 	"strings"
 	"time"
 )
@@ -44,6 +45,8 @@ type IndicesShrinkRequest struct {
 	Human      bool
 	ErrorTrace bool
 	FilterPath []string
+
+	Header http.Header
 
 	ctx context.Context
 }
@@ -109,6 +112,10 @@ func (r IndicesShrinkRequest) Do(ctx context.Context, transport Transport) (*Res
 
 	if r.Body != nil {
 		req.Header[headerContentType] = headerContentTypeJSON
+	}
+
+	if len(r.Header) > 0 {
+		req.Header = r.Header
 	}
 
 	if ctx != nil {
@@ -198,5 +205,18 @@ func (f IndicesShrink) WithErrorTrace() func(*IndicesShrinkRequest) {
 func (f IndicesShrink) WithFilterPath(v ...string) func(*IndicesShrinkRequest) {
 	return func(r *IndicesShrinkRequest) {
 		r.FilterPath = v
+	}
+}
+
+// WithHeader adds the headers to the HTTP request
+//
+func (f IndicesShrink) WithHeader(h map[string]string) func(*IndicesShrinkRequest) {
+	return func(r *IndicesShrinkRequest) {
+		if r.Header == nil {
+			r.Header = make(http.Header)
+		}
+		for k, v := range h {
+			r.Header.Add(k, v)
+		}
 	}
 }

--- a/esapi/api.indices.split.go
+++ b/esapi/api.indices.split.go
@@ -5,6 +5,7 @@ package esapi
 import (
 	"context"
 	"io"
+	"net/http"
 	"strings"
 	"time"
 )
@@ -44,6 +45,8 @@ type IndicesSplitRequest struct {
 	Human      bool
 	ErrorTrace bool
 	FilterPath []string
+
+	Header http.Header
 
 	ctx context.Context
 }
@@ -109,6 +112,10 @@ func (r IndicesSplitRequest) Do(ctx context.Context, transport Transport) (*Resp
 
 	if r.Body != nil {
 		req.Header[headerContentType] = headerContentTypeJSON
+	}
+
+	if len(r.Header) > 0 {
+		req.Header = r.Header
 	}
 
 	if ctx != nil {
@@ -198,5 +205,18 @@ func (f IndicesSplit) WithErrorTrace() func(*IndicesSplitRequest) {
 func (f IndicesSplit) WithFilterPath(v ...string) func(*IndicesSplitRequest) {
 	return func(r *IndicesSplitRequest) {
 		r.FilterPath = v
+	}
+}
+
+// WithHeader adds the headers to the HTTP request
+//
+func (f IndicesSplit) WithHeader(h map[string]string) func(*IndicesSplitRequest) {
+	return func(r *IndicesSplitRequest) {
+		if r.Header == nil {
+			r.Header = make(http.Header)
+		}
+		for k, v := range h {
+			r.Header.Add(k, v)
+		}
 	}
 }

--- a/esapi/api.indices.split.go
+++ b/esapi/api.indices.split.go
@@ -115,7 +115,11 @@ func (r IndicesSplitRequest) Do(ctx context.Context, transport Transport) (*Resp
 	}
 
 	if len(r.Header) > 0 {
-		req.Header = r.Header
+		for k, vv := range r.Header {
+			for _, v := range vv {
+				req.Header.Add(k, v)
+			}
+		}
 	}
 
 	if ctx != nil {

--- a/esapi/api.indices.split.go
+++ b/esapi/api.indices.split.go
@@ -115,9 +115,13 @@ func (r IndicesSplitRequest) Do(ctx context.Context, transport Transport) (*Resp
 	}
 
 	if len(r.Header) > 0 {
-		for k, vv := range r.Header {
-			for _, v := range vv {
-				req.Header.Add(k, v)
+		if len(req.Header) == 0 {
+			req.Header = r.Header
+		} else {
+			for k, vv := range r.Header {
+				for _, v := range vv {
+					req.Header.Add(k, v)
+				}
 			}
 		}
 	}

--- a/esapi/api.indices.stats.go
+++ b/esapi/api.indices.stats.go
@@ -147,7 +147,11 @@ func (r IndicesStatsRequest) Do(ctx context.Context, transport Transport) (*Resp
 	}
 
 	if len(r.Header) > 0 {
-		req.Header = r.Header
+		for k, vv := range r.Header {
+			for _, v := range vv {
+				req.Header.Add(k, v)
+			}
+		}
 	}
 
 	if ctx != nil {

--- a/esapi/api.indices.stats.go
+++ b/esapi/api.indices.stats.go
@@ -4,6 +4,7 @@ package esapi
 
 import (
 	"context"
+	"net/http"
 	"strconv"
 	"strings"
 )
@@ -48,6 +49,8 @@ type IndicesStatsRequest struct {
 	Human      bool
 	ErrorTrace bool
 	FilterPath []string
+
+	Header http.Header
 
 	ctx context.Context
 }
@@ -141,6 +144,10 @@ func (r IndicesStatsRequest) Do(ctx context.Context, transport Transport) (*Resp
 			q.Set(k, v)
 		}
 		req.URL.RawQuery = q.Encode()
+	}
+
+	if len(r.Header) > 0 {
+		req.Header = r.Header
 	}
 
 	if ctx != nil {
@@ -294,5 +301,18 @@ func (f IndicesStats) WithErrorTrace() func(*IndicesStatsRequest) {
 func (f IndicesStats) WithFilterPath(v ...string) func(*IndicesStatsRequest) {
 	return func(r *IndicesStatsRequest) {
 		r.FilterPath = v
+	}
+}
+
+// WithHeader adds the headers to the HTTP request
+//
+func (f IndicesStats) WithHeader(h map[string]string) func(*IndicesStatsRequest) {
+	return func(r *IndicesStatsRequest) {
+		if r.Header == nil {
+			r.Header = make(http.Header)
+		}
+		for k, v := range h {
+			r.Header.Add(k, v)
+		}
 	}
 }

--- a/esapi/api.indices.stats.go
+++ b/esapi/api.indices.stats.go
@@ -147,9 +147,13 @@ func (r IndicesStatsRequest) Do(ctx context.Context, transport Transport) (*Resp
 	}
 
 	if len(r.Header) > 0 {
-		for k, vv := range r.Header {
-			for _, v := range vv {
-				req.Header.Add(k, v)
+		if len(req.Header) == 0 {
+			req.Header = r.Header
+		} else {
+			for k, vv := range r.Header {
+				for _, v := range vv {
+					req.Header.Add(k, v)
+				}
 			}
 		}
 	}

--- a/esapi/api.indices.update_aliases.go
+++ b/esapi/api.indices.update_aliases.go
@@ -101,7 +101,11 @@ func (r IndicesUpdateAliasesRequest) Do(ctx context.Context, transport Transport
 	}
 
 	if len(r.Header) > 0 {
-		req.Header = r.Header
+		for k, vv := range r.Header {
+			for _, v := range vv {
+				req.Header.Add(k, v)
+			}
+		}
 	}
 
 	if ctx != nil {

--- a/esapi/api.indices.update_aliases.go
+++ b/esapi/api.indices.update_aliases.go
@@ -101,9 +101,13 @@ func (r IndicesUpdateAliasesRequest) Do(ctx context.Context, transport Transport
 	}
 
 	if len(r.Header) > 0 {
-		for k, vv := range r.Header {
-			for _, v := range vv {
-				req.Header.Add(k, v)
+		if len(req.Header) == 0 {
+			req.Header = r.Header
+		} else {
+			for k, vv := range r.Header {
+				for _, v := range vv {
+					req.Header.Add(k, v)
+				}
 			}
 		}
 	}

--- a/esapi/api.indices.update_aliases.go
+++ b/esapi/api.indices.update_aliases.go
@@ -5,6 +5,7 @@ package esapi
 import (
 	"context"
 	"io"
+	"net/http"
 	"strings"
 	"time"
 )
@@ -39,6 +40,8 @@ type IndicesUpdateAliasesRequest struct {
 	Human      bool
 	ErrorTrace bool
 	FilterPath []string
+
+	Header http.Header
 
 	ctx context.Context
 }
@@ -95,6 +98,10 @@ func (r IndicesUpdateAliasesRequest) Do(ctx context.Context, transport Transport
 
 	if r.Body != nil {
 		req.Header[headerContentType] = headerContentTypeJSON
+	}
+
+	if len(r.Header) > 0 {
+		req.Header = r.Header
 	}
 
 	if ctx != nil {
@@ -168,5 +175,18 @@ func (f IndicesUpdateAliases) WithErrorTrace() func(*IndicesUpdateAliasesRequest
 func (f IndicesUpdateAliases) WithFilterPath(v ...string) func(*IndicesUpdateAliasesRequest) {
 	return func(r *IndicesUpdateAliasesRequest) {
 		r.FilterPath = v
+	}
+}
+
+// WithHeader adds the headers to the HTTP request
+//
+func (f IndicesUpdateAliases) WithHeader(h map[string]string) func(*IndicesUpdateAliasesRequest) {
+	return func(r *IndicesUpdateAliasesRequest) {
+		if r.Header == nil {
+			r.Header = make(http.Header)
+		}
+		for k, v := range h {
+			r.Header.Add(k, v)
+		}
 	}
 }

--- a/esapi/api.indices.upgrade.go
+++ b/esapi/api.indices.upgrade.go
@@ -116,9 +116,13 @@ func (r IndicesUpgradeRequest) Do(ctx context.Context, transport Transport) (*Re
 	}
 
 	if len(r.Header) > 0 {
-		for k, vv := range r.Header {
-			for _, v := range vv {
-				req.Header.Add(k, v)
+		if len(req.Header) == 0 {
+			req.Header = r.Header
+		} else {
+			for k, vv := range r.Header {
+				for _, v := range vv {
+					req.Header.Add(k, v)
+				}
 			}
 		}
 	}

--- a/esapi/api.indices.upgrade.go
+++ b/esapi/api.indices.upgrade.go
@@ -116,7 +116,11 @@ func (r IndicesUpgradeRequest) Do(ctx context.Context, transport Transport) (*Re
 	}
 
 	if len(r.Header) > 0 {
-		req.Header = r.Header
+		for k, vv := range r.Header {
+			for _, v := range vv {
+				req.Header.Add(k, v)
+			}
+		}
 	}
 
 	if ctx != nil {

--- a/esapi/api.indices.upgrade.go
+++ b/esapi/api.indices.upgrade.go
@@ -4,6 +4,7 @@ package esapi
 
 import (
 	"context"
+	"net/http"
 	"strconv"
 	"strings"
 )
@@ -41,6 +42,8 @@ type IndicesUpgradeRequest struct {
 	Human      bool
 	ErrorTrace bool
 	FilterPath []string
+
+	Header http.Header
 
 	ctx context.Context
 }
@@ -110,6 +113,10 @@ func (r IndicesUpgradeRequest) Do(ctx context.Context, transport Transport) (*Re
 			q.Set(k, v)
 		}
 		req.URL.RawQuery = q.Encode()
+	}
+
+	if len(r.Header) > 0 {
+		req.Header = r.Header
 	}
 
 	if ctx != nil {
@@ -215,5 +222,18 @@ func (f IndicesUpgrade) WithErrorTrace() func(*IndicesUpgradeRequest) {
 func (f IndicesUpgrade) WithFilterPath(v ...string) func(*IndicesUpgradeRequest) {
 	return func(r *IndicesUpgradeRequest) {
 		r.FilterPath = v
+	}
+}
+
+// WithHeader adds the headers to the HTTP request
+//
+func (f IndicesUpgrade) WithHeader(h map[string]string) func(*IndicesUpgradeRequest) {
+	return func(r *IndicesUpgradeRequest) {
+		if r.Header == nil {
+			r.Header = make(http.Header)
+		}
+		for k, v := range h {
+			r.Header.Add(k, v)
+		}
 	}
 }

--- a/esapi/api.indices.validate_query.go
+++ b/esapi/api.indices.validate_query.go
@@ -165,9 +165,13 @@ func (r IndicesValidateQueryRequest) Do(ctx context.Context, transport Transport
 	}
 
 	if len(r.Header) > 0 {
-		for k, vv := range r.Header {
-			for _, v := range vv {
-				req.Header.Add(k, v)
+		if len(req.Header) == 0 {
+			req.Header = r.Header
+		} else {
+			for k, vv := range r.Header {
+				for _, v := range vv {
+					req.Header.Add(k, v)
+				}
 			}
 		}
 	}

--- a/esapi/api.indices.validate_query.go
+++ b/esapi/api.indices.validate_query.go
@@ -5,6 +5,7 @@ package esapi
 import (
 	"context"
 	"io"
+	"net/http"
 	"strconv"
 	"strings"
 )
@@ -52,6 +53,8 @@ type IndicesValidateQueryRequest struct {
 	Human      bool
 	ErrorTrace bool
 	FilterPath []string
+
+	Header http.Header
 
 	ctx context.Context
 }
@@ -159,6 +162,10 @@ func (r IndicesValidateQueryRequest) Do(ctx context.Context, transport Transport
 
 	if r.Body != nil {
 		req.Header[headerContentType] = headerContentTypeJSON
+	}
+
+	if len(r.Header) > 0 {
+		req.Header = r.Header
 	}
 
 	if ctx != nil {
@@ -336,5 +343,18 @@ func (f IndicesValidateQuery) WithErrorTrace() func(*IndicesValidateQueryRequest
 func (f IndicesValidateQuery) WithFilterPath(v ...string) func(*IndicesValidateQueryRequest) {
 	return func(r *IndicesValidateQueryRequest) {
 		r.FilterPath = v
+	}
+}
+
+// WithHeader adds the headers to the HTTP request
+//
+func (f IndicesValidateQuery) WithHeader(h map[string]string) func(*IndicesValidateQueryRequest) {
+	return func(r *IndicesValidateQueryRequest) {
+		if r.Header == nil {
+			r.Header = make(http.Header)
+		}
+		for k, v := range h {
+			r.Header.Add(k, v)
+		}
 	}
 }

--- a/esapi/api.indices.validate_query.go
+++ b/esapi/api.indices.validate_query.go
@@ -165,7 +165,11 @@ func (r IndicesValidateQueryRequest) Do(ctx context.Context, transport Transport
 	}
 
 	if len(r.Header) > 0 {
-		req.Header = r.Header
+		for k, vv := range r.Header {
+			for _, v := range vv {
+				req.Header.Add(k, v)
+			}
+		}
 	}
 
 	if ctx != nil {

--- a/esapi/api.info.go
+++ b/esapi/api.info.go
@@ -82,7 +82,11 @@ func (r InfoRequest) Do(ctx context.Context, transport Transport) (*Response, er
 	}
 
 	if len(r.Header) > 0 {
-		req.Header = r.Header
+		for k, vv := range r.Header {
+			for _, v := range vv {
+				req.Header.Add(k, v)
+			}
+		}
 	}
 
 	if ctx != nil {

--- a/esapi/api.info.go
+++ b/esapi/api.info.go
@@ -82,9 +82,13 @@ func (r InfoRequest) Do(ctx context.Context, transport Transport) (*Response, er
 	}
 
 	if len(r.Header) > 0 {
-		for k, vv := range r.Header {
-			for _, v := range vv {
-				req.Header.Add(k, v)
+		if len(req.Header) == 0 {
+			req.Header = r.Header
+		} else {
+			for k, vv := range r.Header {
+				for _, v := range vv {
+					req.Header.Add(k, v)
+				}
 			}
 		}
 	}

--- a/esapi/api.info.go
+++ b/esapi/api.info.go
@@ -4,6 +4,7 @@ package esapi
 
 import (
 	"context"
+	"net/http"
 	"strings"
 )
 
@@ -32,6 +33,8 @@ type InfoRequest struct {
 	Human      bool
 	ErrorTrace bool
 	FilterPath []string
+
+	Header http.Header
 
 	ctx context.Context
 }
@@ -76,6 +79,10 @@ func (r InfoRequest) Do(ctx context.Context, transport Transport) (*Response, er
 			q.Set(k, v)
 		}
 		req.URL.RawQuery = q.Encode()
+	}
+
+	if len(r.Header) > 0 {
+		req.Header = r.Header
 	}
 
 	if ctx != nil {
@@ -125,5 +132,18 @@ func (f Info) WithErrorTrace() func(*InfoRequest) {
 func (f Info) WithFilterPath(v ...string) func(*InfoRequest) {
 	return func(r *InfoRequest) {
 		r.FilterPath = v
+	}
+}
+
+// WithHeader adds the headers to the HTTP request
+//
+func (f Info) WithHeader(h map[string]string) func(*InfoRequest) {
+	return func(r *InfoRequest) {
+		if r.Header == nil {
+			r.Header = make(http.Header)
+		}
+		for k, v := range h {
+			r.Header.Add(k, v)
+		}
 	}
 }

--- a/esapi/api.ingest.delete_pipeline.go
+++ b/esapi/api.ingest.delete_pipeline.go
@@ -101,9 +101,13 @@ func (r IngestDeletePipelineRequest) Do(ctx context.Context, transport Transport
 	}
 
 	if len(r.Header) > 0 {
-		for k, vv := range r.Header {
-			for _, v := range vv {
-				req.Header.Add(k, v)
+		if len(req.Header) == 0 {
+			req.Header = r.Header
+		} else {
+			for k, vv := range r.Header {
+				for _, v := range vv {
+					req.Header.Add(k, v)
+				}
 			}
 		}
 	}

--- a/esapi/api.ingest.delete_pipeline.go
+++ b/esapi/api.ingest.delete_pipeline.go
@@ -4,6 +4,7 @@ package esapi
 
 import (
 	"context"
+	"net/http"
 	"strings"
 	"time"
 )
@@ -38,6 +39,8 @@ type IngestDeletePipelineRequest struct {
 	Human      bool
 	ErrorTrace bool
 	FilterPath []string
+
+	Header http.Header
 
 	ctx context.Context
 }
@@ -95,6 +98,10 @@ func (r IngestDeletePipelineRequest) Do(ctx context.Context, transport Transport
 			q.Set(k, v)
 		}
 		req.URL.RawQuery = q.Encode()
+	}
+
+	if len(r.Header) > 0 {
+		req.Header = r.Header
 	}
 
 	if ctx != nil {
@@ -168,5 +175,18 @@ func (f IngestDeletePipeline) WithErrorTrace() func(*IngestDeletePipelineRequest
 func (f IngestDeletePipeline) WithFilterPath(v ...string) func(*IngestDeletePipelineRequest) {
 	return func(r *IngestDeletePipelineRequest) {
 		r.FilterPath = v
+	}
+}
+
+// WithHeader adds the headers to the HTTP request
+//
+func (f IngestDeletePipeline) WithHeader(h map[string]string) func(*IngestDeletePipelineRequest) {
+	return func(r *IngestDeletePipelineRequest) {
+		if r.Header == nil {
+			r.Header = make(http.Header)
+		}
+		for k, v := range h {
+			r.Header.Add(k, v)
+		}
 	}
 }

--- a/esapi/api.ingest.delete_pipeline.go
+++ b/esapi/api.ingest.delete_pipeline.go
@@ -101,7 +101,11 @@ func (r IngestDeletePipelineRequest) Do(ctx context.Context, transport Transport
 	}
 
 	if len(r.Header) > 0 {
-		req.Header = r.Header
+		for k, vv := range r.Header {
+			for _, v := range vv {
+				req.Header.Add(k, v)
+			}
+		}
 	}
 
 	if ctx != nil {

--- a/esapi/api.ingest.get_pipeline.go
+++ b/esapi/api.ingest.get_pipeline.go
@@ -98,7 +98,11 @@ func (r IngestGetPipelineRequest) Do(ctx context.Context, transport Transport) (
 	}
 
 	if len(r.Header) > 0 {
-		req.Header = r.Header
+		for k, vv := range r.Header {
+			for _, v := range vv {
+				req.Header.Add(k, v)
+			}
+		}
 	}
 
 	if ctx != nil {

--- a/esapi/api.ingest.get_pipeline.go
+++ b/esapi/api.ingest.get_pipeline.go
@@ -4,6 +4,7 @@ package esapi
 
 import (
 	"context"
+	"net/http"
 	"strings"
 	"time"
 )
@@ -37,6 +38,8 @@ type IngestGetPipelineRequest struct {
 	Human      bool
 	ErrorTrace bool
 	FilterPath []string
+
+	Header http.Header
 
 	ctx context.Context
 }
@@ -92,6 +95,10 @@ func (r IngestGetPipelineRequest) Do(ctx context.Context, transport Transport) (
 			q.Set(k, v)
 		}
 		req.URL.RawQuery = q.Encode()
+	}
+
+	if len(r.Header) > 0 {
+		req.Header = r.Header
 	}
 
 	if ctx != nil {
@@ -165,5 +172,18 @@ func (f IngestGetPipeline) WithErrorTrace() func(*IngestGetPipelineRequest) {
 func (f IngestGetPipeline) WithFilterPath(v ...string) func(*IngestGetPipelineRequest) {
 	return func(r *IngestGetPipelineRequest) {
 		r.FilterPath = v
+	}
+}
+
+// WithHeader adds the headers to the HTTP request
+//
+func (f IngestGetPipeline) WithHeader(h map[string]string) func(*IngestGetPipelineRequest) {
+	return func(r *IngestGetPipelineRequest) {
+		if r.Header == nil {
+			r.Header = make(http.Header)
+		}
+		for k, v := range h {
+			r.Header.Add(k, v)
+		}
 	}
 }

--- a/esapi/api.ingest.get_pipeline.go
+++ b/esapi/api.ingest.get_pipeline.go
@@ -98,9 +98,13 @@ func (r IngestGetPipelineRequest) Do(ctx context.Context, transport Transport) (
 	}
 
 	if len(r.Header) > 0 {
-		for k, vv := range r.Header {
-			for _, v := range vv {
-				req.Header.Add(k, v)
+		if len(req.Header) == 0 {
+			req.Header = r.Header
+		} else {
+			for k, vv := range r.Header {
+				for _, v := range vv {
+					req.Header.Add(k, v)
+				}
 			}
 		}
 	}

--- a/esapi/api.ingest.processor_grok.go
+++ b/esapi/api.ingest.processor_grok.go
@@ -82,9 +82,13 @@ func (r IngestProcessorGrokRequest) Do(ctx context.Context, transport Transport)
 	}
 
 	if len(r.Header) > 0 {
-		for k, vv := range r.Header {
-			for _, v := range vv {
-				req.Header.Add(k, v)
+		if len(req.Header) == 0 {
+			req.Header = r.Header
+		} else {
+			for k, vv := range r.Header {
+				for _, v := range vv {
+					req.Header.Add(k, v)
+				}
 			}
 		}
 	}

--- a/esapi/api.ingest.processor_grok.go
+++ b/esapi/api.ingest.processor_grok.go
@@ -4,6 +4,7 @@ package esapi
 
 import (
 	"context"
+	"net/http"
 	"strings"
 )
 
@@ -32,6 +33,8 @@ type IngestProcessorGrokRequest struct {
 	Human      bool
 	ErrorTrace bool
 	FilterPath []string
+
+	Header http.Header
 
 	ctx context.Context
 }
@@ -76,6 +79,10 @@ func (r IngestProcessorGrokRequest) Do(ctx context.Context, transport Transport)
 			q.Set(k, v)
 		}
 		req.URL.RawQuery = q.Encode()
+	}
+
+	if len(r.Header) > 0 {
+		req.Header = r.Header
 	}
 
 	if ctx != nil {
@@ -133,5 +140,18 @@ func (f IngestProcessorGrok) WithErrorTrace() func(*IngestProcessorGrokRequest) 
 func (f IngestProcessorGrok) WithFilterPath(v ...string) func(*IngestProcessorGrokRequest) {
 	return func(r *IngestProcessorGrokRequest) {
 		r.FilterPath = v
+	}
+}
+
+// WithHeader adds the headers to the HTTP request
+//
+func (f IngestProcessorGrok) WithHeader(h map[string]string) func(*IngestProcessorGrokRequest) {
+	return func(r *IngestProcessorGrokRequest) {
+		if r.Header == nil {
+			r.Header = make(http.Header)
+		}
+		for k, v := range h {
+			r.Header.Add(k, v)
+		}
 	}
 }

--- a/esapi/api.ingest.processor_grok.go
+++ b/esapi/api.ingest.processor_grok.go
@@ -82,7 +82,11 @@ func (r IngestProcessorGrokRequest) Do(ctx context.Context, transport Transport)
 	}
 
 	if len(r.Header) > 0 {
-		req.Header = r.Header
+		for k, vv := range r.Header {
+			for _, v := range vv {
+				req.Header.Add(k, v)
+			}
+		}
 	}
 
 	if ctx != nil {

--- a/esapi/api.ingest.put_pipeline.go
+++ b/esapi/api.ingest.put_pipeline.go
@@ -5,6 +5,7 @@ package esapi
 import (
 	"context"
 	"io"
+	"net/http"
 	"strings"
 	"time"
 )
@@ -41,6 +42,8 @@ type IngestPutPipelineRequest struct {
 	Human      bool
 	ErrorTrace bool
 	FilterPath []string
+
+	Header http.Header
 
 	ctx context.Context
 }
@@ -102,6 +105,10 @@ func (r IngestPutPipelineRequest) Do(ctx context.Context, transport Transport) (
 
 	if r.Body != nil {
 		req.Header[headerContentType] = headerContentTypeJSON
+	}
+
+	if len(r.Header) > 0 {
+		req.Header = r.Header
 	}
 
 	if ctx != nil {
@@ -175,5 +182,18 @@ func (f IngestPutPipeline) WithErrorTrace() func(*IngestPutPipelineRequest) {
 func (f IngestPutPipeline) WithFilterPath(v ...string) func(*IngestPutPipelineRequest) {
 	return func(r *IngestPutPipelineRequest) {
 		r.FilterPath = v
+	}
+}
+
+// WithHeader adds the headers to the HTTP request
+//
+func (f IngestPutPipeline) WithHeader(h map[string]string) func(*IngestPutPipelineRequest) {
+	return func(r *IngestPutPipelineRequest) {
+		if r.Header == nil {
+			r.Header = make(http.Header)
+		}
+		for k, v := range h {
+			r.Header.Add(k, v)
+		}
 	}
 }

--- a/esapi/api.ingest.put_pipeline.go
+++ b/esapi/api.ingest.put_pipeline.go
@@ -108,9 +108,13 @@ func (r IngestPutPipelineRequest) Do(ctx context.Context, transport Transport) (
 	}
 
 	if len(r.Header) > 0 {
-		for k, vv := range r.Header {
-			for _, v := range vv {
-				req.Header.Add(k, v)
+		if len(req.Header) == 0 {
+			req.Header = r.Header
+		} else {
+			for k, vv := range r.Header {
+				for _, v := range vv {
+					req.Header.Add(k, v)
+				}
 			}
 		}
 	}

--- a/esapi/api.ingest.put_pipeline.go
+++ b/esapi/api.ingest.put_pipeline.go
@@ -108,7 +108,11 @@ func (r IngestPutPipelineRequest) Do(ctx context.Context, transport Transport) (
 	}
 
 	if len(r.Header) > 0 {
-		req.Header = r.Header
+		for k, vv := range r.Header {
+			for _, v := range vv {
+				req.Header.Add(k, v)
+			}
+		}
 	}
 
 	if ctx != nil {

--- a/esapi/api.ingest.simulate.go
+++ b/esapi/api.ingest.simulate.go
@@ -107,7 +107,11 @@ func (r IngestSimulateRequest) Do(ctx context.Context, transport Transport) (*Re
 	}
 
 	if len(r.Header) > 0 {
-		req.Header = r.Header
+		for k, vv := range r.Header {
+			for _, v := range vv {
+				req.Header.Add(k, v)
+			}
+		}
 	}
 
 	if ctx != nil {

--- a/esapi/api.ingest.simulate.go
+++ b/esapi/api.ingest.simulate.go
@@ -5,6 +5,7 @@ package esapi
 import (
 	"context"
 	"io"
+	"net/http"
 	"strconv"
 	"strings"
 )
@@ -40,6 +41,8 @@ type IngestSimulateRequest struct {
 	Human      bool
 	ErrorTrace bool
 	FilterPath []string
+
+	Header http.Header
 
 	ctx context.Context
 }
@@ -101,6 +104,10 @@ func (r IngestSimulateRequest) Do(ctx context.Context, transport Transport) (*Re
 
 	if r.Body != nil {
 		req.Header[headerContentType] = headerContentTypeJSON
+	}
+
+	if len(r.Header) > 0 {
+		req.Header = r.Header
 	}
 
 	if ctx != nil {
@@ -174,5 +181,18 @@ func (f IngestSimulate) WithErrorTrace() func(*IngestSimulateRequest) {
 func (f IngestSimulate) WithFilterPath(v ...string) func(*IngestSimulateRequest) {
 	return func(r *IngestSimulateRequest) {
 		r.FilterPath = v
+	}
+}
+
+// WithHeader adds the headers to the HTTP request
+//
+func (f IngestSimulate) WithHeader(h map[string]string) func(*IngestSimulateRequest) {
+	return func(r *IngestSimulateRequest) {
+		if r.Header == nil {
+			r.Header = make(http.Header)
+		}
+		for k, v := range h {
+			r.Header.Add(k, v)
+		}
 	}
 }

--- a/esapi/api.ingest.simulate.go
+++ b/esapi/api.ingest.simulate.go
@@ -107,9 +107,13 @@ func (r IngestSimulateRequest) Do(ctx context.Context, transport Transport) (*Re
 	}
 
 	if len(r.Header) > 0 {
-		for k, vv := range r.Header {
-			for _, v := range vv {
-				req.Header.Add(k, v)
+		if len(req.Header) == 0 {
+			req.Header = r.Header
+		} else {
+			for k, vv := range r.Header {
+				for _, v := range vv {
+					req.Header.Add(k, v)
+				}
 			}
 		}
 	}

--- a/esapi/api.mget.go
+++ b/esapi/api.mget.go
@@ -143,7 +143,11 @@ func (r MgetRequest) Do(ctx context.Context, transport Transport) (*Response, er
 	}
 
 	if len(r.Header) > 0 {
-		req.Header = r.Header
+		for k, vv := range r.Header {
+			for _, v := range vv {
+				req.Header.Add(k, v)
+			}
+		}
 	}
 
 	if ctx != nil {

--- a/esapi/api.mget.go
+++ b/esapi/api.mget.go
@@ -143,9 +143,13 @@ func (r MgetRequest) Do(ctx context.Context, transport Transport) (*Response, er
 	}
 
 	if len(r.Header) > 0 {
-		for k, vv := range r.Header {
-			for _, v := range vv {
-				req.Header.Add(k, v)
+		if len(req.Header) == 0 {
+			req.Header = r.Header
+		} else {
+			for k, vv := range r.Header {
+				for _, v := range vv {
+					req.Header.Add(k, v)
+				}
 			}
 		}
 	}

--- a/esapi/api.mget.go
+++ b/esapi/api.mget.go
@@ -5,6 +5,7 @@ package esapi
 import (
 	"context"
 	"io"
+	"net/http"
 	"strconv"
 	"strings"
 )
@@ -48,6 +49,8 @@ type MgetRequest struct {
 	Human      bool
 	ErrorTrace bool
 	FilterPath []string
+
+	Header http.Header
 
 	ctx context.Context
 }
@@ -137,6 +140,10 @@ func (r MgetRequest) Do(ctx context.Context, transport Transport) (*Response, er
 
 	if r.Body != nil {
 		req.Header[headerContentType] = headerContentTypeJSON
+	}
+
+	if len(r.Header) > 0 {
+		req.Header = r.Header
 	}
 
 	if ctx != nil {
@@ -274,5 +281,18 @@ func (f Mget) WithErrorTrace() func(*MgetRequest) {
 func (f Mget) WithFilterPath(v ...string) func(*MgetRequest) {
 	return func(r *MgetRequest) {
 		r.FilterPath = v
+	}
+}
+
+// WithHeader adds the headers to the HTTP request
+//
+func (f Mget) WithHeader(h map[string]string) func(*MgetRequest) {
+	return func(r *MgetRequest) {
+		if r.Header == nil {
+			r.Header = make(http.Header)
+		}
+		for k, v := range h {
+			r.Header.Add(k, v)
+		}
 	}
 }

--- a/esapi/api.msearch.go
+++ b/esapi/api.msearch.go
@@ -5,6 +5,7 @@ package esapi
 import (
 	"context"
 	"io"
+	"net/http"
 	"strconv"
 	"strings"
 )
@@ -46,6 +47,8 @@ type MsearchRequest struct {
 	Human      bool
 	ErrorTrace bool
 	FilterPath []string
+
+	Header http.Header
 
 	ctx context.Context
 }
@@ -127,6 +130,10 @@ func (r MsearchRequest) Do(ctx context.Context, transport Transport) (*Response,
 
 	if r.Body != nil {
 		req.Header[headerContentType] = headerContentTypeJSON
+	}
+
+	if len(r.Header) > 0 {
+		req.Header = r.Header
 	}
 
 	if ctx != nil {
@@ -248,5 +255,18 @@ func (f Msearch) WithErrorTrace() func(*MsearchRequest) {
 func (f Msearch) WithFilterPath(v ...string) func(*MsearchRequest) {
 	return func(r *MsearchRequest) {
 		r.FilterPath = v
+	}
+}
+
+// WithHeader adds the headers to the HTTP request
+//
+func (f Msearch) WithHeader(h map[string]string) func(*MsearchRequest) {
+	return func(r *MsearchRequest) {
+		if r.Header == nil {
+			r.Header = make(http.Header)
+		}
+		for k, v := range h {
+			r.Header.Add(k, v)
+		}
 	}
 }

--- a/esapi/api.msearch.go
+++ b/esapi/api.msearch.go
@@ -133,7 +133,11 @@ func (r MsearchRequest) Do(ctx context.Context, transport Transport) (*Response,
 	}
 
 	if len(r.Header) > 0 {
-		req.Header = r.Header
+		for k, vv := range r.Header {
+			for _, v := range vv {
+				req.Header.Add(k, v)
+			}
+		}
 	}
 
 	if ctx != nil {

--- a/esapi/api.msearch.go
+++ b/esapi/api.msearch.go
@@ -133,9 +133,13 @@ func (r MsearchRequest) Do(ctx context.Context, transport Transport) (*Response,
 	}
 
 	if len(r.Header) > 0 {
-		for k, vv := range r.Header {
-			for _, v := range vv {
-				req.Header.Add(k, v)
+		if len(req.Header) == 0 {
+			req.Header = r.Header
+		} else {
+			for k, vv := range r.Header {
+				for _, v := range vv {
+					req.Header.Add(k, v)
+				}
 			}
 		}
 	}

--- a/esapi/api.msearch_template.go
+++ b/esapi/api.msearch_template.go
@@ -125,7 +125,11 @@ func (r MsearchTemplateRequest) Do(ctx context.Context, transport Transport) (*R
 	}
 
 	if len(r.Header) > 0 {
-		req.Header = r.Header
+		for k, vv := range r.Header {
+			for _, v := range vv {
+				req.Header.Add(k, v)
+			}
+		}
 	}
 
 	if ctx != nil {

--- a/esapi/api.msearch_template.go
+++ b/esapi/api.msearch_template.go
@@ -125,9 +125,13 @@ func (r MsearchTemplateRequest) Do(ctx context.Context, transport Transport) (*R
 	}
 
 	if len(r.Header) > 0 {
-		for k, vv := range r.Header {
-			for _, v := range vv {
-				req.Header.Add(k, v)
+		if len(req.Header) == 0 {
+			req.Header = r.Header
+		} else {
+			for k, vv := range r.Header {
+				for _, v := range vv {
+					req.Header.Add(k, v)
+				}
 			}
 		}
 	}

--- a/esapi/api.msearch_template.go
+++ b/esapi/api.msearch_template.go
@@ -5,6 +5,7 @@ package esapi
 import (
 	"context"
 	"io"
+	"net/http"
 	"strconv"
 	"strings"
 )
@@ -44,6 +45,8 @@ type MsearchTemplateRequest struct {
 	Human      bool
 	ErrorTrace bool
 	FilterPath []string
+
+	Header http.Header
 
 	ctx context.Context
 }
@@ -119,6 +122,10 @@ func (r MsearchTemplateRequest) Do(ctx context.Context, transport Transport) (*R
 
 	if r.Body != nil {
 		req.Header[headerContentType] = headerContentTypeJSON
+	}
+
+	if len(r.Header) > 0 {
+		req.Header = r.Header
 	}
 
 	if ctx != nil {
@@ -224,5 +231,18 @@ func (f MsearchTemplate) WithErrorTrace() func(*MsearchTemplateRequest) {
 func (f MsearchTemplate) WithFilterPath(v ...string) func(*MsearchTemplateRequest) {
 	return func(r *MsearchTemplateRequest) {
 		r.FilterPath = v
+	}
+}
+
+// WithHeader adds the headers to the HTTP request
+//
+func (f MsearchTemplate) WithHeader(h map[string]string) func(*MsearchTemplateRequest) {
+	return func(r *MsearchTemplateRequest) {
+		if r.Header == nil {
+			r.Header = make(http.Header)
+		}
+		for k, v := range h {
+			r.Header.Add(k, v)
+		}
 	}
 }

--- a/esapi/api.mtermvectors.go
+++ b/esapi/api.mtermvectors.go
@@ -158,7 +158,11 @@ func (r MtermvectorsRequest) Do(ctx context.Context, transport Transport) (*Resp
 	}
 
 	if len(r.Header) > 0 {
-		req.Header = r.Header
+		for k, vv := range r.Header {
+			for _, v := range vv {
+				req.Header.Add(k, v)
+			}
+		}
 	}
 
 	if ctx != nil {

--- a/esapi/api.mtermvectors.go
+++ b/esapi/api.mtermvectors.go
@@ -158,9 +158,13 @@ func (r MtermvectorsRequest) Do(ctx context.Context, transport Transport) (*Resp
 	}
 
 	if len(r.Header) > 0 {
-		for k, vv := range r.Header {
-			for _, v := range vv {
-				req.Header.Add(k, v)
+		if len(req.Header) == 0 {
+			req.Header = r.Header
+		} else {
+			for k, vv := range r.Header {
+				for _, v := range vv {
+					req.Header.Add(k, v)
+				}
 			}
 		}
 	}

--- a/esapi/api.mtermvectors.go
+++ b/esapi/api.mtermvectors.go
@@ -5,6 +5,7 @@ package esapi
 import (
 	"context"
 	"io"
+	"net/http"
 	"strconv"
 	"strings"
 )
@@ -51,6 +52,8 @@ type MtermvectorsRequest struct {
 	Human      bool
 	ErrorTrace bool
 	FilterPath []string
+
+	Header http.Header
 
 	ctx context.Context
 }
@@ -152,6 +155,10 @@ func (r MtermvectorsRequest) Do(ctx context.Context, transport Transport) (*Resp
 
 	if r.Body != nil {
 		req.Header[headerContentType] = headerContentTypeJSON
+	}
+
+	if len(r.Header) > 0 {
+		req.Header = r.Header
 	}
 
 	if ctx != nil {
@@ -321,5 +328,18 @@ func (f Mtermvectors) WithErrorTrace() func(*MtermvectorsRequest) {
 func (f Mtermvectors) WithFilterPath(v ...string) func(*MtermvectorsRequest) {
 	return func(r *MtermvectorsRequest) {
 		r.FilterPath = v
+	}
+}
+
+// WithHeader adds the headers to the HTTP request
+//
+func (f Mtermvectors) WithHeader(h map[string]string) func(*MtermvectorsRequest) {
+	return func(r *MtermvectorsRequest) {
+		if r.Header == nil {
+			r.Header = make(http.Header)
+		}
+		for k, v := range h {
+			r.Header.Add(k, v)
+		}
 	}
 }

--- a/esapi/api.nodes.hot_threads.go
+++ b/esapi/api.nodes.hot_threads.go
@@ -126,7 +126,11 @@ func (r NodesHotThreadsRequest) Do(ctx context.Context, transport Transport) (*R
 	}
 
 	if len(r.Header) > 0 {
-		req.Header = r.Header
+		for k, vv := range r.Header {
+			for _, v := range vv {
+				req.Header.Add(k, v)
+			}
+		}
 	}
 
 	if ctx != nil {

--- a/esapi/api.nodes.hot_threads.go
+++ b/esapi/api.nodes.hot_threads.go
@@ -4,6 +4,7 @@ package esapi
 
 import (
 	"context"
+	"net/http"
 	"strconv"
 	"strings"
 	"time"
@@ -43,6 +44,8 @@ type NodesHotThreadsRequest struct {
 	Human      bool
 	ErrorTrace bool
 	FilterPath []string
+
+	Header http.Header
 
 	ctx context.Context
 }
@@ -120,6 +123,10 @@ func (r NodesHotThreadsRequest) Do(ctx context.Context, transport Transport) (*R
 			q.Set(k, v)
 		}
 		req.URL.RawQuery = q.Encode()
+	}
+
+	if len(r.Header) > 0 {
+		req.Header = r.Header
 	}
 
 	if ctx != nil {
@@ -233,5 +240,18 @@ func (f NodesHotThreads) WithErrorTrace() func(*NodesHotThreadsRequest) {
 func (f NodesHotThreads) WithFilterPath(v ...string) func(*NodesHotThreadsRequest) {
 	return func(r *NodesHotThreadsRequest) {
 		r.FilterPath = v
+	}
+}
+
+// WithHeader adds the headers to the HTTP request
+//
+func (f NodesHotThreads) WithHeader(h map[string]string) func(*NodesHotThreadsRequest) {
+	return func(r *NodesHotThreadsRequest) {
+		if r.Header == nil {
+			r.Header = make(http.Header)
+		}
+		for k, v := range h {
+			r.Header.Add(k, v)
+		}
 	}
 }

--- a/esapi/api.nodes.hot_threads.go
+++ b/esapi/api.nodes.hot_threads.go
@@ -126,9 +126,13 @@ func (r NodesHotThreadsRequest) Do(ctx context.Context, transport Transport) (*R
 	}
 
 	if len(r.Header) > 0 {
-		for k, vv := range r.Header {
-			for _, v := range vv {
-				req.Header.Add(k, v)
+		if len(req.Header) == 0 {
+			req.Header = r.Header
+		} else {
+			for k, vv := range r.Header {
+				for _, v := range vv {
+					req.Header.Add(k, v)
+				}
 			}
 		}
 	}

--- a/esapi/api.nodes.info.go
+++ b/esapi/api.nodes.info.go
@@ -107,7 +107,11 @@ func (r NodesInfoRequest) Do(ctx context.Context, transport Transport) (*Respons
 	}
 
 	if len(r.Header) > 0 {
-		req.Header = r.Header
+		for k, vv := range r.Header {
+			for _, v := range vv {
+				req.Header.Add(k, v)
+			}
+		}
 	}
 
 	if ctx != nil {

--- a/esapi/api.nodes.info.go
+++ b/esapi/api.nodes.info.go
@@ -107,9 +107,13 @@ func (r NodesInfoRequest) Do(ctx context.Context, transport Transport) (*Respons
 	}
 
 	if len(r.Header) > 0 {
-		for k, vv := range r.Header {
-			for _, v := range vv {
-				req.Header.Add(k, v)
+		if len(req.Header) == 0 {
+			req.Header = r.Header
+		} else {
+			for k, vv := range r.Header {
+				for _, v := range vv {
+					req.Header.Add(k, v)
+				}
 			}
 		}
 	}

--- a/esapi/api.nodes.info.go
+++ b/esapi/api.nodes.info.go
@@ -4,6 +4,7 @@ package esapi
 
 import (
 	"context"
+	"net/http"
 	"strconv"
 	"strings"
 	"time"
@@ -40,6 +41,8 @@ type NodesInfoRequest struct {
 	Human      bool
 	ErrorTrace bool
 	FilterPath []string
+
+	Header http.Header
 
 	ctx context.Context
 }
@@ -101,6 +104,10 @@ func (r NodesInfoRequest) Do(ctx context.Context, transport Transport) (*Respons
 			q.Set(k, v)
 		}
 		req.URL.RawQuery = q.Encode()
+	}
+
+	if len(r.Header) > 0 {
+		req.Header = r.Header
 	}
 
 	if ctx != nil {
@@ -190,5 +197,18 @@ func (f NodesInfo) WithErrorTrace() func(*NodesInfoRequest) {
 func (f NodesInfo) WithFilterPath(v ...string) func(*NodesInfoRequest) {
 	return func(r *NodesInfoRequest) {
 		r.FilterPath = v
+	}
+}
+
+// WithHeader adds the headers to the HTTP request
+//
+func (f NodesInfo) WithHeader(h map[string]string) func(*NodesInfoRequest) {
+	return func(r *NodesInfoRequest) {
+		if r.Header == nil {
+			r.Header = make(http.Header)
+		}
+		for k, v := range h {
+			r.Header.Add(k, v)
+		}
 	}
 }

--- a/esapi/api.nodes.reload_secure_settings.go
+++ b/esapi/api.nodes.reload_secure_settings.go
@@ -98,9 +98,13 @@ func (r NodesReloadSecureSettingsRequest) Do(ctx context.Context, transport Tran
 	}
 
 	if len(r.Header) > 0 {
-		for k, vv := range r.Header {
-			for _, v := range vv {
-				req.Header.Add(k, v)
+		if len(req.Header) == 0 {
+			req.Header = r.Header
+		} else {
+			for k, vv := range r.Header {
+				for _, v := range vv {
+					req.Header.Add(k, v)
+				}
 			}
 		}
 	}

--- a/esapi/api.nodes.reload_secure_settings.go
+++ b/esapi/api.nodes.reload_secure_settings.go
@@ -4,6 +4,7 @@ package esapi
 
 import (
 	"context"
+	"net/http"
 	"strings"
 	"time"
 )
@@ -37,6 +38,8 @@ type NodesReloadSecureSettingsRequest struct {
 	Human      bool
 	ErrorTrace bool
 	FilterPath []string
+
+	Header http.Header
 
 	ctx context.Context
 }
@@ -92,6 +95,10 @@ func (r NodesReloadSecureSettingsRequest) Do(ctx context.Context, transport Tran
 			q.Set(k, v)
 		}
 		req.URL.RawQuery = q.Encode()
+	}
+
+	if len(r.Header) > 0 {
+		req.Header = r.Header
 	}
 
 	if ctx != nil {
@@ -165,5 +172,18 @@ func (f NodesReloadSecureSettings) WithErrorTrace() func(*NodesReloadSecureSetti
 func (f NodesReloadSecureSettings) WithFilterPath(v ...string) func(*NodesReloadSecureSettingsRequest) {
 	return func(r *NodesReloadSecureSettingsRequest) {
 		r.FilterPath = v
+	}
+}
+
+// WithHeader adds the headers to the HTTP request
+//
+func (f NodesReloadSecureSettings) WithHeader(h map[string]string) func(*NodesReloadSecureSettingsRequest) {
+	return func(r *NodesReloadSecureSettingsRequest) {
+		if r.Header == nil {
+			r.Header = make(http.Header)
+		}
+		for k, v := range h {
+			r.Header.Add(k, v)
+		}
 	}
 }

--- a/esapi/api.nodes.reload_secure_settings.go
+++ b/esapi/api.nodes.reload_secure_settings.go
@@ -98,7 +98,11 @@ func (r NodesReloadSecureSettingsRequest) Do(ctx context.Context, transport Tran
 	}
 
 	if len(r.Header) > 0 {
-		req.Header = r.Header
+		for k, vv := range r.Header {
+			for _, v := range vv {
+				req.Header.Add(k, v)
+			}
+		}
 	}
 
 	if ctx != nil {

--- a/esapi/api.nodes.stats.go
+++ b/esapi/api.nodes.stats.go
@@ -4,6 +4,7 @@ package esapi
 
 import (
 	"context"
+	"net/http"
 	"strconv"
 	"strings"
 	"time"
@@ -47,6 +48,8 @@ type NodesStatsRequest struct {
 	Human      bool
 	ErrorTrace bool
 	FilterPath []string
+
+	Header http.Header
 
 	ctx context.Context
 }
@@ -138,6 +141,10 @@ func (r NodesStatsRequest) Do(ctx context.Context, transport Transport) (*Respon
 			q.Set(k, v)
 		}
 		req.URL.RawQuery = q.Encode()
+	}
+
+	if len(r.Header) > 0 {
+		req.Header = r.Header
 	}
 
 	if ctx != nil {
@@ -283,5 +290,18 @@ func (f NodesStats) WithErrorTrace() func(*NodesStatsRequest) {
 func (f NodesStats) WithFilterPath(v ...string) func(*NodesStatsRequest) {
 	return func(r *NodesStatsRequest) {
 		r.FilterPath = v
+	}
+}
+
+// WithHeader adds the headers to the HTTP request
+//
+func (f NodesStats) WithHeader(h map[string]string) func(*NodesStatsRequest) {
+	return func(r *NodesStatsRequest) {
+		if r.Header == nil {
+			r.Header = make(http.Header)
+		}
+		for k, v := range h {
+			r.Header.Add(k, v)
+		}
 	}
 }

--- a/esapi/api.nodes.stats.go
+++ b/esapi/api.nodes.stats.go
@@ -144,9 +144,13 @@ func (r NodesStatsRequest) Do(ctx context.Context, transport Transport) (*Respon
 	}
 
 	if len(r.Header) > 0 {
-		for k, vv := range r.Header {
-			for _, v := range vv {
-				req.Header.Add(k, v)
+		if len(req.Header) == 0 {
+			req.Header = r.Header
+		} else {
+			for k, vv := range r.Header {
+				for _, v := range vv {
+					req.Header.Add(k, v)
+				}
 			}
 		}
 	}

--- a/esapi/api.nodes.stats.go
+++ b/esapi/api.nodes.stats.go
@@ -144,7 +144,11 @@ func (r NodesStatsRequest) Do(ctx context.Context, transport Transport) (*Respon
 	}
 
 	if len(r.Header) > 0 {
-		req.Header = r.Header
+		for k, vv := range r.Header {
+			for _, v := range vv {
+				req.Header.Add(k, v)
+			}
+		}
 	}
 
 	if ctx != nil {

--- a/esapi/api.nodes.usage.go
+++ b/esapi/api.nodes.usage.go
@@ -103,9 +103,13 @@ func (r NodesUsageRequest) Do(ctx context.Context, transport Transport) (*Respon
 	}
 
 	if len(r.Header) > 0 {
-		for k, vv := range r.Header {
-			for _, v := range vv {
-				req.Header.Add(k, v)
+		if len(req.Header) == 0 {
+			req.Header = r.Header
+		} else {
+			for k, vv := range r.Header {
+				for _, v := range vv {
+					req.Header.Add(k, v)
+				}
 			}
 		}
 	}

--- a/esapi/api.nodes.usage.go
+++ b/esapi/api.nodes.usage.go
@@ -103,7 +103,11 @@ func (r NodesUsageRequest) Do(ctx context.Context, transport Transport) (*Respon
 	}
 
 	if len(r.Header) > 0 {
-		req.Header = r.Header
+		for k, vv := range r.Header {
+			for _, v := range vv {
+				req.Header.Add(k, v)
+			}
+		}
 	}
 
 	if ctx != nil {

--- a/esapi/api.nodes.usage.go
+++ b/esapi/api.nodes.usage.go
@@ -4,6 +4,7 @@ package esapi
 
 import (
 	"context"
+	"net/http"
 	"strings"
 	"time"
 )
@@ -38,6 +39,8 @@ type NodesUsageRequest struct {
 	Human      bool
 	ErrorTrace bool
 	FilterPath []string
+
+	Header http.Header
 
 	ctx context.Context
 }
@@ -97,6 +100,10 @@ func (r NodesUsageRequest) Do(ctx context.Context, transport Transport) (*Respon
 			q.Set(k, v)
 		}
 		req.URL.RawQuery = q.Encode()
+	}
+
+	if len(r.Header) > 0 {
+		req.Header = r.Header
 	}
 
 	if ctx != nil {
@@ -178,5 +185,18 @@ func (f NodesUsage) WithErrorTrace() func(*NodesUsageRequest) {
 func (f NodesUsage) WithFilterPath(v ...string) func(*NodesUsageRequest) {
 	return func(r *NodesUsageRequest) {
 		r.FilterPath = v
+	}
+}
+
+// WithHeader adds the headers to the HTTP request
+//
+func (f NodesUsage) WithHeader(h map[string]string) func(*NodesUsageRequest) {
+	return func(r *NodesUsageRequest) {
+		if r.Header == nil {
+			r.Header = make(http.Header)
+		}
+		for k, v := range h {
+			r.Header.Add(k, v)
+		}
 	}
 }

--- a/esapi/api.ping.go
+++ b/esapi/api.ping.go
@@ -82,9 +82,13 @@ func (r PingRequest) Do(ctx context.Context, transport Transport) (*Response, er
 	}
 
 	if len(r.Header) > 0 {
-		for k, vv := range r.Header {
-			for _, v := range vv {
-				req.Header.Add(k, v)
+		if len(req.Header) == 0 {
+			req.Header = r.Header
+		} else {
+			for k, vv := range r.Header {
+				for _, v := range vv {
+					req.Header.Add(k, v)
+				}
 			}
 		}
 	}

--- a/esapi/api.ping.go
+++ b/esapi/api.ping.go
@@ -4,6 +4,7 @@ package esapi
 
 import (
 	"context"
+	"net/http"
 	"strings"
 )
 
@@ -32,6 +33,8 @@ type PingRequest struct {
 	Human      bool
 	ErrorTrace bool
 	FilterPath []string
+
+	Header http.Header
 
 	ctx context.Context
 }
@@ -76,6 +79,10 @@ func (r PingRequest) Do(ctx context.Context, transport Transport) (*Response, er
 			q.Set(k, v)
 		}
 		req.URL.RawQuery = q.Encode()
+	}
+
+	if len(r.Header) > 0 {
+		req.Header = r.Header
 	}
 
 	if ctx != nil {
@@ -133,5 +140,18 @@ func (f Ping) WithErrorTrace() func(*PingRequest) {
 func (f Ping) WithFilterPath(v ...string) func(*PingRequest) {
 	return func(r *PingRequest) {
 		r.FilterPath = v
+	}
+}
+
+// WithHeader adds the headers to the HTTP request
+//
+func (f Ping) WithHeader(h map[string]string) func(*PingRequest) {
+	return func(r *PingRequest) {
+		if r.Header == nil {
+			r.Header = make(http.Header)
+		}
+		for k, v := range h {
+			r.Header.Add(k, v)
+		}
 	}
 }

--- a/esapi/api.ping.go
+++ b/esapi/api.ping.go
@@ -82,7 +82,11 @@ func (r PingRequest) Do(ctx context.Context, transport Transport) (*Response, er
 	}
 
 	if len(r.Header) > 0 {
-		req.Header = r.Header
+		for k, vv := range r.Header {
+			for _, v := range vv {
+				req.Header.Add(k, v)
+			}
+		}
 	}
 
 	if ctx != nil {

--- a/esapi/api.put_script.go
+++ b/esapi/api.put_script.go
@@ -116,7 +116,11 @@ func (r PutScriptRequest) Do(ctx context.Context, transport Transport) (*Respons
 	}
 
 	if len(r.Header) > 0 {
-		req.Header = r.Header
+		for k, vv := range r.Header {
+			for _, v := range vv {
+				req.Header.Add(k, v)
+			}
+		}
 	}
 
 	if ctx != nil {

--- a/esapi/api.put_script.go
+++ b/esapi/api.put_script.go
@@ -116,9 +116,13 @@ func (r PutScriptRequest) Do(ctx context.Context, transport Transport) (*Respons
 	}
 
 	if len(r.Header) > 0 {
-		for k, vv := range r.Header {
-			for _, v := range vv {
-				req.Header.Add(k, v)
+		if len(req.Header) == 0 {
+			req.Header = r.Header
+		} else {
+			for k, vv := range r.Header {
+				for _, v := range vv {
+					req.Header.Add(k, v)
+				}
 			}
 		}
 	}

--- a/esapi/api.put_script.go
+++ b/esapi/api.put_script.go
@@ -5,6 +5,7 @@ package esapi
 import (
 	"context"
 	"io"
+	"net/http"
 	"strings"
 	"time"
 )
@@ -43,6 +44,8 @@ type PutScriptRequest struct {
 	Human      bool
 	ErrorTrace bool
 	FilterPath []string
+
+	Header http.Header
 
 	ctx context.Context
 }
@@ -110,6 +113,10 @@ func (r PutScriptRequest) Do(ctx context.Context, transport Transport) (*Respons
 
 	if r.Body != nil {
 		req.Header[headerContentType] = headerContentTypeJSON
+	}
+
+	if len(r.Header) > 0 {
+		req.Header = r.Header
 	}
 
 	if ctx != nil {
@@ -191,5 +198,18 @@ func (f PutScript) WithErrorTrace() func(*PutScriptRequest) {
 func (f PutScript) WithFilterPath(v ...string) func(*PutScriptRequest) {
 	return func(r *PutScriptRequest) {
 		r.FilterPath = v
+	}
+}
+
+// WithHeader adds the headers to the HTTP request
+//
+func (f PutScript) WithHeader(h map[string]string) func(*PutScriptRequest) {
+	return func(r *PutScriptRequest) {
+		if r.Header == nil {
+			r.Header = make(http.Header)
+		}
+		for k, v := range h {
+			r.Header.Add(k, v)
+		}
 	}
 }

--- a/esapi/api.rank_eval.go
+++ b/esapi/api.rank_eval.go
@@ -113,9 +113,13 @@ func (r RankEvalRequest) Do(ctx context.Context, transport Transport) (*Response
 	}
 
 	if len(r.Header) > 0 {
-		for k, vv := range r.Header {
-			for _, v := range vv {
-				req.Header.Add(k, v)
+		if len(req.Header) == 0 {
+			req.Header = r.Header
+		} else {
+			for k, vv := range r.Header {
+				for _, v := range vv {
+					req.Header.Add(k, v)
+				}
 			}
 		}
 	}

--- a/esapi/api.rank_eval.go
+++ b/esapi/api.rank_eval.go
@@ -113,7 +113,11 @@ func (r RankEvalRequest) Do(ctx context.Context, transport Transport) (*Response
 	}
 
 	if len(r.Header) > 0 {
-		req.Header = r.Header
+		for k, vv := range r.Header {
+			for _, v := range vv {
+				req.Header.Add(k, v)
+			}
+		}
 	}
 
 	if ctx != nil {

--- a/esapi/api.rank_eval.go
+++ b/esapi/api.rank_eval.go
@@ -5,6 +5,7 @@ package esapi
 import (
 	"context"
 	"io"
+	"net/http"
 	"strconv"
 	"strings"
 )
@@ -42,6 +43,8 @@ type RankEvalRequest struct {
 	Human      bool
 	ErrorTrace bool
 	FilterPath []string
+
+	Header http.Header
 
 	ctx context.Context
 }
@@ -107,6 +110,10 @@ func (r RankEvalRequest) Do(ctx context.Context, transport Transport) (*Response
 
 	if r.Body != nil {
 		req.Header[headerContentType] = headerContentTypeJSON
+	}
+
+	if len(r.Header) > 0 {
+		req.Header = r.Header
 	}
 
 	if ctx != nil {
@@ -196,5 +203,18 @@ func (f RankEval) WithErrorTrace() func(*RankEvalRequest) {
 func (f RankEval) WithFilterPath(v ...string) func(*RankEvalRequest) {
 	return func(r *RankEvalRequest) {
 		r.FilterPath = v
+	}
+}
+
+// WithHeader adds the headers to the HTTP request
+//
+func (f RankEval) WithHeader(h map[string]string) func(*RankEvalRequest) {
+	return func(r *RankEvalRequest) {
+		if r.Header == nil {
+			r.Header = make(http.Header)
+		}
+		for k, v := range h {
+			r.Header.Add(k, v)
+		}
 	}
 }

--- a/esapi/api.reindex.go
+++ b/esapi/api.reindex.go
@@ -5,6 +5,7 @@ package esapi
 import (
 	"context"
 	"io"
+	"net/http"
 	"strconv"
 	"strings"
 	"time"
@@ -48,6 +49,8 @@ type ReindexRequest struct {
 	Human      bool
 	ErrorTrace bool
 	FilterPath []string
+
+	Header http.Header
 
 	ctx context.Context
 }
@@ -128,6 +131,10 @@ func (r ReindexRequest) Do(ctx context.Context, transport Transport) (*Response,
 
 	if r.Body != nil {
 		req.Header[headerContentType] = headerContentTypeJSON
+	}
+
+	if len(r.Header) > 0 {
+		req.Header = r.Header
 	}
 
 	if ctx != nil {
@@ -249,5 +256,18 @@ func (f Reindex) WithErrorTrace() func(*ReindexRequest) {
 func (f Reindex) WithFilterPath(v ...string) func(*ReindexRequest) {
 	return func(r *ReindexRequest) {
 		r.FilterPath = v
+	}
+}
+
+// WithHeader adds the headers to the HTTP request
+//
+func (f Reindex) WithHeader(h map[string]string) func(*ReindexRequest) {
+	return func(r *ReindexRequest) {
+		if r.Header == nil {
+			r.Header = make(http.Header)
+		}
+		for k, v := range h {
+			r.Header.Add(k, v)
+		}
 	}
 }

--- a/esapi/api.reindex.go
+++ b/esapi/api.reindex.go
@@ -134,9 +134,13 @@ func (r ReindexRequest) Do(ctx context.Context, transport Transport) (*Response,
 	}
 
 	if len(r.Header) > 0 {
-		for k, vv := range r.Header {
-			for _, v := range vv {
-				req.Header.Add(k, v)
+		if len(req.Header) == 0 {
+			req.Header = r.Header
+		} else {
+			for k, vv := range r.Header {
+				for _, v := range vv {
+					req.Header.Add(k, v)
+				}
 			}
 		}
 	}

--- a/esapi/api.reindex.go
+++ b/esapi/api.reindex.go
@@ -134,7 +134,11 @@ func (r ReindexRequest) Do(ctx context.Context, transport Transport) (*Response,
 	}
 
 	if len(r.Header) > 0 {
-		req.Header = r.Header
+		for k, vv := range r.Header {
+			for _, v := range vv {
+				req.Header.Add(k, v)
+			}
+		}
 	}
 
 	if ctx != nil {

--- a/esapi/api.reindex_rethrottle.go
+++ b/esapi/api.reindex_rethrottle.go
@@ -96,7 +96,11 @@ func (r ReindexRethrottleRequest) Do(ctx context.Context, transport Transport) (
 	}
 
 	if len(r.Header) > 0 {
-		req.Header = r.Header
+		for k, vv := range r.Header {
+			for _, v := range vv {
+				req.Header.Add(k, v)
+			}
+		}
 	}
 
 	if ctx != nil {

--- a/esapi/api.reindex_rethrottle.go
+++ b/esapi/api.reindex_rethrottle.go
@@ -96,9 +96,13 @@ func (r ReindexRethrottleRequest) Do(ctx context.Context, transport Transport) (
 	}
 
 	if len(r.Header) > 0 {
-		for k, vv := range r.Header {
-			for _, v := range vv {
-				req.Header.Add(k, v)
+		if len(req.Header) == 0 {
+			req.Header = r.Header
+		} else {
+			for k, vv := range r.Header {
+				for _, v := range vv {
+					req.Header.Add(k, v)
+				}
 			}
 		}
 	}

--- a/esapi/api.reindex_rethrottle.go
+++ b/esapi/api.reindex_rethrottle.go
@@ -4,6 +4,7 @@ package esapi
 
 import (
 	"context"
+	"net/http"
 	"strconv"
 	"strings"
 )
@@ -37,6 +38,8 @@ type ReindexRethrottleRequest struct {
 	Human      bool
 	ErrorTrace bool
 	FilterPath []string
+
+	Header http.Header
 
 	ctx context.Context
 }
@@ -90,6 +93,10 @@ func (r ReindexRethrottleRequest) Do(ctx context.Context, transport Transport) (
 			q.Set(k, v)
 		}
 		req.URL.RawQuery = q.Encode()
+	}
+
+	if len(r.Header) > 0 {
+		req.Header = r.Header
 	}
 
 	if ctx != nil {
@@ -155,5 +162,18 @@ func (f ReindexRethrottle) WithErrorTrace() func(*ReindexRethrottleRequest) {
 func (f ReindexRethrottle) WithFilterPath(v ...string) func(*ReindexRethrottleRequest) {
 	return func(r *ReindexRethrottleRequest) {
 		r.FilterPath = v
+	}
+}
+
+// WithHeader adds the headers to the HTTP request
+//
+func (f ReindexRethrottle) WithHeader(h map[string]string) func(*ReindexRethrottleRequest) {
+	return func(r *ReindexRethrottleRequest) {
+		if r.Header == nil {
+			r.Header = make(http.Header)
+		}
+		for k, v := range h {
+			r.Header.Add(k, v)
+		}
 	}
 }

--- a/esapi/api.render_search_template.go
+++ b/esapi/api.render_search_template.go
@@ -5,6 +5,7 @@ package esapi
 import (
 	"context"
 	"io"
+	"net/http"
 	"strings"
 )
 
@@ -37,6 +38,8 @@ type RenderSearchTemplateRequest struct {
 	Human      bool
 	ErrorTrace bool
 	FilterPath []string
+
+	Header http.Header
 
 	ctx context.Context
 }
@@ -92,6 +95,10 @@ func (r RenderSearchTemplateRequest) Do(ctx context.Context, transport Transport
 
 	if r.Body != nil {
 		req.Header[headerContentType] = headerContentTypeJSON
+	}
+
+	if len(r.Header) > 0 {
+		req.Header = r.Header
 	}
 
 	if ctx != nil {
@@ -165,5 +172,18 @@ func (f RenderSearchTemplate) WithErrorTrace() func(*RenderSearchTemplateRequest
 func (f RenderSearchTemplate) WithFilterPath(v ...string) func(*RenderSearchTemplateRequest) {
 	return func(r *RenderSearchTemplateRequest) {
 		r.FilterPath = v
+	}
+}
+
+// WithHeader adds the headers to the HTTP request
+//
+func (f RenderSearchTemplate) WithHeader(h map[string]string) func(*RenderSearchTemplateRequest) {
+	return func(r *RenderSearchTemplateRequest) {
+		if r.Header == nil {
+			r.Header = make(http.Header)
+		}
+		for k, v := range h {
+			r.Header.Add(k, v)
+		}
 	}
 }

--- a/esapi/api.render_search_template.go
+++ b/esapi/api.render_search_template.go
@@ -98,9 +98,13 @@ func (r RenderSearchTemplateRequest) Do(ctx context.Context, transport Transport
 	}
 
 	if len(r.Header) > 0 {
-		for k, vv := range r.Header {
-			for _, v := range vv {
-				req.Header.Add(k, v)
+		if len(req.Header) == 0 {
+			req.Header = r.Header
+		} else {
+			for k, vv := range r.Header {
+				for _, v := range vv {
+					req.Header.Add(k, v)
+				}
 			}
 		}
 	}

--- a/esapi/api.render_search_template.go
+++ b/esapi/api.render_search_template.go
@@ -98,7 +98,11 @@ func (r RenderSearchTemplateRequest) Do(ctx context.Context, transport Transport
 	}
 
 	if len(r.Header) > 0 {
-		req.Header = r.Header
+		for k, vv := range r.Header {
+			for _, v := range vv {
+				req.Header.Add(k, v)
+			}
+		}
 	}
 
 	if ctx != nil {

--- a/esapi/api.scripts_painless_context.go
+++ b/esapi/api.scripts_painless_context.go
@@ -4,6 +4,7 @@ package esapi
 
 import (
 	"context"
+	"net/http"
 	"strings"
 )
 
@@ -32,6 +33,8 @@ type ScriptsPainlessContextRequest struct {
 	Human      bool
 	ErrorTrace bool
 	FilterPath []string
+
+	Header http.Header
 
 	ctx context.Context
 }
@@ -80,6 +83,10 @@ func (r ScriptsPainlessContextRequest) Do(ctx context.Context, transport Transpo
 			q.Set(k, v)
 		}
 		req.URL.RawQuery = q.Encode()
+	}
+
+	if len(r.Header) > 0 {
+		req.Header = r.Header
 	}
 
 	if ctx != nil {
@@ -145,5 +152,18 @@ func (f ScriptsPainlessContext) WithErrorTrace() func(*ScriptsPainlessContextReq
 func (f ScriptsPainlessContext) WithFilterPath(v ...string) func(*ScriptsPainlessContextRequest) {
 	return func(r *ScriptsPainlessContextRequest) {
 		r.FilterPath = v
+	}
+}
+
+// WithHeader adds the headers to the HTTP request
+//
+func (f ScriptsPainlessContext) WithHeader(h map[string]string) func(*ScriptsPainlessContextRequest) {
+	return func(r *ScriptsPainlessContextRequest) {
+		if r.Header == nil {
+			r.Header = make(http.Header)
+		}
+		for k, v := range h {
+			r.Header.Add(k, v)
+		}
 	}
 }

--- a/esapi/api.scripts_painless_context.go
+++ b/esapi/api.scripts_painless_context.go
@@ -86,7 +86,11 @@ func (r ScriptsPainlessContextRequest) Do(ctx context.Context, transport Transpo
 	}
 
 	if len(r.Header) > 0 {
-		req.Header = r.Header
+		for k, vv := range r.Header {
+			for _, v := range vv {
+				req.Header.Add(k, v)
+			}
+		}
 	}
 
 	if ctx != nil {

--- a/esapi/api.scripts_painless_execute.go
+++ b/esapi/api.scripts_painless_execute.go
@@ -89,7 +89,11 @@ func (r ScriptsPainlessExecuteRequest) Do(ctx context.Context, transport Transpo
 	}
 
 	if len(r.Header) > 0 {
-		req.Header = r.Header
+		for k, vv := range r.Header {
+			for _, v := range vv {
+				req.Header.Add(k, v)
+			}
+		}
 	}
 
 	if ctx != nil {

--- a/esapi/api.scripts_painless_execute.go
+++ b/esapi/api.scripts_painless_execute.go
@@ -5,6 +5,7 @@ package esapi
 import (
 	"context"
 	"io"
+	"net/http"
 	"strings"
 )
 
@@ -35,6 +36,8 @@ type ScriptsPainlessExecuteRequest struct {
 	Human      bool
 	ErrorTrace bool
 	FilterPath []string
+
+	Header http.Header
 
 	ctx context.Context
 }
@@ -83,6 +86,10 @@ func (r ScriptsPainlessExecuteRequest) Do(ctx context.Context, transport Transpo
 
 	if r.Body != nil {
 		req.Header[headerContentType] = headerContentTypeJSON
+	}
+
+	if len(r.Header) > 0 {
+		req.Header = r.Header
 	}
 
 	if ctx != nil {
@@ -148,5 +155,18 @@ func (f ScriptsPainlessExecute) WithErrorTrace() func(*ScriptsPainlessExecuteReq
 func (f ScriptsPainlessExecute) WithFilterPath(v ...string) func(*ScriptsPainlessExecuteRequest) {
 	return func(r *ScriptsPainlessExecuteRequest) {
 		r.FilterPath = v
+	}
+}
+
+// WithHeader adds the headers to the HTTP request
+//
+func (f ScriptsPainlessExecute) WithHeader(h map[string]string) func(*ScriptsPainlessExecuteRequest) {
+	return func(r *ScriptsPainlessExecuteRequest) {
+		if r.Header == nil {
+			r.Header = make(http.Header)
+		}
+		for k, v := range h {
+			r.Header.Add(k, v)
+		}
 	}
 }

--- a/esapi/api.scripts_painless_execute.go
+++ b/esapi/api.scripts_painless_execute.go
@@ -89,9 +89,13 @@ func (r ScriptsPainlessExecuteRequest) Do(ctx context.Context, transport Transpo
 	}
 
 	if len(r.Header) > 0 {
-		for k, vv := range r.Header {
-			for _, v := range vv {
-				req.Header.Add(k, v)
+		if len(req.Header) == 0 {
+			req.Header = r.Header
+		} else {
+			for k, vv := range r.Header {
+				for _, v := range vv {
+					req.Header.Add(k, v)
+				}
 			}
 		}
 	}

--- a/esapi/api.scroll.go
+++ b/esapi/api.scroll.go
@@ -5,6 +5,7 @@ package esapi
 import (
 	"context"
 	"io"
+	"net/http"
 	"strconv"
 	"strings"
 	"time"
@@ -42,6 +43,8 @@ type ScrollRequest struct {
 	Human      bool
 	ErrorTrace bool
 	FilterPath []string
+
+	Header http.Header
 
 	ctx context.Context
 }
@@ -102,6 +105,10 @@ func (r ScrollRequest) Do(ctx context.Context, transport Transport) (*Response, 
 
 	if r.Body != nil {
 		req.Header[headerContentType] = headerContentTypeJSON
+	}
+
+	if len(r.Header) > 0 {
+		req.Header = r.Header
 	}
 
 	if ctx != nil {
@@ -191,5 +198,18 @@ func (f Scroll) WithErrorTrace() func(*ScrollRequest) {
 func (f Scroll) WithFilterPath(v ...string) func(*ScrollRequest) {
 	return func(r *ScrollRequest) {
 		r.FilterPath = v
+	}
+}
+
+// WithHeader adds the headers to the HTTP request
+//
+func (f Scroll) WithHeader(h map[string]string) func(*ScrollRequest) {
+	return func(r *ScrollRequest) {
+		if r.Header == nil {
+			r.Header = make(http.Header)
+		}
+		for k, v := range h {
+			r.Header.Add(k, v)
+		}
 	}
 }

--- a/esapi/api.scroll.go
+++ b/esapi/api.scroll.go
@@ -108,7 +108,11 @@ func (r ScrollRequest) Do(ctx context.Context, transport Transport) (*Response, 
 	}
 
 	if len(r.Header) > 0 {
-		req.Header = r.Header
+		for k, vv := range r.Header {
+			for _, v := range vv {
+				req.Header.Add(k, v)
+			}
+		}
 	}
 
 	if ctx != nil {

--- a/esapi/api.scroll.go
+++ b/esapi/api.scroll.go
@@ -108,9 +108,13 @@ func (r ScrollRequest) Do(ctx context.Context, transport Transport) (*Response, 
 	}
 
 	if len(r.Header) > 0 {
-		for k, vv := range r.Header {
-			for _, v := range vv {
-				req.Header.Add(k, v)
+		if len(req.Header) == 0 {
+			req.Header = r.Header
+		} else {
+			for k, vv := range r.Header {
+				for _, v := range vv {
+					req.Header.Add(k, v)
+				}
 			}
 		}
 	}

--- a/esapi/api.search.go
+++ b/esapi/api.search.go
@@ -310,9 +310,13 @@ func (r SearchRequest) Do(ctx context.Context, transport Transport) (*Response, 
 	}
 
 	if len(r.Header) > 0 {
-		for k, vv := range r.Header {
-			for _, v := range vv {
-				req.Header.Add(k, v)
+		if len(req.Header) == 0 {
+			req.Header = r.Header
+		} else {
+			for k, vv := range r.Header {
+				for _, v := range vv {
+					req.Header.Add(k, v)
+				}
 			}
 		}
 	}

--- a/esapi/api.search.go
+++ b/esapi/api.search.go
@@ -310,7 +310,11 @@ func (r SearchRequest) Do(ctx context.Context, transport Transport) (*Response, 
 	}
 
 	if len(r.Header) > 0 {
-		req.Header = r.Header
+		for k, vv := range r.Header {
+			for _, v := range vv {
+				req.Header.Add(k, v)
+			}
+		}
 	}
 
 	if ctx != nil {

--- a/esapi/api.search.go
+++ b/esapi/api.search.go
@@ -6,6 +6,7 @@ import (
 	"context"
 	"fmt"
 	"io"
+	"net/http"
 	"strconv"
 	"strings"
 	"time"
@@ -83,6 +84,8 @@ type SearchRequest struct {
 	Human      bool
 	ErrorTrace bool
 	FilterPath []string
+
+	Header http.Header
 
 	ctx context.Context
 }
@@ -304,6 +307,10 @@ func (r SearchRequest) Do(ctx context.Context, transport Transport) (*Response, 
 
 	if r.Body != nil {
 		req.Header[headerContentType] = headerContentTypeJSON
+	}
+
+	if len(r.Header) > 0 {
+		req.Header = r.Header
 	}
 
 	if ctx != nil {
@@ -713,5 +720,18 @@ func (f Search) WithErrorTrace() func(*SearchRequest) {
 func (f Search) WithFilterPath(v ...string) func(*SearchRequest) {
 	return func(r *SearchRequest) {
 		r.FilterPath = v
+	}
+}
+
+// WithHeader adds the headers to the HTTP request
+//
+func (f Search) WithHeader(h map[string]string) func(*SearchRequest) {
+	return func(r *SearchRequest) {
+		if r.Header == nil {
+			r.Header = make(http.Header)
+		}
+		for k, v := range h {
+			r.Header.Add(k, v)
+		}
 	}
 }

--- a/esapi/api.search_shards.go
+++ b/esapi/api.search_shards.go
@@ -121,9 +121,13 @@ func (r SearchShardsRequest) Do(ctx context.Context, transport Transport) (*Resp
 	}
 
 	if len(r.Header) > 0 {
-		for k, vv := range r.Header {
-			for _, v := range vv {
-				req.Header.Add(k, v)
+		if len(req.Header) == 0 {
+			req.Header = r.Header
+		} else {
+			for k, vv := range r.Header {
+				for _, v := range vv {
+					req.Header.Add(k, v)
+				}
 			}
 		}
 	}

--- a/esapi/api.search_shards.go
+++ b/esapi/api.search_shards.go
@@ -121,7 +121,11 @@ func (r SearchShardsRequest) Do(ctx context.Context, transport Transport) (*Resp
 	}
 
 	if len(r.Header) > 0 {
-		req.Header = r.Header
+		for k, vv := range r.Header {
+			for _, v := range vv {
+				req.Header.Add(k, v)
+			}
+		}
 	}
 
 	if ctx != nil {

--- a/esapi/api.search_shards.go
+++ b/esapi/api.search_shards.go
@@ -4,6 +4,7 @@ package esapi
 
 import (
 	"context"
+	"net/http"
 	"strconv"
 	"strings"
 )
@@ -42,6 +43,8 @@ type SearchShardsRequest struct {
 	Human      bool
 	ErrorTrace bool
 	FilterPath []string
+
+	Header http.Header
 
 	ctx context.Context
 }
@@ -115,6 +118,10 @@ func (r SearchShardsRequest) Do(ctx context.Context, transport Transport) (*Resp
 			q.Set(k, v)
 		}
 		req.URL.RawQuery = q.Encode()
+	}
+
+	if len(r.Header) > 0 {
+		req.Header = r.Header
 	}
 
 	if ctx != nil {
@@ -228,5 +235,18 @@ func (f SearchShards) WithErrorTrace() func(*SearchShardsRequest) {
 func (f SearchShards) WithFilterPath(v ...string) func(*SearchShardsRequest) {
 	return func(r *SearchShardsRequest) {
 		r.FilterPath = v
+	}
+}
+
+// WithHeader adds the headers to the HTTP request
+//
+func (f SearchShards) WithHeader(h map[string]string) func(*SearchShardsRequest) {
+	return func(r *SearchShardsRequest) {
+		if r.Header == nil {
+			r.Header = make(http.Header)
+		}
+		for k, v := range h {
+			r.Header.Add(k, v)
+		}
 	}
 }

--- a/esapi/api.search_template.go
+++ b/esapi/api.search_template.go
@@ -166,7 +166,11 @@ func (r SearchTemplateRequest) Do(ctx context.Context, transport Transport) (*Re
 	}
 
 	if len(r.Header) > 0 {
-		req.Header = r.Header
+		for k, vv := range r.Header {
+			for _, v := range vv {
+				req.Header.Add(k, v)
+			}
+		}
 	}
 
 	if ctx != nil {

--- a/esapi/api.search_template.go
+++ b/esapi/api.search_template.go
@@ -166,9 +166,13 @@ func (r SearchTemplateRequest) Do(ctx context.Context, transport Transport) (*Re
 	}
 
 	if len(r.Header) > 0 {
-		for k, vv := range r.Header {
-			for _, v := range vv {
-				req.Header.Add(k, v)
+		if len(req.Header) == 0 {
+			req.Header = r.Header
+		} else {
+			for k, vv := range r.Header {
+				for _, v := range vv {
+					req.Header.Add(k, v)
+				}
 			}
 		}
 	}

--- a/esapi/api.search_template.go
+++ b/esapi/api.search_template.go
@@ -5,6 +5,7 @@ package esapi
 import (
 	"context"
 	"io"
+	"net/http"
 	"strconv"
 	"strings"
 	"time"
@@ -53,6 +54,8 @@ type SearchTemplateRequest struct {
 	Human      bool
 	ErrorTrace bool
 	FilterPath []string
+
+	Header http.Header
 
 	ctx context.Context
 }
@@ -160,6 +163,10 @@ func (r SearchTemplateRequest) Do(ctx context.Context, transport Transport) (*Re
 
 	if r.Body != nil {
 		req.Header[headerContentType] = headerContentTypeJSON
+	}
+
+	if len(r.Header) > 0 {
+		req.Header = r.Header
 	}
 
 	if ctx != nil {
@@ -329,5 +336,18 @@ func (f SearchTemplate) WithErrorTrace() func(*SearchTemplateRequest) {
 func (f SearchTemplate) WithFilterPath(v ...string) func(*SearchTemplateRequest) {
 	return func(r *SearchTemplateRequest) {
 		r.FilterPath = v
+	}
+}
+
+// WithHeader adds the headers to the HTTP request
+//
+func (f SearchTemplate) WithHeader(h map[string]string) func(*SearchTemplateRequest) {
+	return func(r *SearchTemplateRequest) {
+		if r.Header == nil {
+			r.Header = make(http.Header)
+		}
+		for k, v := range h {
+			r.Header.Add(k, v)
+		}
 	}
 }

--- a/esapi/api.snapshot.create.go
+++ b/esapi/api.snapshot.create.go
@@ -110,9 +110,13 @@ func (r SnapshotCreateRequest) Do(ctx context.Context, transport Transport) (*Re
 	}
 
 	if len(r.Header) > 0 {
-		for k, vv := range r.Header {
-			for _, v := range vv {
-				req.Header.Add(k, v)
+		if len(req.Header) == 0 {
+			req.Header = r.Header
+		} else {
+			for k, vv := range r.Header {
+				for _, v := range vv {
+					req.Header.Add(k, v)
+				}
 			}
 		}
 	}

--- a/esapi/api.snapshot.create.go
+++ b/esapi/api.snapshot.create.go
@@ -5,6 +5,7 @@ package esapi
 import (
 	"context"
 	"io"
+	"net/http"
 	"strconv"
 	"strings"
 	"time"
@@ -43,6 +44,8 @@ type SnapshotCreateRequest struct {
 	Human      bool
 	ErrorTrace bool
 	FilterPath []string
+
+	Header http.Header
 
 	ctx context.Context
 }
@@ -104,6 +107,10 @@ func (r SnapshotCreateRequest) Do(ctx context.Context, transport Transport) (*Re
 
 	if r.Body != nil {
 		req.Header[headerContentType] = headerContentTypeJSON
+	}
+
+	if len(r.Header) > 0 {
+		req.Header = r.Header
 	}
 
 	if ctx != nil {
@@ -185,5 +192,18 @@ func (f SnapshotCreate) WithErrorTrace() func(*SnapshotCreateRequest) {
 func (f SnapshotCreate) WithFilterPath(v ...string) func(*SnapshotCreateRequest) {
 	return func(r *SnapshotCreateRequest) {
 		r.FilterPath = v
+	}
+}
+
+// WithHeader adds the headers to the HTTP request
+//
+func (f SnapshotCreate) WithHeader(h map[string]string) func(*SnapshotCreateRequest) {
+	return func(r *SnapshotCreateRequest) {
+		if r.Header == nil {
+			r.Header = make(http.Header)
+		}
+		for k, v := range h {
+			r.Header.Add(k, v)
+		}
 	}
 }

--- a/esapi/api.snapshot.create.go
+++ b/esapi/api.snapshot.create.go
@@ -110,7 +110,11 @@ func (r SnapshotCreateRequest) Do(ctx context.Context, transport Transport) (*Re
 	}
 
 	if len(r.Header) > 0 {
-		req.Header = r.Header
+		for k, vv := range r.Header {
+			for _, v := range vv {
+				req.Header.Add(k, v)
+			}
+		}
 	}
 
 	if ctx != nil {

--- a/esapi/api.snapshot.create_repository.go
+++ b/esapi/api.snapshot.create_repository.go
@@ -5,6 +5,7 @@ package esapi
 import (
 	"context"
 	"io"
+	"net/http"
 	"strconv"
 	"strings"
 	"time"
@@ -43,6 +44,8 @@ type SnapshotCreateRepositoryRequest struct {
 	Human      bool
 	ErrorTrace bool
 	FilterPath []string
+
+	Header http.Header
 
 	ctx context.Context
 }
@@ -106,6 +109,10 @@ func (r SnapshotCreateRepositoryRequest) Do(ctx context.Context, transport Trans
 
 	if r.Body != nil {
 		req.Header[headerContentType] = headerContentTypeJSON
+	}
+
+	if len(r.Header) > 0 {
+		req.Header = r.Header
 	}
 
 	if ctx != nil {
@@ -187,5 +194,18 @@ func (f SnapshotCreateRepository) WithErrorTrace() func(*SnapshotCreateRepositor
 func (f SnapshotCreateRepository) WithFilterPath(v ...string) func(*SnapshotCreateRepositoryRequest) {
 	return func(r *SnapshotCreateRepositoryRequest) {
 		r.FilterPath = v
+	}
+}
+
+// WithHeader adds the headers to the HTTP request
+//
+func (f SnapshotCreateRepository) WithHeader(h map[string]string) func(*SnapshotCreateRepositoryRequest) {
+	return func(r *SnapshotCreateRepositoryRequest) {
+		if r.Header == nil {
+			r.Header = make(http.Header)
+		}
+		for k, v := range h {
+			r.Header.Add(k, v)
+		}
 	}
 }

--- a/esapi/api.snapshot.create_repository.go
+++ b/esapi/api.snapshot.create_repository.go
@@ -112,7 +112,11 @@ func (r SnapshotCreateRepositoryRequest) Do(ctx context.Context, transport Trans
 	}
 
 	if len(r.Header) > 0 {
-		req.Header = r.Header
+		for k, vv := range r.Header {
+			for _, v := range vv {
+				req.Header.Add(k, v)
+			}
+		}
 	}
 
 	if ctx != nil {

--- a/esapi/api.snapshot.create_repository.go
+++ b/esapi/api.snapshot.create_repository.go
@@ -112,9 +112,13 @@ func (r SnapshotCreateRepositoryRequest) Do(ctx context.Context, transport Trans
 	}
 
 	if len(r.Header) > 0 {
-		for k, vv := range r.Header {
-			for _, v := range vv {
-				req.Header.Add(k, v)
+		if len(req.Header) == 0 {
+			req.Header = r.Header
+		} else {
+			for k, vv := range r.Header {
+				for _, v := range vv {
+					req.Header.Add(k, v)
+				}
 			}
 		}
 	}

--- a/esapi/api.snapshot.delete.go
+++ b/esapi/api.snapshot.delete.go
@@ -4,6 +4,7 @@ package esapi
 
 import (
 	"context"
+	"net/http"
 	"strings"
 	"time"
 )
@@ -38,6 +39,8 @@ type SnapshotDeleteRequest struct {
 	Human      bool
 	ErrorTrace bool
 	FilterPath []string
+
+	Header http.Header
 
 	ctx context.Context
 }
@@ -91,6 +94,10 @@ func (r SnapshotDeleteRequest) Do(ctx context.Context, transport Transport) (*Re
 			q.Set(k, v)
 		}
 		req.URL.RawQuery = q.Encode()
+	}
+
+	if len(r.Header) > 0 {
+		req.Header = r.Header
 	}
 
 	if ctx != nil {
@@ -156,5 +163,18 @@ func (f SnapshotDelete) WithErrorTrace() func(*SnapshotDeleteRequest) {
 func (f SnapshotDelete) WithFilterPath(v ...string) func(*SnapshotDeleteRequest) {
 	return func(r *SnapshotDeleteRequest) {
 		r.FilterPath = v
+	}
+}
+
+// WithHeader adds the headers to the HTTP request
+//
+func (f SnapshotDelete) WithHeader(h map[string]string) func(*SnapshotDeleteRequest) {
+	return func(r *SnapshotDeleteRequest) {
+		if r.Header == nil {
+			r.Header = make(http.Header)
+		}
+		for k, v := range h {
+			r.Header.Add(k, v)
+		}
 	}
 }

--- a/esapi/api.snapshot.delete.go
+++ b/esapi/api.snapshot.delete.go
@@ -97,9 +97,13 @@ func (r SnapshotDeleteRequest) Do(ctx context.Context, transport Transport) (*Re
 	}
 
 	if len(r.Header) > 0 {
-		for k, vv := range r.Header {
-			for _, v := range vv {
-				req.Header.Add(k, v)
+		if len(req.Header) == 0 {
+			req.Header = r.Header
+		} else {
+			for k, vv := range r.Header {
+				for _, v := range vv {
+					req.Header.Add(k, v)
+				}
 			}
 		}
 	}

--- a/esapi/api.snapshot.delete.go
+++ b/esapi/api.snapshot.delete.go
@@ -97,7 +97,11 @@ func (r SnapshotDeleteRequest) Do(ctx context.Context, transport Transport) (*Re
 	}
 
 	if len(r.Header) > 0 {
-		req.Header = r.Header
+		for k, vv := range r.Header {
+			for _, v := range vv {
+				req.Header.Add(k, v)
+			}
+		}
 	}
 
 	if ctx != nil {

--- a/esapi/api.snapshot.delete_repository.go
+++ b/esapi/api.snapshot.delete_repository.go
@@ -99,7 +99,11 @@ func (r SnapshotDeleteRepositoryRequest) Do(ctx context.Context, transport Trans
 	}
 
 	if len(r.Header) > 0 {
-		req.Header = r.Header
+		for k, vv := range r.Header {
+			for _, v := range vv {
+				req.Header.Add(k, v)
+			}
+		}
 	}
 
 	if ctx != nil {

--- a/esapi/api.snapshot.delete_repository.go
+++ b/esapi/api.snapshot.delete_repository.go
@@ -4,6 +4,7 @@ package esapi
 
 import (
 	"context"
+	"net/http"
 	"strings"
 	"time"
 )
@@ -38,6 +39,8 @@ type SnapshotDeleteRepositoryRequest struct {
 	Human      bool
 	ErrorTrace bool
 	FilterPath []string
+
+	Header http.Header
 
 	ctx context.Context
 }
@@ -93,6 +96,10 @@ func (r SnapshotDeleteRepositoryRequest) Do(ctx context.Context, transport Trans
 			q.Set(k, v)
 		}
 		req.URL.RawQuery = q.Encode()
+	}
+
+	if len(r.Header) > 0 {
+		req.Header = r.Header
 	}
 
 	if ctx != nil {
@@ -166,5 +173,18 @@ func (f SnapshotDeleteRepository) WithErrorTrace() func(*SnapshotDeleteRepositor
 func (f SnapshotDeleteRepository) WithFilterPath(v ...string) func(*SnapshotDeleteRepositoryRequest) {
 	return func(r *SnapshotDeleteRepositoryRequest) {
 		r.FilterPath = v
+	}
+}
+
+// WithHeader adds the headers to the HTTP request
+//
+func (f SnapshotDeleteRepository) WithHeader(h map[string]string) func(*SnapshotDeleteRepositoryRequest) {
+	return func(r *SnapshotDeleteRepositoryRequest) {
+		if r.Header == nil {
+			r.Header = make(http.Header)
+		}
+		for k, v := range h {
+			r.Header.Add(k, v)
+		}
 	}
 }

--- a/esapi/api.snapshot.delete_repository.go
+++ b/esapi/api.snapshot.delete_repository.go
@@ -99,9 +99,13 @@ func (r SnapshotDeleteRepositoryRequest) Do(ctx context.Context, transport Trans
 	}
 
 	if len(r.Header) > 0 {
-		for k, vv := range r.Header {
-			for _, v := range vv {
-				req.Header.Add(k, v)
+		if len(req.Header) == 0 {
+			req.Header = r.Header
+		} else {
+			for k, vv := range r.Header {
+				for _, v := range vv {
+					req.Header.Add(k, v)
+				}
 			}
 		}
 	}

--- a/esapi/api.snapshot.get.go
+++ b/esapi/api.snapshot.get.go
@@ -108,7 +108,11 @@ func (r SnapshotGetRequest) Do(ctx context.Context, transport Transport) (*Respo
 	}
 
 	if len(r.Header) > 0 {
-		req.Header = r.Header
+		for k, vv := range r.Header {
+			for _, v := range vv {
+				req.Header.Add(k, v)
+			}
+		}
 	}
 
 	if ctx != nil {

--- a/esapi/api.snapshot.get.go
+++ b/esapi/api.snapshot.get.go
@@ -4,6 +4,7 @@ package esapi
 
 import (
 	"context"
+	"net/http"
 	"strconv"
 	"strings"
 	"time"
@@ -41,6 +42,8 @@ type SnapshotGetRequest struct {
 	Human      bool
 	ErrorTrace bool
 	FilterPath []string
+
+	Header http.Header
 
 	ctx context.Context
 }
@@ -102,6 +105,10 @@ func (r SnapshotGetRequest) Do(ctx context.Context, transport Transport) (*Respo
 			q.Set(k, v)
 		}
 		req.URL.RawQuery = q.Encode()
+	}
+
+	if len(r.Header) > 0 {
+		req.Header = r.Header
 	}
 
 	if ctx != nil {
@@ -183,5 +190,18 @@ func (f SnapshotGet) WithErrorTrace() func(*SnapshotGetRequest) {
 func (f SnapshotGet) WithFilterPath(v ...string) func(*SnapshotGetRequest) {
 	return func(r *SnapshotGetRequest) {
 		r.FilterPath = v
+	}
+}
+
+// WithHeader adds the headers to the HTTP request
+//
+func (f SnapshotGet) WithHeader(h map[string]string) func(*SnapshotGetRequest) {
+	return func(r *SnapshotGetRequest) {
+		if r.Header == nil {
+			r.Header = make(http.Header)
+		}
+		for k, v := range h {
+			r.Header.Add(k, v)
+		}
 	}
 }

--- a/esapi/api.snapshot.get.go
+++ b/esapi/api.snapshot.get.go
@@ -108,9 +108,13 @@ func (r SnapshotGetRequest) Do(ctx context.Context, transport Transport) (*Respo
 	}
 
 	if len(r.Header) > 0 {
-		for k, vv := range r.Header {
-			for _, v := range vv {
-				req.Header.Add(k, v)
+		if len(req.Header) == 0 {
+			req.Header = r.Header
+		} else {
+			for k, vv := range r.Header {
+				for _, v := range vv {
+					req.Header.Add(k, v)
+				}
 			}
 		}
 	}

--- a/esapi/api.snapshot.get_repository.go
+++ b/esapi/api.snapshot.get_repository.go
@@ -4,6 +4,7 @@ package esapi
 
 import (
 	"context"
+	"net/http"
 	"strconv"
 	"strings"
 	"time"
@@ -39,6 +40,8 @@ type SnapshotGetRepositoryRequest struct {
 	Human      bool
 	ErrorTrace bool
 	FilterPath []string
+
+	Header http.Header
 
 	ctx context.Context
 }
@@ -96,6 +99,10 @@ func (r SnapshotGetRepositoryRequest) Do(ctx context.Context, transport Transpor
 			q.Set(k, v)
 		}
 		req.URL.RawQuery = q.Encode()
+	}
+
+	if len(r.Header) > 0 {
+		req.Header = r.Header
 	}
 
 	if ctx != nil {
@@ -177,5 +184,18 @@ func (f SnapshotGetRepository) WithErrorTrace() func(*SnapshotGetRepositoryReque
 func (f SnapshotGetRepository) WithFilterPath(v ...string) func(*SnapshotGetRepositoryRequest) {
 	return func(r *SnapshotGetRepositoryRequest) {
 		r.FilterPath = v
+	}
+}
+
+// WithHeader adds the headers to the HTTP request
+//
+func (f SnapshotGetRepository) WithHeader(h map[string]string) func(*SnapshotGetRepositoryRequest) {
+	return func(r *SnapshotGetRepositoryRequest) {
+		if r.Header == nil {
+			r.Header = make(http.Header)
+		}
+		for k, v := range h {
+			r.Header.Add(k, v)
+		}
 	}
 }

--- a/esapi/api.snapshot.get_repository.go
+++ b/esapi/api.snapshot.get_repository.go
@@ -102,9 +102,13 @@ func (r SnapshotGetRepositoryRequest) Do(ctx context.Context, transport Transpor
 	}
 
 	if len(r.Header) > 0 {
-		for k, vv := range r.Header {
-			for _, v := range vv {
-				req.Header.Add(k, v)
+		if len(req.Header) == 0 {
+			req.Header = r.Header
+		} else {
+			for k, vv := range r.Header {
+				for _, v := range vv {
+					req.Header.Add(k, v)
+				}
 			}
 		}
 	}

--- a/esapi/api.snapshot.get_repository.go
+++ b/esapi/api.snapshot.get_repository.go
@@ -102,7 +102,11 @@ func (r SnapshotGetRepositoryRequest) Do(ctx context.Context, transport Transpor
 	}
 
 	if len(r.Header) > 0 {
-		req.Header = r.Header
+		for k, vv := range r.Header {
+			for _, v := range vv {
+				req.Header.Add(k, v)
+			}
+		}
 	}
 
 	if ctx != nil {

--- a/esapi/api.snapshot.restore.go
+++ b/esapi/api.snapshot.restore.go
@@ -5,6 +5,7 @@ package esapi
 import (
 	"context"
 	"io"
+	"net/http"
 	"strconv"
 	"strings"
 	"time"
@@ -43,6 +44,8 @@ type SnapshotRestoreRequest struct {
 	Human      bool
 	ErrorTrace bool
 	FilterPath []string
+
+	Header http.Header
 
 	ctx context.Context
 }
@@ -106,6 +109,10 @@ func (r SnapshotRestoreRequest) Do(ctx context.Context, transport Transport) (*R
 
 	if r.Body != nil {
 		req.Header[headerContentType] = headerContentTypeJSON
+	}
+
+	if len(r.Header) > 0 {
+		req.Header = r.Header
 	}
 
 	if ctx != nil {
@@ -187,5 +194,18 @@ func (f SnapshotRestore) WithErrorTrace() func(*SnapshotRestoreRequest) {
 func (f SnapshotRestore) WithFilterPath(v ...string) func(*SnapshotRestoreRequest) {
 	return func(r *SnapshotRestoreRequest) {
 		r.FilterPath = v
+	}
+}
+
+// WithHeader adds the headers to the HTTP request
+//
+func (f SnapshotRestore) WithHeader(h map[string]string) func(*SnapshotRestoreRequest) {
+	return func(r *SnapshotRestoreRequest) {
+		if r.Header == nil {
+			r.Header = make(http.Header)
+		}
+		for k, v := range h {
+			r.Header.Add(k, v)
+		}
 	}
 }

--- a/esapi/api.snapshot.restore.go
+++ b/esapi/api.snapshot.restore.go
@@ -112,9 +112,13 @@ func (r SnapshotRestoreRequest) Do(ctx context.Context, transport Transport) (*R
 	}
 
 	if len(r.Header) > 0 {
-		for k, vv := range r.Header {
-			for _, v := range vv {
-				req.Header.Add(k, v)
+		if len(req.Header) == 0 {
+			req.Header = r.Header
+		} else {
+			for k, vv := range r.Header {
+				for _, v := range vv {
+					req.Header.Add(k, v)
+				}
 			}
 		}
 	}

--- a/esapi/api.snapshot.restore.go
+++ b/esapi/api.snapshot.restore.go
@@ -112,7 +112,11 @@ func (r SnapshotRestoreRequest) Do(ctx context.Context, transport Transport) (*R
 	}
 
 	if len(r.Header) > 0 {
-		req.Header = r.Header
+		for k, vv := range r.Header {
+			for _, v := range vv {
+				req.Header.Add(k, v)
+			}
+		}
 	}
 
 	if ctx != nil {

--- a/esapi/api.snapshot.status.go
+++ b/esapi/api.snapshot.status.go
@@ -4,6 +4,7 @@ package esapi
 
 import (
 	"context"
+	"net/http"
 	"strconv"
 	"strings"
 	"time"
@@ -40,6 +41,8 @@ type SnapshotStatusRequest struct {
 	Human      bool
 	ErrorTrace bool
 	FilterPath []string
+
+	Header http.Header
 
 	ctx context.Context
 }
@@ -103,6 +106,10 @@ func (r SnapshotStatusRequest) Do(ctx context.Context, transport Transport) (*Re
 			q.Set(k, v)
 		}
 		req.URL.RawQuery = q.Encode()
+	}
+
+	if len(r.Header) > 0 {
+		req.Header = r.Header
 	}
 
 	if ctx != nil {
@@ -192,5 +199,18 @@ func (f SnapshotStatus) WithErrorTrace() func(*SnapshotStatusRequest) {
 func (f SnapshotStatus) WithFilterPath(v ...string) func(*SnapshotStatusRequest) {
 	return func(r *SnapshotStatusRequest) {
 		r.FilterPath = v
+	}
+}
+
+// WithHeader adds the headers to the HTTP request
+//
+func (f SnapshotStatus) WithHeader(h map[string]string) func(*SnapshotStatusRequest) {
+	return func(r *SnapshotStatusRequest) {
+		if r.Header == nil {
+			r.Header = make(http.Header)
+		}
+		for k, v := range h {
+			r.Header.Add(k, v)
+		}
 	}
 }

--- a/esapi/api.snapshot.status.go
+++ b/esapi/api.snapshot.status.go
@@ -109,9 +109,13 @@ func (r SnapshotStatusRequest) Do(ctx context.Context, transport Transport) (*Re
 	}
 
 	if len(r.Header) > 0 {
-		for k, vv := range r.Header {
-			for _, v := range vv {
-				req.Header.Add(k, v)
+		if len(req.Header) == 0 {
+			req.Header = r.Header
+		} else {
+			for k, vv := range r.Header {
+				for _, v := range vv {
+					req.Header.Add(k, v)
+				}
 			}
 		}
 	}

--- a/esapi/api.snapshot.status.go
+++ b/esapi/api.snapshot.status.go
@@ -109,7 +109,11 @@ func (r SnapshotStatusRequest) Do(ctx context.Context, transport Transport) (*Re
 	}
 
 	if len(r.Header) > 0 {
-		req.Header = r.Header
+		for k, vv := range r.Header {
+			for _, v := range vv {
+				req.Header.Add(k, v)
+			}
+		}
 	}
 
 	if ctx != nil {

--- a/esapi/api.snapshot.verify_repository.go
+++ b/esapi/api.snapshot.verify_repository.go
@@ -101,7 +101,11 @@ func (r SnapshotVerifyRepositoryRequest) Do(ctx context.Context, transport Trans
 	}
 
 	if len(r.Header) > 0 {
-		req.Header = r.Header
+		for k, vv := range r.Header {
+			for _, v := range vv {
+				req.Header.Add(k, v)
+			}
+		}
 	}
 
 	if ctx != nil {

--- a/esapi/api.snapshot.verify_repository.go
+++ b/esapi/api.snapshot.verify_repository.go
@@ -4,6 +4,7 @@ package esapi
 
 import (
 	"context"
+	"net/http"
 	"strings"
 	"time"
 )
@@ -38,6 +39,8 @@ type SnapshotVerifyRepositoryRequest struct {
 	Human      bool
 	ErrorTrace bool
 	FilterPath []string
+
+	Header http.Header
 
 	ctx context.Context
 }
@@ -95,6 +98,10 @@ func (r SnapshotVerifyRepositoryRequest) Do(ctx context.Context, transport Trans
 			q.Set(k, v)
 		}
 		req.URL.RawQuery = q.Encode()
+	}
+
+	if len(r.Header) > 0 {
+		req.Header = r.Header
 	}
 
 	if ctx != nil {
@@ -168,5 +175,18 @@ func (f SnapshotVerifyRepository) WithErrorTrace() func(*SnapshotVerifyRepositor
 func (f SnapshotVerifyRepository) WithFilterPath(v ...string) func(*SnapshotVerifyRepositoryRequest) {
 	return func(r *SnapshotVerifyRepositoryRequest) {
 		r.FilterPath = v
+	}
+}
+
+// WithHeader adds the headers to the HTTP request
+//
+func (f SnapshotVerifyRepository) WithHeader(h map[string]string) func(*SnapshotVerifyRepositoryRequest) {
+	return func(r *SnapshotVerifyRepositoryRequest) {
+		if r.Header == nil {
+			r.Header = make(http.Header)
+		}
+		for k, v := range h {
+			r.Header.Add(k, v)
+		}
 	}
 }

--- a/esapi/api.snapshot.verify_repository.go
+++ b/esapi/api.snapshot.verify_repository.go
@@ -101,9 +101,13 @@ func (r SnapshotVerifyRepositoryRequest) Do(ctx context.Context, transport Trans
 	}
 
 	if len(r.Header) > 0 {
-		for k, vv := range r.Header {
-			for _, v := range vv {
-				req.Header.Add(k, v)
+		if len(req.Header) == 0 {
+			req.Header = r.Header
+		} else {
+			for k, vv := range r.Header {
+				for _, v := range vv {
+					req.Header.Add(k, v)
+				}
 			}
 		}
 	}

--- a/esapi/api.tasks.cancel.go
+++ b/esapi/api.tasks.cancel.go
@@ -4,6 +4,7 @@ package esapi
 
 import (
 	"context"
+	"net/http"
 	"strings"
 )
 
@@ -38,6 +39,8 @@ type TasksCancelRequest struct {
 	Human      bool
 	ErrorTrace bool
 	FilterPath []string
+
+	Header http.Header
 
 	ctx context.Context
 }
@@ -101,6 +104,10 @@ func (r TasksCancelRequest) Do(ctx context.Context, transport Transport) (*Respo
 			q.Set(k, v)
 		}
 		req.URL.RawQuery = q.Encode()
+	}
+
+	if len(r.Header) > 0 {
+		req.Header = r.Header
 	}
 
 	if ctx != nil {
@@ -190,5 +197,18 @@ func (f TasksCancel) WithErrorTrace() func(*TasksCancelRequest) {
 func (f TasksCancel) WithFilterPath(v ...string) func(*TasksCancelRequest) {
 	return func(r *TasksCancelRequest) {
 		r.FilterPath = v
+	}
+}
+
+// WithHeader adds the headers to the HTTP request
+//
+func (f TasksCancel) WithHeader(h map[string]string) func(*TasksCancelRequest) {
+	return func(r *TasksCancelRequest) {
+		if r.Header == nil {
+			r.Header = make(http.Header)
+		}
+		for k, v := range h {
+			r.Header.Add(k, v)
+		}
 	}
 }

--- a/esapi/api.tasks.cancel.go
+++ b/esapi/api.tasks.cancel.go
@@ -107,7 +107,11 @@ func (r TasksCancelRequest) Do(ctx context.Context, transport Transport) (*Respo
 	}
 
 	if len(r.Header) > 0 {
-		req.Header = r.Header
+		for k, vv := range r.Header {
+			for _, v := range vv {
+				req.Header.Add(k, v)
+			}
+		}
 	}
 
 	if ctx != nil {

--- a/esapi/api.tasks.cancel.go
+++ b/esapi/api.tasks.cancel.go
@@ -107,9 +107,13 @@ func (r TasksCancelRequest) Do(ctx context.Context, transport Transport) (*Respo
 	}
 
 	if len(r.Header) > 0 {
-		for k, vv := range r.Header {
-			for _, v := range vv {
-				req.Header.Add(k, v)
+		if len(req.Header) == 0 {
+			req.Header = r.Header
+		} else {
+			for k, vv := range r.Header {
+				for _, v := range vv {
+					req.Header.Add(k, v)
+				}
 			}
 		}
 	}

--- a/esapi/api.tasks.get.go
+++ b/esapi/api.tasks.get.go
@@ -100,9 +100,13 @@ func (r TasksGetRequest) Do(ctx context.Context, transport Transport) (*Response
 	}
 
 	if len(r.Header) > 0 {
-		for k, vv := range r.Header {
-			for _, v := range vv {
-				req.Header.Add(k, v)
+		if len(req.Header) == 0 {
+			req.Header = r.Header
+		} else {
+			for k, vv := range r.Header {
+				for _, v := range vv {
+					req.Header.Add(k, v)
+				}
 			}
 		}
 	}

--- a/esapi/api.tasks.get.go
+++ b/esapi/api.tasks.get.go
@@ -100,7 +100,11 @@ func (r TasksGetRequest) Do(ctx context.Context, transport Transport) (*Response
 	}
 
 	if len(r.Header) > 0 {
-		req.Header = r.Header
+		for k, vv := range r.Header {
+			for _, v := range vv {
+				req.Header.Add(k, v)
+			}
+		}
 	}
 
 	if ctx != nil {

--- a/esapi/api.tasks.get.go
+++ b/esapi/api.tasks.get.go
@@ -4,6 +4,7 @@ package esapi
 
 import (
 	"context"
+	"net/http"
 	"strconv"
 	"strings"
 	"time"
@@ -39,6 +40,8 @@ type TasksGetRequest struct {
 	Human      bool
 	ErrorTrace bool
 	FilterPath []string
+
+	Header http.Header
 
 	ctx context.Context
 }
@@ -94,6 +97,10 @@ func (r TasksGetRequest) Do(ctx context.Context, transport Transport) (*Response
 			q.Set(k, v)
 		}
 		req.URL.RawQuery = q.Encode()
+	}
+
+	if len(r.Header) > 0 {
+		req.Header = r.Header
 	}
 
 	if ctx != nil {
@@ -167,5 +174,18 @@ func (f TasksGet) WithErrorTrace() func(*TasksGetRequest) {
 func (f TasksGet) WithFilterPath(v ...string) func(*TasksGetRequest) {
 	return func(r *TasksGetRequest) {
 		r.FilterPath = v
+	}
+}
+
+// WithHeader adds the headers to the HTTP request
+//
+func (f TasksGet) WithHeader(h map[string]string) func(*TasksGetRequest) {
+	return func(r *TasksGetRequest) {
+		if r.Header == nil {
+			r.Header = make(http.Header)
+		}
+		for k, v := range h {
+			r.Header.Add(k, v)
+		}
 	}
 }

--- a/esapi/api.tasks.list.go
+++ b/esapi/api.tasks.list.go
@@ -120,9 +120,13 @@ func (r TasksListRequest) Do(ctx context.Context, transport Transport) (*Respons
 	}
 
 	if len(r.Header) > 0 {
-		for k, vv := range r.Header {
-			for _, v := range vv {
-				req.Header.Add(k, v)
+		if len(req.Header) == 0 {
+			req.Header = r.Header
+		} else {
+			for k, vv := range r.Header {
+				for _, v := range vv {
+					req.Header.Add(k, v)
+				}
 			}
 		}
 	}

--- a/esapi/api.tasks.list.go
+++ b/esapi/api.tasks.list.go
@@ -120,7 +120,11 @@ func (r TasksListRequest) Do(ctx context.Context, transport Transport) (*Respons
 	}
 
 	if len(r.Header) > 0 {
-		req.Header = r.Header
+		for k, vv := range r.Header {
+			for _, v := range vv {
+				req.Header.Add(k, v)
+			}
+		}
 	}
 
 	if ctx != nil {

--- a/esapi/api.tasks.list.go
+++ b/esapi/api.tasks.list.go
@@ -4,6 +4,7 @@ package esapi
 
 import (
 	"context"
+	"net/http"
 	"strconv"
 	"strings"
 	"time"
@@ -42,6 +43,8 @@ type TasksListRequest struct {
 	Human      bool
 	ErrorTrace bool
 	FilterPath []string
+
+	Header http.Header
 
 	ctx context.Context
 }
@@ -114,6 +117,10 @@ func (r TasksListRequest) Do(ctx context.Context, transport Transport) (*Respons
 			q.Set(k, v)
 		}
 		req.URL.RawQuery = q.Encode()
+	}
+
+	if len(r.Header) > 0 {
+		req.Header = r.Header
 	}
 
 	if ctx != nil {
@@ -227,5 +234,18 @@ func (f TasksList) WithErrorTrace() func(*TasksListRequest) {
 func (f TasksList) WithFilterPath(v ...string) func(*TasksListRequest) {
 	return func(r *TasksListRequest) {
 		r.FilterPath = v
+	}
+}
+
+// WithHeader adds the headers to the HTTP request
+//
+func (f TasksList) WithHeader(h map[string]string) func(*TasksListRequest) {
+	return func(r *TasksListRequest) {
+		if r.Header == nil {
+			r.Header = make(http.Header)
+		}
+		for k, v := range h {
+			r.Header.Add(k, v)
+		}
 	}
 }

--- a/esapi/api.termvectors.go
+++ b/esapi/api.termvectors.go
@@ -156,9 +156,13 @@ func (r TermvectorsRequest) Do(ctx context.Context, transport Transport) (*Respo
 	}
 
 	if len(r.Header) > 0 {
-		for k, vv := range r.Header {
-			for _, v := range vv {
-				req.Header.Add(k, v)
+		if len(req.Header) == 0 {
+			req.Header = r.Header
+		} else {
+			for k, vv := range r.Header {
+				for _, v := range vv {
+					req.Header.Add(k, v)
+				}
 			}
 		}
 	}

--- a/esapi/api.termvectors.go
+++ b/esapi/api.termvectors.go
@@ -5,6 +5,7 @@ package esapi
 import (
 	"context"
 	"io"
+	"net/http"
 	"strconv"
 	"strings"
 )
@@ -51,6 +52,8 @@ type TermvectorsRequest struct {
 	Human      bool
 	ErrorTrace bool
 	FilterPath []string
+
+	Header http.Header
 
 	ctx context.Context
 }
@@ -150,6 +153,10 @@ func (r TermvectorsRequest) Do(ctx context.Context, transport Transport) (*Respo
 
 	if r.Body != nil {
 		req.Header[headerContentType] = headerContentTypeJSON
+	}
+
+	if len(r.Header) > 0 {
+		req.Header = r.Header
 	}
 
 	if ctx != nil {
@@ -311,5 +318,18 @@ func (f Termvectors) WithErrorTrace() func(*TermvectorsRequest) {
 func (f Termvectors) WithFilterPath(v ...string) func(*TermvectorsRequest) {
 	return func(r *TermvectorsRequest) {
 		r.FilterPath = v
+	}
+}
+
+// WithHeader adds the headers to the HTTP request
+//
+func (f Termvectors) WithHeader(h map[string]string) func(*TermvectorsRequest) {
+	return func(r *TermvectorsRequest) {
+		if r.Header == nil {
+			r.Header = make(http.Header)
+		}
+		for k, v := range h {
+			r.Header.Add(k, v)
+		}
 	}
 }

--- a/esapi/api.termvectors.go
+++ b/esapi/api.termvectors.go
@@ -156,7 +156,11 @@ func (r TermvectorsRequest) Do(ctx context.Context, transport Transport) (*Respo
 	}
 
 	if len(r.Header) > 0 {
-		req.Header = r.Header
+		for k, vv := range r.Header {
+			for _, v := range vv {
+				req.Header.Add(k, v)
+			}
+		}
 	}
 
 	if ctx != nil {

--- a/esapi/api.update.go
+++ b/esapi/api.update.go
@@ -164,9 +164,13 @@ func (r UpdateRequest) Do(ctx context.Context, transport Transport) (*Response, 
 	}
 
 	if len(r.Header) > 0 {
-		for k, vv := range r.Header {
-			for _, v := range vv {
-				req.Header.Add(k, v)
+		if len(req.Header) == 0 {
+			req.Header = r.Header
+		} else {
+			for k, vv := range r.Header {
+				for _, v := range vv {
+					req.Header.Add(k, v)
+				}
 			}
 		}
 	}

--- a/esapi/api.update.go
+++ b/esapi/api.update.go
@@ -5,6 +5,7 @@ package esapi
 import (
 	"context"
 	"io"
+	"net/http"
 	"strconv"
 	"strings"
 	"time"
@@ -53,6 +54,8 @@ type UpdateRequest struct {
 	Human      bool
 	ErrorTrace bool
 	FilterPath []string
+
+	Header http.Header
 
 	ctx context.Context
 }
@@ -158,6 +161,10 @@ func (r UpdateRequest) Do(ctx context.Context, transport Transport) (*Response, 
 
 	if r.Body != nil {
 		req.Header[headerContentType] = headerContentTypeJSON
+	}
+
+	if len(r.Header) > 0 {
+		req.Header = r.Header
 	}
 
 	if ctx != nil {
@@ -311,5 +318,18 @@ func (f Update) WithErrorTrace() func(*UpdateRequest) {
 func (f Update) WithFilterPath(v ...string) func(*UpdateRequest) {
 	return func(r *UpdateRequest) {
 		r.FilterPath = v
+	}
+}
+
+// WithHeader adds the headers to the HTTP request
+//
+func (f Update) WithHeader(h map[string]string) func(*UpdateRequest) {
+	return func(r *UpdateRequest) {
+		if r.Header == nil {
+			r.Header = make(http.Header)
+		}
+		for k, v := range h {
+			r.Header.Add(k, v)
+		}
 	}
 }

--- a/esapi/api.update.go
+++ b/esapi/api.update.go
@@ -164,7 +164,11 @@ func (r UpdateRequest) Do(ctx context.Context, transport Transport) (*Response, 
 	}
 
 	if len(r.Header) > 0 {
-		req.Header = r.Header
+		for k, vv := range r.Header {
+			for _, v := range vv {
+				req.Header.Add(k, v)
+			}
+		}
 	}
 
 	if ctx != nil {

--- a/esapi/api.update_by_query.go
+++ b/esapi/api.update_by_query.go
@@ -268,7 +268,11 @@ func (r UpdateByQueryRequest) Do(ctx context.Context, transport Transport) (*Res
 	}
 
 	if len(r.Header) > 0 {
-		req.Header = r.Header
+		for k, vv := range r.Header {
+			for _, v := range vv {
+				req.Header.Add(k, v)
+			}
+		}
 	}
 
 	if ctx != nil {

--- a/esapi/api.update_by_query.go
+++ b/esapi/api.update_by_query.go
@@ -5,6 +5,7 @@ package esapi
 import (
 	"context"
 	"io"
+	"net/http"
 	"strconv"
 	"strings"
 	"time"
@@ -75,6 +76,8 @@ type UpdateByQueryRequest struct {
 	Human      bool
 	ErrorTrace bool
 	FilterPath []string
+
+	Header http.Header
 
 	ctx context.Context
 }
@@ -262,6 +265,10 @@ func (r UpdateByQueryRequest) Do(ctx context.Context, transport Transport) (*Res
 
 	if r.Body != nil {
 		req.Header[headerContentType] = headerContentTypeJSON
+	}
+
+	if len(r.Header) > 0 {
+		req.Header = r.Header
 	}
 
 	if ctx != nil {
@@ -599,5 +606,18 @@ func (f UpdateByQuery) WithErrorTrace() func(*UpdateByQueryRequest) {
 func (f UpdateByQuery) WithFilterPath(v ...string) func(*UpdateByQueryRequest) {
 	return func(r *UpdateByQueryRequest) {
 		r.FilterPath = v
+	}
+}
+
+// WithHeader adds the headers to the HTTP request
+//
+func (f UpdateByQuery) WithHeader(h map[string]string) func(*UpdateByQueryRequest) {
+	return func(r *UpdateByQueryRequest) {
+		if r.Header == nil {
+			r.Header = make(http.Header)
+		}
+		for k, v := range h {
+			r.Header.Add(k, v)
+		}
 	}
 }

--- a/esapi/api.update_by_query.go
+++ b/esapi/api.update_by_query.go
@@ -268,9 +268,13 @@ func (r UpdateByQueryRequest) Do(ctx context.Context, transport Transport) (*Res
 	}
 
 	if len(r.Header) > 0 {
-		for k, vv := range r.Header {
-			for _, v := range vv {
-				req.Header.Add(k, v)
+		if len(req.Header) == 0 {
+			req.Header = r.Header
+		} else {
+			for k, vv := range r.Header {
+				for _, v := range vv {
+					req.Header.Add(k, v)
+				}
 			}
 		}
 	}

--- a/esapi/api.update_by_query_rethrottle.go
+++ b/esapi/api.update_by_query_rethrottle.go
@@ -96,9 +96,13 @@ func (r UpdateByQueryRethrottleRequest) Do(ctx context.Context, transport Transp
 	}
 
 	if len(r.Header) > 0 {
-		for k, vv := range r.Header {
-			for _, v := range vv {
-				req.Header.Add(k, v)
+		if len(req.Header) == 0 {
+			req.Header = r.Header
+		} else {
+			for k, vv := range r.Header {
+				for _, v := range vv {
+					req.Header.Add(k, v)
+				}
 			}
 		}
 	}

--- a/esapi/api.update_by_query_rethrottle.go
+++ b/esapi/api.update_by_query_rethrottle.go
@@ -96,7 +96,11 @@ func (r UpdateByQueryRethrottleRequest) Do(ctx context.Context, transport Transp
 	}
 
 	if len(r.Header) > 0 {
-		req.Header = r.Header
+		for k, vv := range r.Header {
+			for _, v := range vv {
+				req.Header.Add(k, v)
+			}
+		}
 	}
 
 	if ctx != nil {

--- a/esapi/api.update_by_query_rethrottle.go
+++ b/esapi/api.update_by_query_rethrottle.go
@@ -4,6 +4,7 @@ package esapi
 
 import (
 	"context"
+	"net/http"
 	"strconv"
 	"strings"
 )
@@ -37,6 +38,8 @@ type UpdateByQueryRethrottleRequest struct {
 	Human      bool
 	ErrorTrace bool
 	FilterPath []string
+
+	Header http.Header
 
 	ctx context.Context
 }
@@ -90,6 +93,10 @@ func (r UpdateByQueryRethrottleRequest) Do(ctx context.Context, transport Transp
 			q.Set(k, v)
 		}
 		req.URL.RawQuery = q.Encode()
+	}
+
+	if len(r.Header) > 0 {
+		req.Header = r.Header
 	}
 
 	if ctx != nil {
@@ -155,5 +162,18 @@ func (f UpdateByQueryRethrottle) WithErrorTrace() func(*UpdateByQueryRethrottleR
 func (f UpdateByQueryRethrottle) WithFilterPath(v ...string) func(*UpdateByQueryRethrottleRequest) {
 	return func(r *UpdateByQueryRethrottleRequest) {
 		r.FilterPath = v
+	}
+}
+
+// WithHeader adds the headers to the HTTP request
+//
+func (f UpdateByQueryRethrottle) WithHeader(h map[string]string) func(*UpdateByQueryRethrottleRequest) {
+	return func(r *UpdateByQueryRethrottleRequest) {
+		if r.Header == nil {
+			r.Header = make(http.Header)
+		}
+		for k, v := range h {
+			r.Header.Add(k, v)
+		}
 	}
 }

--- a/esapi/esapi_integration_test.go
+++ b/esapi/esapi_integration_test.go
@@ -5,6 +5,7 @@ package esapi_test
 import (
 	"encoding/json"
 	"fmt"
+	"strings"
 	"testing"
 	"time"
 
@@ -18,6 +19,7 @@ func TestAPI(t *testing.T) {
 			t.Fatalf("Error creating the client: %s\n", err)
 		}
 
+		es.Cluster.Health(es.Cluster.Health.WithWaitForStatus("yellow"))
 		res, err := es.Search(es.Search.WithTimeout(500 * time.Millisecond))
 		if err != nil {
 			t.Fatalf("Error getting the response: %s\n", err)
@@ -34,5 +36,26 @@ func TestAPI(t *testing.T) {
 			t.Fatalf("Error parsing the response: %s\n", err)
 		}
 		fmt.Printf("took=%vms\n", d["took"])
+	})
+
+	t.Run("Headers", func(t *testing.T) {
+		es, err := elasticsearch.NewDefaultClient()
+		if err != nil {
+			t.Fatalf("Error creating the client: %s\n", err)
+		}
+
+		res, err := es.Info(es.Info.WithHeader(map[string]string{"Accept": "application/yaml"}))
+		if err != nil {
+			t.Fatalf("Error getting the response: %s\n", err)
+		}
+		defer res.Body.Close()
+
+		if res.IsError() {
+			t.Fatalf("Error response: %s", res.String())
+		}
+
+		if !strings.HasPrefix(res.String(), "[200 OK] ---") {
+			t.Errorf("Unexpected response body: doesn't start with '[200 OK] ---'; %s", res.String())
+		}
 	})
 }

--- a/estransport/estransport.go
+++ b/estransport/estransport.go
@@ -86,8 +86,11 @@ func (c *Client) Perform(req *http.Request) (*http.Response, error) {
 	}
 
 	c.setURL(u, req)
-	c.setBasicAuth(u, req)
 	c.setUserAgent(req)
+
+	if _, ok := req.Header["Authorization"]; !ok {
+		c.setBasicAuth(u, req)
+	}
 
 	var dupReqBody *bytes.Buffer
 	if c.logger != nil && c.logger.RequestBodyEnabled() {

--- a/internal/cmd/generate/commands/gensource/generator.go
+++ b/internal/cmd/generate/commands/gensource/generator.go
@@ -711,9 +711,13 @@ func (r ` + g.Endpoint.MethodWithNamespace() + `Request) Do(ctx context.Context,
 	}
 
 	g.w(`if len(r.Header) > 0 {
-		for k, vv := range r.Header {
-			for _, v := range vv {
-				req.Header.Add(k, v)
+		if len(req.Header) == 0 {
+			req.Header = r.Header
+		} else {
+			for k, vv := range r.Header {
+				for _, v := range vv {
+					req.Header.Add(k, v)
+				}
 			}
 		}
 	}` + "\n\n")

--- a/internal/cmd/generate/commands/gensource/generator.go
+++ b/internal/cmd/generate/commands/gensource/generator.go
@@ -231,6 +231,8 @@ type ` + g.Endpoint.MethodWithNamespace() + `Request struct {`)
 	g.w("\n\tErrorTrace\tbool")
 	g.w("\n\tFilterPath\t[]string\n")
 
+	g.w("\n\n\tHeader\thttp.Header\n")
+
 	g.w("\n\tctx context.Context\n}\n")
 }
 
@@ -404,6 +406,22 @@ func (f ` + g.Endpoint.MethodWithNamespace() + `) WithErrorTrace() func(*` + g.E
 func (f ` + g.Endpoint.MethodWithNamespace() + `) WithFilterPath(v ...string) func(*` + g.Endpoint.MethodWithNamespace() + `Request) {
 	return func(r *` + g.Endpoint.MethodWithNamespace() + `Request) {
 		r.FilterPath = v
+	}
+}
+`)
+
+	// Generate methods for HTTP headers
+	g.w(`
+// WithHeader adds the headers to the HTTP request
+//
+func (f ` + g.Endpoint.MethodWithNamespace() + `) WithHeader(h map[string]string) func(*` + g.Endpoint.MethodWithNamespace() + `Request) {
+	return func(r *` + g.Endpoint.MethodWithNamespace() + `Request) {
+		if r.Header == nil {
+			r.Header = make(http.Header)
+		}
+		for k, v := range h {
+			r.Header.Add(k, v)
+		}
 	}
 }
 `)
@@ -691,6 +709,10 @@ func (r ` + g.Endpoint.MethodWithNamespace() + `Request) Do(ctx context.Context,
 		req.Header[headerContentType] = headerContentTypeJSON
 	}` + "\n\n")
 	}
+
+	g.w(`if len(r.Header) > 0 {
+		req.Header = r.Header
+	}` + "\n\n")
 
 	g.w(`if ctx != nil {
 		req = req.WithContext(ctx)

--- a/internal/cmd/generate/commands/gensource/generator.go
+++ b/internal/cmd/generate/commands/gensource/generator.go
@@ -711,7 +711,11 @@ func (r ` + g.Endpoint.MethodWithNamespace() + `Request) Do(ctx context.Context,
 	}
 
 	g.w(`if len(r.Header) > 0 {
-		req.Header = r.Header
+		for k, vv := range r.Header {
+			for _, v := range vv {
+				req.Header.Add(k, v)
+			}
+		}
 	}` + "\n\n")
 
 	g.w(`if ctx != nil {


### PR DESCRIPTION
This patch adds support for custom HTTP headers into API calls, like this:

```golang
es.Info(
	es.Info.WithHeader(map[string]string{
		"Accept": "application/yaml"},
	),
),
```

There's been some interest in a feature like this, historically, and also, the other official clients allow to set custom HTTP headers in one way or another. I've been postponing the implementation, because setting custom headers is possible by customizing the transport, and I wasn't sure about the performance implications.

However, in order to run the [Elasticsearch REST tests](https://github.com/elastic/elasticsearch/tree/master/rest-api-spec/src/main/resources/rest-api-spec/test), setting a header when creating the request is the least complicated way, and that's a compelling reason to add the support.

From a cursory benchmark comparison, it doesn't appear like it adds weight to the existing implementation, but I would like to double-check that.

Also, the `Header` struct field is lazy initialized in the `WithHeader()` method, and while in my mental calculation it should be concurrency safe, I need to triple-check that assumption.

The interface itself follows the path of "least surprise": the `WithHeader()` takes a `map[string]string`, and uses `(http.Header).Add()` to set the field values. The field itself is of type `http.Header`, so setting it directly involves something like this:

```golang
req := esapi.InfoRequest{}
req.Header = make(http.Header)
req.Header.Add("Accept", "application/yaml")
```

The implementation doesn't deal with conflicting headers yet, eg. when the client is configured with username/password, and the request `Authorization` header is set. I think the only "least surprising" approach is to make request headers take precedence.
