### PR TITLE
Util: Fix for writeMeta in BulkIndexer helper

### DIFF
--- a/esutil/bulk_indexer.go
+++ b/esutil/bulk_indexer.go
@@ -393,6 +393,15 @@ func (w *worker) writeMeta(item BulkIndexerItem) error {
 		w.buf.Write(w.aux)
 		w.aux = w.aux[:0]
 	}
+	if item.Index != "" {
+		if item.DocumentID != "" {
+			w.buf.WriteRune(',')
+		}
+		w.buf.WriteString(`"_index":`)
+		w.aux = strconv.AppendQuote(w.aux, item.Index)
+		w.buf.Write(w.aux)
+		w.aux = w.aux[:0]
+	}
 	w.buf.WriteRune('}')
 	w.buf.WriteRune('}')
 	w.buf.WriteRune('\n')


### PR DESCRIPTION
This fix adds '_index' to meta when BulkIndexerItem.Index is not empty.

Currently, this value was ignored which leads to index errors when the
default index in BulkIndexerConfig.Index is empty.