### PR TITLE
[README] Add missing res.Body.Close()

### DIFF
--- a/README.md
+++ b/README.md
@@ -187,6 +187,7 @@ func main() {
   if err != nil {
     log.Fatalf("Error getting response: %s", err)
   }
+  defer res.Body.Close()
   // Check response status
   if res.IsError() {
     log.Fatalf("Error: %s", res.String())


### PR DESCRIPTION
This is a minor change to the readme file that adds a missing res.Body.Close().