### PR TITLE
Allow setting a custom ConnectionPool

### DIFF
--- a/elasticsearch.go
+++ b/elasticsearch.go
@@ -47,10 +47,12 @@ type Config struct {
 
 	RetryBackoff func(attempt int) time.Duration // Optional backoff duration. Default: nil.
 
-	ConnectionPool estransport.ConnectionPool // The connection pool object.
+	Transport http.RoundTripper    // The HTTP transport object.
+	Logger    estransport.Logger   // The logger object.
+	Selector  estransport.Selector // The selector object.
 
-	Transport http.RoundTripper  // The HTTP transport object.
-	Logger    estransport.Logger // The logger object.
+	// Optional constructor function for a custom ConnectionPool. Default: nil.
+	ConnectionPoolFunc func([]*estransport.Connection, estransport.Selector) estransport.ConnectionPool
 }
 
 // Client represents the Elasticsearch client.
@@ -138,9 +140,10 @@ func NewClient(cfg Config) (*Client, error) {
 		EnableMetrics:     cfg.EnableMetrics,
 		EnableDebugLogger: cfg.EnableDebugLogger,
 
-		ConnectionPool: cfg.ConnectionPool,
-		Transport:      cfg.Transport,
-		Logger:         cfg.Logger,
+		Transport:          cfg.Transport,
+		Logger:             cfg.Logger,
+		Selector:           cfg.Selector,
+		ConnectionPoolFunc: cfg.ConnectionPoolFunc,
 	})
 
 	return &Client{Transport: tp, API: esapi.New(tp)}, nil

--- a/elasticsearch.go
+++ b/elasticsearch.go
@@ -47,6 +47,8 @@ type Config struct {
 
 	RetryBackoff func(attempt int) time.Duration // Optional backoff duration. Default: nil.
 
+	ConnectionPool estransport.ConnectionPool // The connection pool object.
+
 	Transport http.RoundTripper  // The HTTP transport object.
 	Logger    estransport.Logger // The logger object.
 }
@@ -136,8 +138,9 @@ func NewClient(cfg Config) (*Client, error) {
 		EnableMetrics:     cfg.EnableMetrics,
 		EnableDebugLogger: cfg.EnableDebugLogger,
 
-		Transport: cfg.Transport,
-		Logger:    cfg.Logger,
+		ConnectionPool: cfg.ConnectionPool,
+		Transport:      cfg.Transport,
+		Logger:         cfg.Logger,
 	})
 
 	return &Client{Transport: tp, API: esapi.New(tp)}, nil

