### PR TITLE
Scroll id in the body instead of query

### DIFF
--- a/esapi/api.dangling_indices.delete_dangling_index.go
+++ b/esapi/api.dangling_indices.delete_dangling_index.go
@@ -16,7 +16,7 @@ import (
 
 func newDanglingIndicesDeleteDanglingIndexFunc(t Transport) DanglingIndicesDeleteDanglingIndex {
 	return func(index_uuid string, o ...func(*DanglingIndicesDeleteDanglingIndexRequest)) (*Response, error) {
-		var r = DanglingIndicesDeleteDanglingIndexRequest{IndexUuid: index_uuid}
+		var r = DanglingIndicesDeleteDanglingIndexRequest{IndexUUID: index_uuid}
 		for _, f := range o {
 			f(&r)
 		}
@@ -35,7 +35,7 @@ type DanglingIndicesDeleteDanglingIndex func(index_uuid string, o ...func(*Dangl
 // DanglingIndicesDeleteDanglingIndexRequest configures the Dangling Indices Delete Dangling Index API request.
 //
 type DanglingIndicesDeleteDanglingIndexRequest struct {
-	IndexUuid string
+	IndexUUID string
 
 	AcceptDataLoss *bool
 	MasterTimeout  time.Duration
@@ -62,11 +62,11 @@ func (r DanglingIndicesDeleteDanglingIndexRequest) Do(ctx context.Context, trans
 
 	method = "DELETE"
 
-	path.Grow(1 + len("_dangling") + 1 + len(r.IndexUuid))
+	path.Grow(1 + len("_dangling") + 1 + len(r.IndexUUID))
 	path.WriteString("/")
 	path.WriteString("_dangling")
 	path.WriteString("/")
-	path.WriteString(r.IndexUuid)
+	path.WriteString(r.IndexUUID)
 
 	params = make(map[string]string)
 

--- a/esapi/api.dangling_indices.import_dangling_index.go
+++ b/esapi/api.dangling_indices.import_dangling_index.go
@@ -16,7 +16,7 @@ import (
 
 func newDanglingIndicesImportDanglingIndexFunc(t Transport) DanglingIndicesImportDanglingIndex {
 	return func(index_uuid string, o ...func(*DanglingIndicesImportDanglingIndexRequest)) (*Response, error) {
-		var r = DanglingIndicesImportDanglingIndexRequest{IndexUuid: index_uuid}
+		var r = DanglingIndicesImportDanglingIndexRequest{IndexUUID: index_uuid}
 		for _, f := range o {
 			f(&r)
 		}
@@ -35,7 +35,7 @@ type DanglingIndicesImportDanglingIndex func(index_uuid string, o ...func(*Dangl
 // DanglingIndicesImportDanglingIndexRequest configures the Dangling Indices Import Dangling Index API request.
 //
 type DanglingIndicesImportDanglingIndexRequest struct {
-	IndexUuid string
+	IndexUUID string
 
 	AcceptDataLoss *bool
 	MasterTimeout  time.Duration
@@ -62,11 +62,11 @@ func (r DanglingIndicesImportDanglingIndexRequest) Do(ctx context.Context, trans
 
 	method = "POST"
 
-	path.Grow(1 + len("_dangling") + 1 + len(r.IndexUuid))
+	path.Grow(1 + len("_dangling") + 1 + len(r.IndexUUID))
 	path.WriteString("/")
 	path.WriteString("_dangling")
 	path.WriteString("/")
-	path.WriteString(r.IndexUuid)
+	path.WriteString(r.IndexUUID)
 
 	params = make(map[string]string)
 

--- a/esapi/api.scroll.go
+++ b/esapi/api.scroll.go
@@ -62,7 +62,7 @@ func (r ScrollRequest) Do(ctx context.Context, transport Transport) (*Response, 
 		params map[string]string
 	)
 
-	method = "GET"
+	method = "POST"
 
 	path.Grow(len("/_search/scroll"))
 	path.WriteString("/_search/scroll")

--- a/esapi/api.scroll.go
+++ b/esapi/api.scroll.go
@@ -7,7 +7,9 @@
 package esapi
 
 import (
+	"bytes"
 	"context"
+	"encoding/json"
 	"io"
 	"net/http"
 	"strconv"
@@ -97,17 +99,14 @@ func (r ScrollRequest) Do(ctx context.Context, transport Transport) (*Response, 
 		params["filter_path"] = strings.Join(r.FilterPath, ",")
 	}
 
+	if len(params) > 0 {
+		_data, _ := json.Marshal(params)
+		r.Body = bytes.NewReader(_data)
+	}
+
 	req, err := newRequest(method, path.String(), r.Body)
 	if err != nil {
 		return nil, err
-	}
-
-	if len(params) > 0 {
-		q := req.URL.Query()
-		for k, v := range params {
-			q.Set(k, v)
-		}
-		req.URL.RawQuery = q.Encode()
 	}
 
 	if r.Body != nil {


### PR DESCRIPTION
This fix by the issue https://github.com/elastic/go-elasticsearch/issues/166
made by example in the documentation https://www.elastic.co/guide/en/elasticsearch/reference/6.8/search-request-scroll.html. 
The scroll should be the post method and the scroll id should be in the body.