### PR TITLE
Add token support for API calls

### DIFF
--- a/elasticsearch.go
+++ b/elasticsearch.go
@@ -30,7 +30,9 @@ type Config struct {
 	Password  string   // Password for HTTP Basic Authentication.
 
 	CloudID string // Endpoint for the Elastic Service (https://elastic.co/cloud).
-	APIKey  string // Base64-encoded token for authorization; if set, overrides username and password.
+
+	APIKey string // Base64-encoded token for authorization; if set, overrides username, password, and token
+	Token  string // Token used for authorization. if set, overrides username and password.
 
 	Transport http.RoundTripper  // The HTTP transport object.
 	Logger    estransport.Logger // The logger object.
@@ -110,7 +112,9 @@ func NewClient(cfg Config) (*Client, error) {
 		URLs:     urls,
 		Username: cfg.Username,
 		Password: cfg.Password,
-		APIKey:   cfg.APIKey,
+
+		APIKey: cfg.APIKey,
+		Token:  cfg.Token,
 
 		Transport: cfg.Transport,
 		Logger:    cfg.Logger,

--- a/estransport/estransport.go
+++ b/estransport/estransport.go
@@ -40,7 +40,9 @@ type Config struct {
 	URLs     []*url.URL
 	Username string
 	Password string
-	APIKey   string
+
+	APIKey string
+	Token  string
 
 	Transport http.RoundTripper
 	Logger    Logger
@@ -52,7 +54,9 @@ type Client struct {
 	urls     []*url.URL
 	username string
 	password string
-	apikey   string
+
+	apikey string
+	token  string
 
 	transport http.RoundTripper
 	selector  Selector
@@ -72,7 +76,9 @@ func New(cfg Config) *Client {
 		urls:     cfg.URLs,
 		username: cfg.Username,
 		password: cfg.Password,
-		apikey:   cfg.APIKey,
+
+		apikey: cfg.APIKey,
+		token:  cfg.Token,
 
 		transport: cfg.Transport,
 		selector:  NewRoundRobinSelector(cfg.URLs...),
@@ -163,6 +169,15 @@ func (c *Client) setAuthorization(u *url.URL, req *http.Request) *http.Request {
 			b.Grow(len("APIKey ") + len(c.apikey))
 			b.WriteString("APIKey ")
 			b.WriteString(c.apikey)
+			req.Header.Set("Authorization", b.String())
+			return req
+		}
+
+		if c.token != "" {
+			var b bytes.Buffer
+			b.Grow(len("Bearer ") + len(c.apikey))
+			b.WriteString("Bearer ")
+			b.WriteString(c.token)
 			req.Header.Set("Authorization", b.String())
 			return req
 		}


### PR DESCRIPTION
The context behind this PR is my desire to support token based authentication for API calls.

The following changes were made to support token authentication according to [token documentation](https://www.elastic.co/guide/en/elasticsearch/reference/current/security-api-get-token.html).

elasticsearch.go:
- Add Token field to elasticsearch.Config struct
- In function elasticsearch.NewClient, add Token field in call to estransport.New for initialization of variable tp

estransport/estransport.go
- Add Token field to estransport.Config struct
- Add token field to estransport.Client struct
- In function estransport.New, add token field to Client return
- In `func (c *Client) setAuthorization(u *url.URL, req *http.Request) *http.Request`, add logic supporting token headers similar what is done for apikey.