### PR TITLE
Fix rule to parse for CloudID.

### DIFF
--- a/elasticsearch.go
+++ b/elasticsearch.go
@@ -161,7 +161,7 @@ func addrsToURLs(addrs []string) ([]*url.URL, error) {
 //
 func addrFromCloudID(input string) (string, error) {
 	var (
-		port   = 9243
+		port   = "9243"
 		scheme = "https://"
 	)
 
@@ -174,5 +174,10 @@ func addrFromCloudID(input string) (string, error) {
 		return "", err
 	}
 	parts := strings.Split(string(data), "$")
-	return fmt.Sprintf("%s%s.%s:%d", scheme, parts[1], parts[0], port), nil
+	host := parts[0]
+	idx := strings.LastIndex(host, ":")
+	if idx >= 0 {
+		host, port = host[:idx], host[idx+1:]
+	}
+	return fmt.Sprintf("%s%s.%s:%s", scheme, parts[1], host, port), nil
 }

--- a/elasticsearch_internal_test.go
+++ b/elasticsearch_internal_test.go
@@ -245,6 +245,19 @@ func TestCloudID(t *testing.T) {
 		}
 	})
 
+	t.Run("Parse(include port)", func(t *testing.T) {
+		input := "name:" + base64.StdEncoding.EncodeToString([]byte("host:9243$es$kibana"))
+		expected := "https://es.host:9243"
+
+		actual, err := addrFromCloudID(input)
+		if err != nil {
+			t.Errorf("Unexpected error: %s", err)
+		}
+		if actual != expected {
+			t.Errorf("Unexpected output, want=%q, got=%q", expected, actual)
+		}
+	})
+
 	t.Run("Invalid format", func(t *testing.T) {
 		input := "foobar"
 		_, err := addrFromCloudID(input)


### PR DESCRIPTION
Hi maintainer.
I have used this library with Elastic Cloud(ElasticSearch) recently.

And when I was connecting to Elastic Cloud(ElasticSearch) having GCP  backend in the Tokyo region, I used CloudID instead of an endpoint.

But I encountered an error having "invalid port".
First encountered  I don't understand this error, So I did look under the hood for troubleshooting this error.

And I found this error reason, and It is that CloudID made by GCP in the Tokyo region regardless of other backend had an odd pattern of a key.

A normal CloudID seems to a pattern like "cluster_name:base64 string", "base64 string" seems to a pattern like "host$number$number" after decode.
But "base64 string"(part of CloudID) made by GCP in the Tokyo region has a pattern "host:9243$number$number".

So I contacted the Elastic Cloud Support Center for resolving this issue.
After some days,  I was answered this issue resolve.

But I would say this library needs to defensive code which shouldn't occur an error for this issue.
Both Filebeat and Logstash have worked very well, even though this issue. 
I would say both Filebeat and Logstash seem to have a defensive code for this issue.

So I Suggest to this PR.

Thank you. 