### PR TITLE
fix readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ cat > main.go <<-END
   }
 END
 
-go run main.go
+GO111MODULE="on" go run main.go
 ```
 
 


### PR DESCRIPTION
If you try out what's in README.md you'll run into this situation..

amsmac011:condor pathcl$ cat > go.mod <<-END
>   module my-elasticsearch-app
>
>   require github.com/elastic/go-elasticsearch/v8 master
> END

amsmac011:condor pathcl$ cat > main.go <<-END
>   package main
>
>   import (
>     "log"
>
>     "github.com/elastic/go-elasticsearch/v8"
>   )
>
>   func main() {
>     es, _ := elasticsearch.NewDefaultClient()
>     log.Println(elasticsearch.Version)
>     log.Println(es.Info())
>   }
> END

amsmac011:condor pathcl$ go run main.go
main.go:6:5: cannot find package "github.com/elastic/go-elasticsearch/v8" in any of:
	/usr/local/Cellar/go/1.12.6/libexec/src/github.com/elastic/go-elasticsearch/v8 (from $GOROOT)
	/Users/pathcl/go/src/github.com/elastic/go-elasticsearch/v8 (from $GOPATH)

that's why I added GO111MODULE="on"