--- a/estransport/connection_benchmark_test.go
+++ b/estransport/connection_benchmark_test.go
@@ -24,9 +24,9 @@ func BenchmarkSingleConnectionPool(b *testing.B) {
 	b.ReportAllocs()
 
 	b.Run("Next()", func(b *testing.B) {
-		pool := newSingleConnectionPool(&url.URL{Scheme: "http", Host: "foo1"})
+		pool := &singleConnectionPool{connection: &Connection{URL: &url.URL{Scheme: "http", Host: "foo1"}}}
 
-		b.Run("Single    ", func(b *testing.B) {
+		b.Run("Single          ", func(b *testing.B) {
 			for i := 0; i < b.N; i++ {
 				_, err := pool.Next()
 				if err != nil {
@@ -48,14 +48,14 @@ func BenchmarkSingleConnectionPool(b *testing.B) {
 		})
 	})
 
-	b.Run("Remove()", func(b *testing.B) {
-		pool := newSingleConnectionPool(&url.URL{Scheme: "http", Host: "foo1"})
+	b.Run("OnFailure()", func(b *testing.B) {
+		pool := &singleConnectionPool{connection: &Connection{URL: &url.URL{Scheme: "http", Host: "foo1"}}}
 
-		b.Run("Single    ", func(b *testing.B) {
+		b.Run("Single     ", func(b *testing.B) {
 			c, _ := pool.Next()
 
 			for i := 0; i < b.N; i++ {
-				if err := pool.Remove(c); err != nil {
+				if err := pool.OnFailure(c); err != nil {
 					b.Errorf("Unexpected error: %v", err)
 				}
 			}
@@ -67,7 +67,7 @@ func BenchmarkSingleConnectionPool(b *testing.B) {
 				c, _ := pool.Next()
 
 				for pb.Next() {
-					if err := pool.Remove(c); err != nil {
+					if err := pool.OnFailure(c); err != nil {
 						b.Errorf("Unexpected error: %v", err)
 					}
 				}
@@ -79,15 +79,18 @@ func BenchmarkSingleConnectionPool(b *testing.B) {
 func BenchmarkRoundRobinConnectionPool(b *testing.B) {
 	b.ReportAllocs()
 
-	var urls []*url.URL
+	var conns []*Connection
 	for i := 0; i < 1000; i++ {
-		urls = append(urls, &url.URL{Scheme: "http", Host: fmt.Sprintf("foo%d", i)})
+		conns = append(conns, &Connection{URL: &url.URL{Scheme: "http", Host: fmt.Sprintf("foo%d", i)}})
 	}
 
 	b.Run("Next()", func(b *testing.B) {
-		pool := newRoundRobinConnectionPool(urls...)
+		pool := &roundRobinConnectionPool{
+			live:     conns,
+			selector: &roundRobinSelector{curr: -1},
+		}
 
-		b.Run("Single    ", func(b *testing.B) {
+		b.Run("Single     ", func(b *testing.B) {
 			for i := 0; i < b.N; i++ {
 				_, err := pool.Next()
 				if err != nil {
@@ -121,14 +124,20 @@ func BenchmarkRoundRobinConnectionPool(b *testing.B) {
 		})
 	})
 
-	b.Run("Remove()", func(b *testing.B) {
-		pool := newRoundRobinConnectionPool(urls...)
+	b.Run("OnFailure()", func(b *testing.B) {
+		pool := &roundRobinConnectionPool{
+			live:     conns,
+			selector: &roundRobinSelector{curr: -1},
+		}
 
-		b.Run("Single    ", func(b *testing.B) {
-			c, _ := pool.Next()
+		b.Run("Single     ", func(b *testing.B) {
+			c, err := pool.Next()
+			if err != nil {
+				b.Fatalf("Unexpected error: %s", err)
+			}
 
 			for i := 0; i < b.N; i++ {
-				if err := pool.Remove(c); err != nil {
+				if err := pool.OnFailure(c); err != nil {
 					b.Errorf("Unexpected error: %v", err)
 				}
 			}
@@ -137,10 +146,13 @@ func BenchmarkRoundRobinConnectionPool(b *testing.B) {
 		b.Run("Parallel (10)", func(b *testing.B) {
 			b.SetParallelism(10)
 			b.RunParallel(func(pb *testing.PB) {
-				c, _ := pool.Next()
+				c, err := pool.Next()
+				if err != nil {
+					b.Fatalf("Unexpected error: %s", err)
+				}
 
 				for pb.Next() {
-					if err := pool.Remove(c); err != nil {
+					if err := pool.OnFailure(c); err != nil {
 						b.Errorf("Unexpected error: %v", err)
 					}
 				}
@@ -150,10 +162,13 @@ func BenchmarkRoundRobinConnectionPool(b *testing.B) {
 		b.Run("Parallel (100)", func(b *testing.B) {
 			b.SetParallelism(100)
 			b.RunParallel(func(pb *testing.PB) {
-				c, _ := pool.Next()
+				c, err := pool.Next()
+				if err != nil {
+					b.Fatalf("Unexpected error: %s", err)
+				}
 
 				for pb.Next() {
-					if err := pool.Remove(c); err != nil {
+					if err := pool.OnFailure(c); err != nil {
 						b.Errorf("Unexpected error: %v", err)
 					}
 				}
@@ -161,30 +176,49 @@ func BenchmarkRoundRobinConnectionPool(b *testing.B) {
 		})
 	})
 
-	b.Run("Resurrect()", func(b *testing.B) {
-		pool := newRoundRobinConnectionPool(urls...)
+	b.Run("resurrect()", func(b *testing.B) {
+		pool := &roundRobinConnectionPool{
+			live:     conns,
+			selector: &roundRobinSelector{curr: -1},
+		}
 
-		b.Run("Single       ", func(b *testing.B) {
-			c, _ := pool.Next()
-			pool.Remove(c)
+		b.Run("Single", func(b *testing.B) {
+			c, err := pool.Next()
+			if err != nil {
+				b.Fatalf("Unexpected error: %s", err)
+			}
+			err = pool.OnFailure(c)
+			if err != nil {
+				b.Fatalf("Unexpected error: %s", err)
+			}
 
 			for i := 0; i < b.N; i++ {
-				if err := pool.Resurrect(c); err != nil {
+				pool.Lock()
+				if err := pool.resurrect(c, true); err != nil {
 					b.Errorf("Unexpected error: %v", err)
 				}
+				pool.Unlock()
 			}
 		})
 
 		b.Run("Parallel (10)", func(b *testing.B) {
 			b.SetParallelism(10)
 			b.RunParallel(func(pb *testing.PB) {
-				c, _ := pool.Next()
-				pool.Remove(c)
+				c, err := pool.Next()
+				if err != nil {
+					b.Fatalf("Unexpected error: %s", err)
+				}
+				err = pool.OnFailure(c)
+				if err != nil {
+					b.Fatalf("Unexpected error: %s", err)
+				}
 
 				for pb.Next() {
-					if err := pool.Resurrect(c); err != nil {
+					pool.Lock()
+					if err := pool.resurrect(c, true); err != nil {
 						b.Errorf("Unexpected error: %v", err)
 					}
+					pool.Unlock()
 				}
 			})
 		})
@@ -192,13 +226,21 @@ func BenchmarkRoundRobinConnectionPool(b *testing.B) {
 		b.Run("Parallel (100)", func(b *testing.B) {
 			b.SetParallelism(100)
 			b.RunParallel(func(pb *testing.PB) {
-				c, _ := pool.Next()
-				pool.Remove(c)
+				c, err := pool.Next()
+				if err != nil {
+					b.Fatalf("Unexpected error: %s", err)
+				}
+				err = pool.OnFailure(c)
+				if err != nil {
+					b.Fatalf("Unexpected error: %s", err)
+				}
 
 				for pb.Next() {
-					if err := pool.Resurrect(c); err != nil {
+					pool.Lock()
+					if err := pool.resurrect(c, true); err != nil {
 						b.Errorf("Unexpected error: %v", err)
 					}
+					pool.Unlock()
 				}
 			})
 		})

--- a/estransport/connection_internal_test.go
+++ b/estransport/connection_internal_test.go
@@ -14,7 +14,9 @@ import (
 
 func TestSingleConnectionPoolNext(t *testing.T) {
 	t.Run("Single URL", func(t *testing.T) {
-		pool := newSingleConnectionPool(&url.URL{Scheme: "http", Host: "foo1"})
+		pool := &singleConnectionPool{
+			connection: &Connection{URL: &url.URL{Scheme: "http", Host: "foo1"}},
+		}
 
 		for i := 0; i < 7; i++ {
 			c, err := pool.Next()
@@ -29,11 +31,13 @@ func TestSingleConnectionPoolNext(t *testing.T) {
 	})
 }
 
-func TestSingleConnectionPoolRemove(t *testing.T) {
+func TestSingleConnectionPoolOnFailure(t *testing.T) {
 	t.Run("Noop", func(t *testing.T) {
-		pool := newSingleConnectionPool(&url.URL{Scheme: "http", Host: "foo1"})
+		pool := &singleConnectionPool{
+			connection: &Connection{URL: &url.URL{Scheme: "http", Host: "foo1"}},
+		}
 
-		if err := pool.Remove(&Connection{URL: &url.URL{Scheme: "http", Host: "foo1"}}); err != nil {
+		if err := pool.OnFailure(&Connection{URL: &url.URL{Scheme: "http", Host: "foo1"}}); err != nil {
 			t.Errorf("Unexpected error: %s", err)
 		}
 	})
@@ -41,7 +45,7 @@ func TestSingleConnectionPoolRemove(t *testing.T) {
 
 func TestRoundRobinConnectionPoolNext(t *testing.T) {
 	t.Run("No URL", func(t *testing.T) {
-		pool := newRoundRobinConnectionPool()
+		pool := &roundRobinConnectionPool{}
 
 		c, err := pool.Next()
 		if err == nil {
@@ -52,11 +56,16 @@ func TestRoundRobinConnectionPoolNext(t *testing.T) {
 	t.Run("Two URLs", func(t *testing.T) {
 		var c *Connection
 
-		pool := newRoundRobinConnectionPool(
-			&url.URL{Scheme: "http", Host: "foo1"},
-			&url.URL{Scheme: "http", Host: "foo2"})
+		pool := &roundRobinConnectionPool{
+			live: []*Connection{
+				&Connection{URL: &url.URL{Scheme: "http", Host: "foo1"}},
+				&Connection{URL: &url.URL{Scheme: "http", Host: "foo2"}},
+			},
+			selector: &roundRobinSelector{curr: -1},
+		}
 
 		c, _ = pool.Next()
+
 		if c.URL.String() != "http://foo1" {
 			t.Errorf("Unexpected URL, want=foo1, got=%s", c.URL)
 		}
@@ -73,10 +82,14 @@ func TestRoundRobinConnectionPoolNext(t *testing.T) {
 	})
 
 	t.Run("Three URLs", func(t *testing.T) {
-		pool := newRoundRobinConnectionPool(
-			&url.URL{Scheme: "http", Host: "foo1"},
-			&url.URL{Scheme: "http", Host: "foo2"},
-			&url.URL{Scheme: "http", Host: "foo3"})
+		pool := &roundRobinConnectionPool{
+			live: []*Connection{
+				&Connection{URL: &url.URL{Scheme: "http", Host: "foo1"}},
+				&Connection{URL: &url.URL{Scheme: "http", Host: "foo2"}},
+				&Connection{URL: &url.URL{Scheme: "http", Host: "foo3"}},
+			},
+			selector: &roundRobinSelector{curr: -1},
+		}
 
 		var expected string
 		for i := 0; i < 11; i++ {
@@ -110,6 +123,7 @@ func TestRoundRobinConnectionPoolNext(t *testing.T) {
 				&Connection{URL: &url.URL{Scheme: "http", Host: "foo1"}, Failures: 3},
 				&Connection{URL: &url.URL{Scheme: "http", Host: "foo2"}, Failures: 1},
 			},
+			selector: &roundRobinSelector{curr: -1},
 		}
 
 		c, err := pool.Next()
@@ -125,7 +139,7 @@ func TestRoundRobinConnectionPoolNext(t *testing.T) {
 			t.Errorf("Expected <http://foo2>, got: %s", c.URL.String())
 		}
 
-		if c.Dead {
+		if c.IsDead {
 			t.Errorf("Expected connection to be live, got: %s", c)
 		}
 
@@ -137,36 +151,9 @@ func TestRoundRobinConnectionPoolNext(t *testing.T) {
 			t.Errorf("Expected 1 connection in dead list, got: %s", pool.dead)
 		}
 	})
-
-	t.Run("Cut off the index", func(t *testing.T) {
-		pool := &roundRobinConnectionPool{
-			curr: 99,
-			live: []*Connection{
-				&Connection{URL: &url.URL{Scheme: "http", Host: "foo1"}},
-				&Connection{URL: &url.URL{Scheme: "http", Host: "foo2"}},
-				&Connection{URL: &url.URL{Scheme: "http", Host: "foo3"}},
-				&Connection{URL: &url.URL{Scheme: "http", Host: "foo4"}},
-			},
-		}
-
-		c, err := pool.Next()
-		if err != nil {
-			t.Fatalf("Unexpected error: %s", err)
-		}
-
-		// Return first connection
-		if c.URL.String() != "http://foo1" {
-			t.Errorf("Expected http://foo1, got: %s", c.URL.String())
-		}
-
-		// Reset the index; (cp.curr + 1) % len(cp.live)
-		if pool.curr != 0 {
-			t.Errorf("Expected curr to be 0, got: %d", pool.curr)
-		}
-	})
 }
 
-func TestRoundRobinConnectionPoolRemove(t *testing.T) {
+func TestRoundRobinConnectionPoolOnFailure(t *testing.T) {
 	t.Run("Remove connection, mark it, and sort dead connections", func(t *testing.T) {
 		pool := &roundRobinConnectionPool{
 			live: []*Connection{
@@ -177,15 +164,16 @@ func TestRoundRobinConnectionPoolRemove(t *testing.T) {
 				&Connection{URL: &url.URL{Scheme: "http", Host: "foo3"}, Failures: 0},
 				&Connection{URL: &url.URL{Scheme: "http", Host: "foo4"}, Failures: 99},
 			},
+			selector: &roundRobinSelector{curr: -1},
 		}
 
 		conn := pool.live[0]
 
-		if err := pool.Remove(conn); err != nil {
+		if err := pool.OnFailure(conn); err != nil {
 			t.Fatalf("Unexpected error: %s", err)
 		}
 
-		if !conn.Dead {
+		if !conn.IsDead {
 			t.Errorf("Expected the connection to be dead; %s", conn)
 		}
 
@@ -211,15 +199,19 @@ func TestRoundRobinConnectionPoolRemove(t *testing.T) {
 	})
 
 	t.Run("Short circuit when the connection is already dead", func(t *testing.T) {
-		pool := newRoundRobinConnectionPool(
-			&url.URL{Scheme: "http", Host: "foo1"},
-			&url.URL{Scheme: "http", Host: "foo2"},
-			&url.URL{Scheme: "http", Host: "foo3"})
+		pool := &roundRobinConnectionPool{
+			live: []*Connection{
+				&Connection{URL: &url.URL{Scheme: "http", Host: "foo1"}},
+				&Connection{URL: &url.URL{Scheme: "http", Host: "foo2"}},
+				&Connection{URL: &url.URL{Scheme: "http", Host: "foo3"}},
+			},
+			selector: &roundRobinSelector{curr: -1},
+		}
 
 		conn := pool.live[0]
-		conn.Dead = true
+		conn.IsDead = true
 
-		if err := pool.Remove(conn); err != nil {
+		if err := pool.OnFailure(conn); err != nil {
 			t.Fatalf("Unexpected error: %s", err)
 		}
 
@@ -227,49 +219,23 @@ func TestRoundRobinConnectionPoolRemove(t *testing.T) {
 			t.Errorf("Expected the dead list to be empty, got: %s", pool.dead)
 		}
 	})
-
-	t.Run("Short circuit when the connection is already removed from live list", func(t *testing.T) {
-		pool := newRoundRobinConnectionPool(
-			&url.URL{Scheme: "http", Host: "foo1"},
-			&url.URL{Scheme: "http", Host: "foo2"},
-			&url.URL{Scheme: "http", Host: "foo3"})
-
-		conn := pool.live[0]
-
-		// Remove connection manually
-		index := 0
-		copy(pool.live[index:], pool.live[index+1:])
-		pool.live = pool.live[:len(pool.live)-1]
-
-		if err := pool.Remove(conn); err != nil {
-			t.Fatalf("Unexpected error: %s", err)
-		}
-
-		if len(pool.live) != 2 {
-			t.Errorf("Expected 2 live connections, got: %s", pool.live)
-		}
-
-		if len(pool.dead) != 1 {
-			t.Logf("pool.dead: %s", pool.dead)
-			t.Errorf("Expected 1 dead connection, got: %s", pool.dead)
-		}
-	})
 }
 
 func TestRoundRobinConnectionPoolResurrect(t *testing.T) {
 	t.Run("Mark the connection as dead and add/remove it to the lists", func(t *testing.T) {
 		pool := &roundRobinConnectionPool{
-			live: []*Connection{},
-			dead: []*Connection{&Connection{URL: &url.URL{Scheme: "http", Host: "foo1"}, Dead: true}},
+			live:     []*Connection{},
+			dead:     []*Connection{&Connection{URL: &url.URL{Scheme: "http", Host: "foo1"}, IsDead: true}},
+			selector: &roundRobinSelector{curr: -1},
 		}
 
 		conn := pool.dead[0]
 
-		if err := pool.Resurrect(conn); err != nil {
+		if err := pool.resurrect(conn, true); err != nil {
 			t.Fatalf("Unexpected error: %s", err)
 		}
 
-		if conn.Dead {
+		if conn.IsDead {
 			t.Errorf("Expected connection to be dead, got: %s", conn)
 		}
 
@@ -282,32 +248,15 @@ func TestRoundRobinConnectionPoolResurrect(t *testing.T) {
 		}
 	})
 
-	t.Run("Short circuit when the connection is already marked as live", func(t *testing.T) {
-		pool := &roundRobinConnectionPool{}
-
-		conn := &Connection{URL: &url.URL{Scheme: "http", Host: "foo1"}, Dead: false}
-
-		if err := pool.Resurrect(conn); err != nil {
-			t.Fatalf("Unexpected error: %s", err)
-		}
-
-		if len(pool.live) != 0 {
-			t.Errorf("Expected no live connections, got: %s", pool.live)
-		}
-
-		if len(pool.dead) != 0 {
-			t.Errorf("Expected no dead connections, got: %s", pool.dead)
-		}
-	})
-
 	t.Run("Short circuit removal when the connection is not in the dead list", func(t *testing.T) {
 		pool := &roundRobinConnectionPool{
-			dead: []*Connection{&Connection{URL: &url.URL{Scheme: "http", Host: "bar"}, Dead: true}},
+			dead:     []*Connection{&Connection{URL: &url.URL{Scheme: "http", Host: "bar"}, IsDead: true}},
+			selector: &roundRobinSelector{curr: -1},
 		}
 
-		conn := &Connection{URL: &url.URL{Scheme: "http", Host: "foo1"}, Dead: true}
+		conn := &Connection{URL: &url.URL{Scheme: "http", Host: "foo1"}, IsDead: true}
 
-		if err := pool.Resurrect(conn); err != nil {
+		if err := pool.resurrect(conn, true); err != nil {
 			t.Fatalf("Unexpected error: %s", err)
 		}
 
@@ -330,10 +279,11 @@ func TestRoundRobinConnectionPoolResurrect(t *testing.T) {
 				&Connection{
 					URL:       &url.URL{Scheme: "http", Host: "foo1"},
 					Failures:  100,
-					Dead:      true,
+					IsDead:    true,
 					DeadSince: time.Now().UTC(),
 				},
 			},
+			selector: &roundRobinSelector{curr: -1},
 		}
 
 		conn := pool.dead[0]

--- a/estransport/estransport.go
+++ b/estransport/estransport.go
@@ -57,6 +57,8 @@ type Config struct {
 	MaxRetries           int
 	RetryBackoff         func(attempt int) time.Duration
 
+	ConnectionPool ConnectionPool
+
 	EnableMetrics     bool
 	EnableDebugLogger bool
 
@@ -106,10 +108,14 @@ func New(cfg Config) *Client {
 	}
 
 	var pool ConnectionPool
-	if len(cfg.URLs) == 1 {
-		pool = newSingleConnectionPool(cfg.URLs[0])
+	if cfg.ConnectionPool != nil {
+		pool = cfg.ConnectionPool
 	} else {
-		pool = newRoundRobinConnectionPool(cfg.URLs...)
+		if len(cfg.URLs) == 1 {
+			pool = newSingleConnectionPool(cfg.URLs[0])
+		} else {
+			pool = newRoundRobinConnectionPool(cfg.URLs...)
+		}
 	}
 
 	client := Client{


### PR DESCRIPTION
This is a draft of the initial support for using a custom connection pool implementation.

Note that the implementation should take the suggestions in https://github.com/elastic/go-elasticsearch/pull/99#discussion_r341083088 into account.