### PR TITLE
estransport: remove enableMetrics

### DIFF
--- a/estransport/metrics.go
+++ b/estransport/metrics.go
@@ -67,7 +67,7 @@ type metrics struct {
 // Metrics returns the transport metrics.
 //
 func (c *Client) Metrics() (Metrics, error) {
-	if !c.enableMetrics {
+	if c.metrics == nil {
 		return Metrics{}, errors.New("transport metrics not enabled")
 	}
 	c.metrics.RLock()


### PR DESCRIPTION
These fields are redundant, as you can check that metrics is non-nil.