### PR TITLE
Expose individual apis

### DIFF
--- a/esapi/api._.go
+++ b/esapi/api._.go
@@ -1,4 +1,4 @@
-// Code generated from specification version 8.0.0 (785a91c1e3f): DO NOT EDIT
+// Code generated from specification version 8.0.0 (0fd6a17aa17f73a9f981394b0a224c3afec57e90): DO NOT EDIT
 
 package esapi
 
@@ -141,6 +141,38 @@ type Cat struct {
 	Transforms           CatTransforms
 }
 
+// NewCat creates a new API client for Cat APIs
+//
+func NewCat(t Transport) *Cat {
+	return &Cat{
+		Aliases:              newCatAliasesFunc(t),
+		Allocation:           newCatAllocationFunc(t),
+		Count:                newCatCountFunc(t),
+		Fielddata:            newCatFielddataFunc(t),
+		Health:               newCatHealthFunc(t),
+		Help:                 newCatHelpFunc(t),
+		Indices:              newCatIndicesFunc(t),
+		MLDataFrameAnalytics: newCatMLDataFrameAnalyticsFunc(t),
+		MLDatafeeds:          newCatMLDatafeedsFunc(t),
+		MLJobs:               newCatMLJobsFunc(t),
+		MLTrainedModels:      newCatMLTrainedModelsFunc(t),
+		Master:               newCatMasterFunc(t),
+		Nodeattrs:            newCatNodeattrsFunc(t),
+		Nodes:                newCatNodesFunc(t),
+		PendingTasks:         newCatPendingTasksFunc(t),
+		Plugins:              newCatPluginsFunc(t),
+		Recovery:             newCatRecoveryFunc(t),
+		Repositories:         newCatRepositoriesFunc(t),
+		Segments:             newCatSegmentsFunc(t),
+		Shards:               newCatShardsFunc(t),
+		Snapshots:            newCatSnapshotsFunc(t),
+		Tasks:                newCatTasksFunc(t),
+		Templates:            newCatTemplatesFunc(t),
+		ThreadPool:           newCatThreadPoolFunc(t),
+		Transforms:           newCatTransformsFunc(t),
+	}
+}
+
 // Cluster contains the Cluster APIs
 type Cluster struct {
 	AllocationExplain            ClusterAllocationExplain
@@ -158,6 +190,28 @@ type Cluster struct {
 	Reroute                      ClusterReroute
 	State                        ClusterState
 	Stats                        ClusterStats
+}
+
+// NewCluster creates a new API client for Cluster APIs
+//
+func NewCluster(t Transport) *Cluster {
+	return &Cluster{
+		AllocationExplain:            newClusterAllocationExplainFunc(t),
+		DeleteComponentTemplate:      newClusterDeleteComponentTemplateFunc(t),
+		DeleteVotingConfigExclusions: newClusterDeleteVotingConfigExclusionsFunc(t),
+		ExistsComponentTemplate:      newClusterExistsComponentTemplateFunc(t),
+		GetComponentTemplate:         newClusterGetComponentTemplateFunc(t),
+		GetSettings:                  newClusterGetSettingsFunc(t),
+		Health:                       newClusterHealthFunc(t),
+		PendingTasks:                 newClusterPendingTasksFunc(t),
+		PostVotingConfigExclusions:   newClusterPostVotingConfigExclusionsFunc(t),
+		PutComponentTemplate:         newClusterPutComponentTemplateFunc(t),
+		PutSettings:                  newClusterPutSettingsFunc(t),
+		RemoteInfo:                   newClusterRemoteInfoFunc(t),
+		Reroute:                      newClusterRerouteFunc(t),
+		State:                        newClusterStateFunc(t),
+		Stats:                        newClusterStatsFunc(t),
+	}
 }
 
 // Indices contains the Indices APIs
@@ -216,6 +270,65 @@ type Indices struct {
 	ValidateQuery         IndicesValidateQuery
 }
 
+// NewIndices creates a new API client for Indices APIs
+//
+func NewIndices(t Transport) *Indices {
+	return &Indices{
+		AddBlock:              newIndicesAddBlockFunc(t),
+		Analyze:               newIndicesAnalyzeFunc(t),
+		ClearCache:            newIndicesClearCacheFunc(t),
+		Clone:                 newIndicesCloneFunc(t),
+		Close:                 newIndicesCloseFunc(t),
+		CreateDataStream:      newIndicesCreateDataStreamFunc(t),
+		Create:                newIndicesCreateFunc(t),
+		DataStreamsStats:      newIndicesDataStreamsStatsFunc(t),
+		DeleteAlias:           newIndicesDeleteAliasFunc(t),
+		DeleteDataStream:      newIndicesDeleteDataStreamFunc(t),
+		DeleteIndexTemplate:   newIndicesDeleteIndexTemplateFunc(t),
+		Delete:                newIndicesDeleteFunc(t),
+		DeleteTemplate:        newIndicesDeleteTemplateFunc(t),
+		ExistsAlias:           newIndicesExistsAliasFunc(t),
+		ExistsDocumentType:    newIndicesExistsDocumentTypeFunc(t),
+		ExistsIndexTemplate:   newIndicesExistsIndexTemplateFunc(t),
+		Exists:                newIndicesExistsFunc(t),
+		ExistsTemplate:        newIndicesExistsTemplateFunc(t),
+		Flush:                 newIndicesFlushFunc(t),
+		Forcemerge:            newIndicesForcemergeFunc(t),
+		Freeze:                newIndicesFreezeFunc(t),
+		GetAlias:              newIndicesGetAliasFunc(t),
+		GetDataStream:         newIndicesGetDataStreamFunc(t),
+		GetFieldMapping:       newIndicesGetFieldMappingFunc(t),
+		GetIndexTemplate:      newIndicesGetIndexTemplateFunc(t),
+		GetMapping:            newIndicesGetMappingFunc(t),
+		Get:                   newIndicesGetFunc(t),
+		GetSettings:           newIndicesGetSettingsFunc(t),
+		GetTemplate:           newIndicesGetTemplateFunc(t),
+		GetUpgrade:            newIndicesGetUpgradeFunc(t),
+		Open:                  newIndicesOpenFunc(t),
+		PutAlias:              newIndicesPutAliasFunc(t),
+		PutIndexTemplate:      newIndicesPutIndexTemplateFunc(t),
+		PutMapping:            newIndicesPutMappingFunc(t),
+		PutSettings:           newIndicesPutSettingsFunc(t),
+		PutTemplate:           newIndicesPutTemplateFunc(t),
+		Recovery:              newIndicesRecoveryFunc(t),
+		Refresh:               newIndicesRefreshFunc(t),
+		ReloadSearchAnalyzers: newIndicesReloadSearchAnalyzersFunc(t),
+		ResolveIndex:          newIndicesResolveIndexFunc(t),
+		Rollover:              newIndicesRolloverFunc(t),
+		Segments:              newIndicesSegmentsFunc(t),
+		ShardStores:           newIndicesShardStoresFunc(t),
+		Shrink:                newIndicesShrinkFunc(t),
+		SimulateIndexTemplate: newIndicesSimulateIndexTemplateFunc(t),
+		SimulateTemplate:      newIndicesSimulateTemplateFunc(t),
+		Split:                 newIndicesSplitFunc(t),
+		Stats:                 newIndicesStatsFunc(t),
+		Unfreeze:              newIndicesUnfreezeFunc(t),
+		UpdateAliases:         newIndicesUpdateAliasesFunc(t),
+		Upgrade:               newIndicesUpgradeFunc(t),
+		ValidateQuery:         newIndicesValidateQueryFunc(t),
+	}
+}
+
 // Ingest contains the Ingest APIs
 type Ingest struct {
 	DeletePipeline IngestDeletePipeline
@@ -223,6 +336,18 @@ type Ingest struct {
 	ProcessorGrok  IngestProcessorGrok
 	PutPipeline    IngestPutPipeline
 	Simulate       IngestSimulate
+}
+
+// NewIngest creates a new API client for Ingest APIs
+//
+func NewIngest(t Transport) *Ingest {
+	return &Ingest{
+		DeletePipeline: newIngestDeletePipelineFunc(t),
+		GetPipeline:    newIngestGetPipelineFunc(t),
+		ProcessorGrok:  newIngestProcessorGrokFunc(t),
+		PutPipeline:    newIngestPutPipelineFunc(t),
+		Simulate:       newIngestSimulateFunc(t),
+	}
 }
 
 // Nodes contains the Nodes APIs
@@ -234,8 +359,26 @@ type Nodes struct {
 	Usage                NodesUsage
 }
 
+// NewNodes creates a new API client for Nodes APIs
+//
+func NewNodes(t Transport) *Nodes {
+	return &Nodes{
+		HotThreads:           newNodesHotThreadsFunc(t),
+		Info:                 newNodesInfoFunc(t),
+		ReloadSecureSettings: newNodesReloadSecureSettingsFunc(t),
+		Stats:                newNodesStatsFunc(t),
+		Usage:                newNodesUsageFunc(t),
+	}
+}
+
 // Remote contains the Remote APIs
 type Remote struct {
+}
+
+// NewRemote creates a new API client for Remote APIs
+//
+func NewRemote(t Transport) *Remote {
+	return &Remote{}
 }
 
 // Snapshot contains the Snapshot APIs
@@ -252,6 +395,23 @@ type Snapshot struct {
 	VerifyRepository  SnapshotVerifyRepository
 }
 
+// NewSnapshot creates a new API client for Snapshot APIs
+//
+func NewSnapshot(t Transport) *Snapshot {
+	return &Snapshot{
+		CleanupRepository: newSnapshotCleanupRepositoryFunc(t),
+		CreateRepository:  newSnapshotCreateRepositoryFunc(t),
+		Create:            newSnapshotCreateFunc(t),
+		DeleteRepository:  newSnapshotDeleteRepositoryFunc(t),
+		Delete:            newSnapshotDeleteFunc(t),
+		GetRepository:     newSnapshotGetRepositoryFunc(t),
+		Get:               newSnapshotGetFunc(t),
+		Restore:           newSnapshotRestoreFunc(t),
+		Status:            newSnapshotStatusFunc(t),
+		VerifyRepository:  newSnapshotVerifyRepositoryFunc(t),
+	}
+}
+
 // Tasks contains the Tasks APIs
 type Tasks struct {
 	Cancel TasksCancel
@@ -259,11 +419,31 @@ type Tasks struct {
 	List   TasksList
 }
 
+// NewTasks creates a new API client for Tasks APIs
+//
+func NewTasks(t Transport) *Tasks {
+	return &Tasks{
+		Cancel: newTasksCancelFunc(t),
+		Get:    newTasksGetFunc(t),
+		List:   newTasksListFunc(t),
+	}
+}
+
 // AsyncSearch contains the AsyncSearch APIs
 type AsyncSearch struct {
 	Delete AsyncSearchDelete
 	Get    AsyncSearchGet
 	Submit AsyncSearchSubmit
+}
+
+// NewAsyncSearch creates a new API client for AsyncSearch APIs
+//
+func NewAsyncSearch(t Transport) *AsyncSearch {
+	return &AsyncSearch{
+		Delete: newAsyncSearchDeleteFunc(t),
+		Get:    newAsyncSearchGetFunc(t),
+		Submit: newAsyncSearchSubmitFunc(t),
+	}
 }
 
 // CCR contains the CCR APIs
@@ -283,6 +463,26 @@ type CCR struct {
 	Unfollow                CCRUnfollow
 }
 
+// NewCCR creates a new API client for CCR APIs
+//
+func NewCCR(t Transport) *CCR {
+	return &CCR{
+		DeleteAutoFollowPattern: newCCRDeleteAutoFollowPatternFunc(t),
+		FollowInfo:              newCCRFollowInfoFunc(t),
+		Follow:                  newCCRFollowFunc(t),
+		FollowStats:             newCCRFollowStatsFunc(t),
+		ForgetFollower:          newCCRForgetFollowerFunc(t),
+		GetAutoFollowPattern:    newCCRGetAutoFollowPatternFunc(t),
+		PauseAutoFollowPattern:  newCCRPauseAutoFollowPatternFunc(t),
+		PauseFollow:             newCCRPauseFollowFunc(t),
+		PutAutoFollowPattern:    newCCRPutAutoFollowPatternFunc(t),
+		ResumeAutoFollowPattern: newCCRResumeAutoFollowPatternFunc(t),
+		ResumeFollow:            newCCRResumeFollowFunc(t),
+		Stats:                   newCCRStatsFunc(t),
+		Unfollow:                newCCRUnfollowFunc(t),
+	}
+}
+
 // ILM contains the ILM APIs
 type ILM struct {
 	DeleteLifecycle  ILMDeleteLifecycle
@@ -297,6 +497,23 @@ type ILM struct {
 	Stop             ILMStop
 }
 
+// NewILM creates a new API client for ILM APIs
+//
+func NewILM(t Transport) *ILM {
+	return &ILM{
+		DeleteLifecycle:  newILMDeleteLifecycleFunc(t),
+		ExplainLifecycle: newILMExplainLifecycleFunc(t),
+		GetLifecycle:     newILMGetLifecycleFunc(t),
+		GetStatus:        newILMGetStatusFunc(t),
+		MoveToStep:       newILMMoveToStepFunc(t),
+		PutLifecycle:     newILMPutLifecycleFunc(t),
+		RemovePolicy:     newILMRemovePolicyFunc(t),
+		Retry:            newILMRetryFunc(t),
+		Start:            newILMStartFunc(t),
+		Stop:             newILMStopFunc(t),
+	}
+}
+
 // License contains the License APIs
 type License struct {
 	Delete         LicenseDelete
@@ -308,9 +525,31 @@ type License struct {
 	PostStartTrial LicensePostStartTrial
 }
 
+// NewLicense creates a new API client for License APIs
+//
+func NewLicense(t Transport) *License {
+	return &License{
+		Delete:         newLicenseDeleteFunc(t),
+		GetBasicStatus: newLicenseGetBasicStatusFunc(t),
+		Get:            newLicenseGetFunc(t),
+		GetTrialStatus: newLicenseGetTrialStatusFunc(t),
+		Post:           newLicensePostFunc(t),
+		PostStartBasic: newLicensePostStartBasicFunc(t),
+		PostStartTrial: newLicensePostStartTrialFunc(t),
+	}
+}
+
 // Migration contains the Migration APIs
 type Migration struct {
 	Deprecations MigrationDeprecations
+}
+
+// NewMigration creates a new API client for Migration APIs
+//
+func NewMigration(t Transport) *Migration {
+	return &Migration{
+		Deprecations: newMigrationDeprecationsFunc(t),
+	}
 }
 
 // ML contains the ML APIs
@@ -377,9 +616,84 @@ type ML struct {
 	Validate                   MLValidate
 }
 
+// NewML creates a new API client for ML APIs
+//
+func NewML(t Transport) *ML {
+	return &ML{
+		CloseJob:                   newMLCloseJobFunc(t),
+		DeleteCalendarEvent:        newMLDeleteCalendarEventFunc(t),
+		DeleteCalendarJob:          newMLDeleteCalendarJobFunc(t),
+		DeleteCalendar:             newMLDeleteCalendarFunc(t),
+		DeleteDataFrameAnalytics:   newMLDeleteDataFrameAnalyticsFunc(t),
+		DeleteDatafeed:             newMLDeleteDatafeedFunc(t),
+		DeleteExpiredData:          newMLDeleteExpiredDataFunc(t),
+		DeleteFilter:               newMLDeleteFilterFunc(t),
+		DeleteForecast:             newMLDeleteForecastFunc(t),
+		DeleteJob:                  newMLDeleteJobFunc(t),
+		DeleteModelSnapshot:        newMLDeleteModelSnapshotFunc(t),
+		DeleteTrainedModel:         newMLDeleteTrainedModelFunc(t),
+		EstimateModelMemory:        newMLEstimateModelMemoryFunc(t),
+		EvaluateDataFrame:          newMLEvaluateDataFrameFunc(t),
+		ExplainDataFrameAnalytics:  newMLExplainDataFrameAnalyticsFunc(t),
+		FindFileStructure:          newMLFindFileStructureFunc(t),
+		FlushJob:                   newMLFlushJobFunc(t),
+		Forecast:                   newMLForecastFunc(t),
+		GetBuckets:                 newMLGetBucketsFunc(t),
+		GetCalendarEvents:          newMLGetCalendarEventsFunc(t),
+		GetCalendars:               newMLGetCalendarsFunc(t),
+		GetCategories:              newMLGetCategoriesFunc(t),
+		GetDataFrameAnalytics:      newMLGetDataFrameAnalyticsFunc(t),
+		GetDataFrameAnalyticsStats: newMLGetDataFrameAnalyticsStatsFunc(t),
+		GetDatafeedStats:           newMLGetDatafeedStatsFunc(t),
+		GetDatafeeds:               newMLGetDatafeedsFunc(t),
+		GetFilters:                 newMLGetFiltersFunc(t),
+		GetInfluencers:             newMLGetInfluencersFunc(t),
+		GetJobStats:                newMLGetJobStatsFunc(t),
+		GetJobs:                    newMLGetJobsFunc(t),
+		GetModelSnapshots:          newMLGetModelSnapshotsFunc(t),
+		GetOverallBuckets:          newMLGetOverallBucketsFunc(t),
+		GetRecords:                 newMLGetRecordsFunc(t),
+		GetTrainedModels:           newMLGetTrainedModelsFunc(t),
+		GetTrainedModelsStats:      newMLGetTrainedModelsStatsFunc(t),
+		Info:                       newMLInfoFunc(t),
+		OpenJob:                    newMLOpenJobFunc(t),
+		PostCalendarEvents:         newMLPostCalendarEventsFunc(t),
+		PostData:                   newMLPostDataFunc(t),
+		PreviewDatafeed:            newMLPreviewDatafeedFunc(t),
+		PutCalendarJob:             newMLPutCalendarJobFunc(t),
+		PutCalendar:                newMLPutCalendarFunc(t),
+		PutDataFrameAnalytics:      newMLPutDataFrameAnalyticsFunc(t),
+		PutDatafeed:                newMLPutDatafeedFunc(t),
+		PutFilter:                  newMLPutFilterFunc(t),
+		PutJob:                     newMLPutJobFunc(t),
+		PutTrainedModel:            newMLPutTrainedModelFunc(t),
+		RevertModelSnapshot:        newMLRevertModelSnapshotFunc(t),
+		SetUpgradeMode:             newMLSetUpgradeModeFunc(t),
+		StartDataFrameAnalytics:    newMLStartDataFrameAnalyticsFunc(t),
+		StartDatafeed:              newMLStartDatafeedFunc(t),
+		StopDataFrameAnalytics:     newMLStopDataFrameAnalyticsFunc(t),
+		StopDatafeed:               newMLStopDatafeedFunc(t),
+		UpdateDataFrameAnalytics:   newMLUpdateDataFrameAnalyticsFunc(t),
+		UpdateDatafeed:             newMLUpdateDatafeedFunc(t),
+		UpdateFilter:               newMLUpdateFilterFunc(t),
+		UpdateJob:                  newMLUpdateJobFunc(t),
+		UpdateModelSnapshot:        newMLUpdateModelSnapshotFunc(t),
+		ValidateDetector:           newMLValidateDetectorFunc(t),
+		Validate:                   newMLValidateFunc(t),
+	}
+}
+
 // Monitoring contains the Monitoring APIs
 type Monitoring struct {
 	Bulk MonitoringBulk
+}
+
+// NewMonitoring creates a new API client for Monitoring APIs
+//
+func NewMonitoring(t Transport) *Monitoring {
+	return &Monitoring{
+		Bulk: newMonitoringBulkFunc(t),
+	}
 }
 
 // Rollup contains the Rollup APIs
@@ -392,6 +706,21 @@ type Rollup struct {
 	Search       RollupRollupSearch
 	StartJob     RollupStartJob
 	StopJob      RollupStopJob
+}
+
+// NewRollup creates a new API client for Rollup APIs
+//
+func NewRollup(t Transport) *Rollup {
+	return &Rollup{
+		DeleteJob:    newRollupDeleteJobFunc(t),
+		GetJobs:      newRollupGetJobsFunc(t),
+		GetCaps:      newRollupGetRollupCapsFunc(t),
+		GetIndexCaps: newRollupGetRollupIndexCapsFunc(t),
+		PutJob:       newRollupPutJobFunc(t),
+		Search:       newRollupRollupSearchFunc(t),
+		StartJob:     newRollupStartJobFunc(t),
+		StopJob:      newRollupStopJobFunc(t),
+	}
 }
 
 // Security contains the Security APIs
@@ -425,6 +754,40 @@ type Security struct {
 	PutUser               SecurityPutUser
 }
 
+// NewSecurity creates a new API client for Security APIs
+//
+func NewSecurity(t Transport) *Security {
+	return &Security{
+		Authenticate:          newSecurityAuthenticateFunc(t),
+		ChangePassword:        newSecurityChangePasswordFunc(t),
+		ClearCachedPrivileges: newSecurityClearCachedPrivilegesFunc(t),
+		ClearCachedRealms:     newSecurityClearCachedRealmsFunc(t),
+		ClearCachedRoles:      newSecurityClearCachedRolesFunc(t),
+		CreateAPIKey:          newSecurityCreateAPIKeyFunc(t),
+		DeletePrivileges:      newSecurityDeletePrivilegesFunc(t),
+		DeleteRoleMapping:     newSecurityDeleteRoleMappingFunc(t),
+		DeleteRole:            newSecurityDeleteRoleFunc(t),
+		DeleteUser:            newSecurityDeleteUserFunc(t),
+		DisableUser:           newSecurityDisableUserFunc(t),
+		EnableUser:            newSecurityEnableUserFunc(t),
+		GetAPIKey:             newSecurityGetAPIKeyFunc(t),
+		GetBuiltinPrivileges:  newSecurityGetBuiltinPrivilegesFunc(t),
+		GetPrivileges:         newSecurityGetPrivilegesFunc(t),
+		GetRoleMapping:        newSecurityGetRoleMappingFunc(t),
+		GetRole:               newSecurityGetRoleFunc(t),
+		GetToken:              newSecurityGetTokenFunc(t),
+		GetUserPrivileges:     newSecurityGetUserPrivilegesFunc(t),
+		GetUser:               newSecurityGetUserFunc(t),
+		HasPrivileges:         newSecurityHasPrivilegesFunc(t),
+		InvalidateAPIKey:      newSecurityInvalidateAPIKeyFunc(t),
+		InvalidateToken:       newSecurityInvalidateTokenFunc(t),
+		PutPrivileges:         newSecurityPutPrivilegesFunc(t),
+		PutRoleMapping:        newSecurityPutRoleMappingFunc(t),
+		PutRole:               newSecurityPutRoleFunc(t),
+		PutUser:               newSecurityPutUserFunc(t),
+	}
+}
+
 // SQL contains the SQL APIs
 type SQL struct {
 	ClearCursor SQLClearCursor
@@ -432,9 +795,27 @@ type SQL struct {
 	Translate   SQLTranslate
 }
 
+// NewSQL creates a new API client for SQL APIs
+//
+func NewSQL(t Transport) *SQL {
+	return &SQL{
+		ClearCursor: newSQLClearCursorFunc(t),
+		Query:       newSQLQueryFunc(t),
+		Translate:   newSQLTranslateFunc(t),
+	}
+}
+
 // SSL contains the SSL APIs
 type SSL struct {
 	Certificates SSLCertificates
+}
+
+// NewSSL creates a new API client for SSL APIs
+//
+func NewSSL(t Transport) *SSL {
+	return &SSL{
+		Certificates: newSSLCertificatesFunc(t),
+	}
 }
 
 // Watcher contains the Watcher APIs
@@ -451,10 +832,36 @@ type Watcher struct {
 	Stop            WatcherStop
 }
 
+// NewWatcher creates a new API client for Watcher APIs
+//
+func NewWatcher(t Transport) *Watcher {
+	return &Watcher{
+		AckWatch:        newWatcherAckWatchFunc(t),
+		ActivateWatch:   newWatcherActivateWatchFunc(t),
+		DeactivateWatch: newWatcherDeactivateWatchFunc(t),
+		DeleteWatch:     newWatcherDeleteWatchFunc(t),
+		ExecuteWatch:    newWatcherExecuteWatchFunc(t),
+		GetWatch:        newWatcherGetWatchFunc(t),
+		PutWatch:        newWatcherPutWatchFunc(t),
+		Start:           newWatcherStartFunc(t),
+		Stats:           newWatcherStatsFunc(t),
+		Stop:            newWatcherStopFunc(t),
+	}
+}
+
 // XPack contains the XPack APIs
 type XPack struct {
 	Info  XPackInfo
 	Usage XPackUsage
+}
+
+// NewXPack creates a new API client for XPack APIs
+//
+func NewXPack(t Transport) *XPack {
+	return &XPack{
+		Info:  newXPackInfoFunc(t),
+		Usage: newXPackUsageFunc(t),
+	}
 }
 
 // New creates new API
@@ -544,307 +951,26 @@ func New(t Transport) *API {
 		UpdateByQuery:                                 newUpdateByQueryFunc(t),
 		UpdateByQueryRethrottle:                       newUpdateByQueryRethrottleFunc(t),
 		Update:                                        newUpdateFunc(t),
-		Cat: &Cat{
-			Aliases:              newCatAliasesFunc(t),
-			Allocation:           newCatAllocationFunc(t),
-			Count:                newCatCountFunc(t),
-			Fielddata:            newCatFielddataFunc(t),
-			Health:               newCatHealthFunc(t),
-			Help:                 newCatHelpFunc(t),
-			Indices:              newCatIndicesFunc(t),
-			MLDataFrameAnalytics: newCatMLDataFrameAnalyticsFunc(t),
-			MLDatafeeds:          newCatMLDatafeedsFunc(t),
-			MLJobs:               newCatMLJobsFunc(t),
-			MLTrainedModels:      newCatMLTrainedModelsFunc(t),
-			Master:               newCatMasterFunc(t),
-			Nodeattrs:            newCatNodeattrsFunc(t),
-			Nodes:                newCatNodesFunc(t),
-			PendingTasks:         newCatPendingTasksFunc(t),
-			Plugins:              newCatPluginsFunc(t),
-			Recovery:             newCatRecoveryFunc(t),
-			Repositories:         newCatRepositoriesFunc(t),
-			Segments:             newCatSegmentsFunc(t),
-			Shards:               newCatShardsFunc(t),
-			Snapshots:            newCatSnapshotsFunc(t),
-			Tasks:                newCatTasksFunc(t),
-			Templates:            newCatTemplatesFunc(t),
-			ThreadPool:           newCatThreadPoolFunc(t),
-			Transforms:           newCatTransformsFunc(t),
-		},
-		Cluster: &Cluster{
-			AllocationExplain:            newClusterAllocationExplainFunc(t),
-			DeleteComponentTemplate:      newClusterDeleteComponentTemplateFunc(t),
-			DeleteVotingConfigExclusions: newClusterDeleteVotingConfigExclusionsFunc(t),
-			ExistsComponentTemplate:      newClusterExistsComponentTemplateFunc(t),
-			GetComponentTemplate:         newClusterGetComponentTemplateFunc(t),
-			GetSettings:                  newClusterGetSettingsFunc(t),
-			Health:                       newClusterHealthFunc(t),
-			PendingTasks:                 newClusterPendingTasksFunc(t),
-			PostVotingConfigExclusions:   newClusterPostVotingConfigExclusionsFunc(t),
-			PutComponentTemplate:         newClusterPutComponentTemplateFunc(t),
-			PutSettings:                  newClusterPutSettingsFunc(t),
-			RemoteInfo:                   newClusterRemoteInfoFunc(t),
-			Reroute:                      newClusterRerouteFunc(t),
-			State:                        newClusterStateFunc(t),
-			Stats:                        newClusterStatsFunc(t),
-		},
-		Indices: &Indices{
-			AddBlock:              newIndicesAddBlockFunc(t),
-			Analyze:               newIndicesAnalyzeFunc(t),
-			ClearCache:            newIndicesClearCacheFunc(t),
-			Clone:                 newIndicesCloneFunc(t),
-			Close:                 newIndicesCloseFunc(t),
-			CreateDataStream:      newIndicesCreateDataStreamFunc(t),
-			Create:                newIndicesCreateFunc(t),
-			DataStreamsStats:      newIndicesDataStreamsStatsFunc(t),
-			DeleteAlias:           newIndicesDeleteAliasFunc(t),
-			DeleteDataStream:      newIndicesDeleteDataStreamFunc(t),
-			DeleteIndexTemplate:   newIndicesDeleteIndexTemplateFunc(t),
-			Delete:                newIndicesDeleteFunc(t),
-			DeleteTemplate:        newIndicesDeleteTemplateFunc(t),
-			ExistsAlias:           newIndicesExistsAliasFunc(t),
-			ExistsDocumentType:    newIndicesExistsDocumentTypeFunc(t),
-			ExistsIndexTemplate:   newIndicesExistsIndexTemplateFunc(t),
-			Exists:                newIndicesExistsFunc(t),
-			ExistsTemplate:        newIndicesExistsTemplateFunc(t),
-			Flush:                 newIndicesFlushFunc(t),
-			Forcemerge:            newIndicesForcemergeFunc(t),
-			Freeze:                newIndicesFreezeFunc(t),
-			GetAlias:              newIndicesGetAliasFunc(t),
-			GetDataStream:         newIndicesGetDataStreamFunc(t),
-			GetFieldMapping:       newIndicesGetFieldMappingFunc(t),
-			GetIndexTemplate:      newIndicesGetIndexTemplateFunc(t),
-			GetMapping:            newIndicesGetMappingFunc(t),
-			Get:                   newIndicesGetFunc(t),
-			GetSettings:           newIndicesGetSettingsFunc(t),
-			GetTemplate:           newIndicesGetTemplateFunc(t),
-			GetUpgrade:            newIndicesGetUpgradeFunc(t),
-			Open:                  newIndicesOpenFunc(t),
-			PutAlias:              newIndicesPutAliasFunc(t),
-			PutIndexTemplate:      newIndicesPutIndexTemplateFunc(t),
-			PutMapping:            newIndicesPutMappingFunc(t),
-			PutSettings:           newIndicesPutSettingsFunc(t),
-			PutTemplate:           newIndicesPutTemplateFunc(t),
-			Recovery:              newIndicesRecoveryFunc(t),
-			Refresh:               newIndicesRefreshFunc(t),
-			ReloadSearchAnalyzers: newIndicesReloadSearchAnalyzersFunc(t),
-			ResolveIndex:          newIndicesResolveIndexFunc(t),
-			Rollover:              newIndicesRolloverFunc(t),
-			Segments:              newIndicesSegmentsFunc(t),
-			ShardStores:           newIndicesShardStoresFunc(t),
-			Shrink:                newIndicesShrinkFunc(t),
-			SimulateIndexTemplate: newIndicesSimulateIndexTemplateFunc(t),
-			SimulateTemplate:      newIndicesSimulateTemplateFunc(t),
-			Split:                 newIndicesSplitFunc(t),
-			Stats:                 newIndicesStatsFunc(t),
-			Unfreeze:              newIndicesUnfreezeFunc(t),
-			UpdateAliases:         newIndicesUpdateAliasesFunc(t),
-			Upgrade:               newIndicesUpgradeFunc(t),
-			ValidateQuery:         newIndicesValidateQueryFunc(t),
-		},
-		Ingest: &Ingest{
-			DeletePipeline: newIngestDeletePipelineFunc(t),
-			GetPipeline:    newIngestGetPipelineFunc(t),
-			ProcessorGrok:  newIngestProcessorGrokFunc(t),
-			PutPipeline:    newIngestPutPipelineFunc(t),
-			Simulate:       newIngestSimulateFunc(t),
-		},
-		Nodes: &Nodes{
-			HotThreads:           newNodesHotThreadsFunc(t),
-			Info:                 newNodesInfoFunc(t),
-			ReloadSecureSettings: newNodesReloadSecureSettingsFunc(t),
-			Stats:                newNodesStatsFunc(t),
-			Usage:                newNodesUsageFunc(t),
-		},
-		Remote: &Remote{},
-		Snapshot: &Snapshot{
-			CleanupRepository: newSnapshotCleanupRepositoryFunc(t),
-			CreateRepository:  newSnapshotCreateRepositoryFunc(t),
-			Create:            newSnapshotCreateFunc(t),
-			DeleteRepository:  newSnapshotDeleteRepositoryFunc(t),
-			Delete:            newSnapshotDeleteFunc(t),
-			GetRepository:     newSnapshotGetRepositoryFunc(t),
-			Get:               newSnapshotGetFunc(t),
-			Restore:           newSnapshotRestoreFunc(t),
-			Status:            newSnapshotStatusFunc(t),
-			VerifyRepository:  newSnapshotVerifyRepositoryFunc(t),
-		},
-		Tasks: &Tasks{
-			Cancel: newTasksCancelFunc(t),
-			Get:    newTasksGetFunc(t),
-			List:   newTasksListFunc(t),
-		},
-		AsyncSearch: &AsyncSearch{
-			Delete: newAsyncSearchDeleteFunc(t),
-			Get:    newAsyncSearchGetFunc(t),
-			Submit: newAsyncSearchSubmitFunc(t),
-		},
-		CCR: &CCR{
-			DeleteAutoFollowPattern: newCCRDeleteAutoFollowPatternFunc(t),
-			FollowInfo:              newCCRFollowInfoFunc(t),
-			Follow:                  newCCRFollowFunc(t),
-			FollowStats:             newCCRFollowStatsFunc(t),
-			ForgetFollower:          newCCRForgetFollowerFunc(t),
-			GetAutoFollowPattern:    newCCRGetAutoFollowPatternFunc(t),
-			PauseAutoFollowPattern:  newCCRPauseAutoFollowPatternFunc(t),
-			PauseFollow:             newCCRPauseFollowFunc(t),
-			PutAutoFollowPattern:    newCCRPutAutoFollowPatternFunc(t),
-			ResumeAutoFollowPattern: newCCRResumeAutoFollowPatternFunc(t),
-			ResumeFollow:            newCCRResumeFollowFunc(t),
-			Stats:                   newCCRStatsFunc(t),
-			Unfollow:                newCCRUnfollowFunc(t),
-		},
-		ILM: &ILM{
-			DeleteLifecycle:  newILMDeleteLifecycleFunc(t),
-			ExplainLifecycle: newILMExplainLifecycleFunc(t),
-			GetLifecycle:     newILMGetLifecycleFunc(t),
-			GetStatus:        newILMGetStatusFunc(t),
-			MoveToStep:       newILMMoveToStepFunc(t),
-			PutLifecycle:     newILMPutLifecycleFunc(t),
-			RemovePolicy:     newILMRemovePolicyFunc(t),
-			Retry:            newILMRetryFunc(t),
-			Start:            newILMStartFunc(t),
-			Stop:             newILMStopFunc(t),
-		},
-		License: &License{
-			Delete:         newLicenseDeleteFunc(t),
-			GetBasicStatus: newLicenseGetBasicStatusFunc(t),
-			Get:            newLicenseGetFunc(t),
-			GetTrialStatus: newLicenseGetTrialStatusFunc(t),
-			Post:           newLicensePostFunc(t),
-			PostStartBasic: newLicensePostStartBasicFunc(t),
-			PostStartTrial: newLicensePostStartTrialFunc(t),
-		},
-		Migration: &Migration{
-			Deprecations: newMigrationDeprecationsFunc(t),
-		},
-		ML: &ML{
-			CloseJob:                   newMLCloseJobFunc(t),
-			DeleteCalendarEvent:        newMLDeleteCalendarEventFunc(t),
-			DeleteCalendarJob:          newMLDeleteCalendarJobFunc(t),
-			DeleteCalendar:             newMLDeleteCalendarFunc(t),
-			DeleteDataFrameAnalytics:   newMLDeleteDataFrameAnalyticsFunc(t),
-			DeleteDatafeed:             newMLDeleteDatafeedFunc(t),
-			DeleteExpiredData:          newMLDeleteExpiredDataFunc(t),
-			DeleteFilter:               newMLDeleteFilterFunc(t),
-			DeleteForecast:             newMLDeleteForecastFunc(t),
-			DeleteJob:                  newMLDeleteJobFunc(t),
-			DeleteModelSnapshot:        newMLDeleteModelSnapshotFunc(t),
-			DeleteTrainedModel:         newMLDeleteTrainedModelFunc(t),
-			EstimateModelMemory:        newMLEstimateModelMemoryFunc(t),
-			EvaluateDataFrame:          newMLEvaluateDataFrameFunc(t),
-			ExplainDataFrameAnalytics:  newMLExplainDataFrameAnalyticsFunc(t),
-			FindFileStructure:          newMLFindFileStructureFunc(t),
-			FlushJob:                   newMLFlushJobFunc(t),
-			Forecast:                   newMLForecastFunc(t),
-			GetBuckets:                 newMLGetBucketsFunc(t),
-			GetCalendarEvents:          newMLGetCalendarEventsFunc(t),
-			GetCalendars:               newMLGetCalendarsFunc(t),
-			GetCategories:              newMLGetCategoriesFunc(t),
-			GetDataFrameAnalytics:      newMLGetDataFrameAnalyticsFunc(t),
-			GetDataFrameAnalyticsStats: newMLGetDataFrameAnalyticsStatsFunc(t),
-			GetDatafeedStats:           newMLGetDatafeedStatsFunc(t),
-			GetDatafeeds:               newMLGetDatafeedsFunc(t),
-			GetFilters:                 newMLGetFiltersFunc(t),
-			GetInfluencers:             newMLGetInfluencersFunc(t),
-			GetJobStats:                newMLGetJobStatsFunc(t),
-			GetJobs:                    newMLGetJobsFunc(t),
-			GetModelSnapshots:          newMLGetModelSnapshotsFunc(t),
-			GetOverallBuckets:          newMLGetOverallBucketsFunc(t),
-			GetRecords:                 newMLGetRecordsFunc(t),
-			GetTrainedModels:           newMLGetTrainedModelsFunc(t),
-			GetTrainedModelsStats:      newMLGetTrainedModelsStatsFunc(t),
-			Info:                       newMLInfoFunc(t),
-			OpenJob:                    newMLOpenJobFunc(t),
-			PostCalendarEvents:         newMLPostCalendarEventsFunc(t),
-			PostData:                   newMLPostDataFunc(t),
-			PreviewDatafeed:            newMLPreviewDatafeedFunc(t),
-			PutCalendarJob:             newMLPutCalendarJobFunc(t),
-			PutCalendar:                newMLPutCalendarFunc(t),
-			PutDataFrameAnalytics:      newMLPutDataFrameAnalyticsFunc(t),
-			PutDatafeed:                newMLPutDatafeedFunc(t),
-			PutFilter:                  newMLPutFilterFunc(t),
-			PutJob:                     newMLPutJobFunc(t),
-			PutTrainedModel:            newMLPutTrainedModelFunc(t),
-			RevertModelSnapshot:        newMLRevertModelSnapshotFunc(t),
-			SetUpgradeMode:             newMLSetUpgradeModeFunc(t),
-			StartDataFrameAnalytics:    newMLStartDataFrameAnalyticsFunc(t),
-			StartDatafeed:              newMLStartDatafeedFunc(t),
-			StopDataFrameAnalytics:     newMLStopDataFrameAnalyticsFunc(t),
-			StopDatafeed:               newMLStopDatafeedFunc(t),
-			UpdateDataFrameAnalytics:   newMLUpdateDataFrameAnalyticsFunc(t),
-			UpdateDatafeed:             newMLUpdateDatafeedFunc(t),
-			UpdateFilter:               newMLUpdateFilterFunc(t),
-			UpdateJob:                  newMLUpdateJobFunc(t),
-			UpdateModelSnapshot:        newMLUpdateModelSnapshotFunc(t),
-			ValidateDetector:           newMLValidateDetectorFunc(t),
-			Validate:                   newMLValidateFunc(t),
-		},
-		Monitoring: &Monitoring{
-			Bulk: newMonitoringBulkFunc(t),
-		},
-		Rollup: &Rollup{
-			DeleteJob:    newRollupDeleteJobFunc(t),
-			GetJobs:      newRollupGetJobsFunc(t),
-			GetCaps:      newRollupGetRollupCapsFunc(t),
-			GetIndexCaps: newRollupGetRollupIndexCapsFunc(t),
-			PutJob:       newRollupPutJobFunc(t),
-			Search:       newRollupRollupSearchFunc(t),
-			StartJob:     newRollupStartJobFunc(t),
-			StopJob:      newRollupStopJobFunc(t),
-		},
-		Security: &Security{
-			Authenticate:          newSecurityAuthenticateFunc(t),
-			ChangePassword:        newSecurityChangePasswordFunc(t),
-			ClearCachedPrivileges: newSecurityClearCachedPrivilegesFunc(t),
-			ClearCachedRealms:     newSecurityClearCachedRealmsFunc(t),
-			ClearCachedRoles:      newSecurityClearCachedRolesFunc(t),
-			CreateAPIKey:          newSecurityCreateAPIKeyFunc(t),
-			DeletePrivileges:      newSecurityDeletePrivilegesFunc(t),
-			DeleteRoleMapping:     newSecurityDeleteRoleMappingFunc(t),
-			DeleteRole:            newSecurityDeleteRoleFunc(t),
-			DeleteUser:            newSecurityDeleteUserFunc(t),
-			DisableUser:           newSecurityDisableUserFunc(t),
-			EnableUser:            newSecurityEnableUserFunc(t),
-			GetAPIKey:             newSecurityGetAPIKeyFunc(t),
-			GetBuiltinPrivileges:  newSecurityGetBuiltinPrivilegesFunc(t),
-			GetPrivileges:         newSecurityGetPrivilegesFunc(t),
-			GetRoleMapping:        newSecurityGetRoleMappingFunc(t),
-			GetRole:               newSecurityGetRoleFunc(t),
-			GetToken:              newSecurityGetTokenFunc(t),
-			GetUserPrivileges:     newSecurityGetUserPrivilegesFunc(t),
-			GetUser:               newSecurityGetUserFunc(t),
-			HasPrivileges:         newSecurityHasPrivilegesFunc(t),
-			InvalidateAPIKey:      newSecurityInvalidateAPIKeyFunc(t),
-			InvalidateToken:       newSecurityInvalidateTokenFunc(t),
-			PutPrivileges:         newSecurityPutPrivilegesFunc(t),
-			PutRoleMapping:        newSecurityPutRoleMappingFunc(t),
-			PutRole:               newSecurityPutRoleFunc(t),
-			PutUser:               newSecurityPutUserFunc(t),
-		},
-		SQL: &SQL{
-			ClearCursor: newSQLClearCursorFunc(t),
-			Query:       newSQLQueryFunc(t),
-			Translate:   newSQLTranslateFunc(t),
-		},
-		SSL: &SSL{
-			Certificates: newSSLCertificatesFunc(t),
-		},
-		Watcher: &Watcher{
-			AckWatch:        newWatcherAckWatchFunc(t),
-			ActivateWatch:   newWatcherActivateWatchFunc(t),
-			DeactivateWatch: newWatcherDeactivateWatchFunc(t),
-			DeleteWatch:     newWatcherDeleteWatchFunc(t),
-			ExecuteWatch:    newWatcherExecuteWatchFunc(t),
-			GetWatch:        newWatcherGetWatchFunc(t),
-			PutWatch:        newWatcherPutWatchFunc(t),
-			Start:           newWatcherStartFunc(t),
-			Stats:           newWatcherStatsFunc(t),
-			Stop:            newWatcherStopFunc(t),
-		},
-		XPack: &XPack{
-			Info:  newXPackInfoFunc(t),
-			Usage: newXPackUsageFunc(t),
-		},
+		Cat:                                           NewCat(t),
+		Cluster:                                       NewCluster(t),
+		Indices:                                       NewIndices(t),
+		Ingest:                                        NewIngest(t),
+		Nodes:                                         NewNodes(t),
+		Remote:                                        NewRemote(t),
+		Snapshot:                                      NewSnapshot(t),
+		Tasks:                                         NewTasks(t),
+		AsyncSearch:                                   NewAsyncSearch(t),
+		CCR:                                           NewCCR(t),
+		ILM:                                           NewILM(t),
+		License:                                       NewLicense(t),
+		Migration:                                     NewMigration(t),
+		ML:                                            NewML(t),
+		Monitoring:                                    NewMonitoring(t),
+		Rollup:                                        NewRollup(t),
+		Security:                                      NewSecurity(t),
+		SQL:                                           NewSQL(t),
+		SSL:                                           NewSSL(t),
+		Watcher:                                       NewWatcher(t),
+		XPack:                                         NewXPack(t),
 	}
 }

--- a/esapi/api.clear_scroll.go
+++ b/esapi/api.clear_scroll.go
@@ -27,7 +27,7 @@ func newClearScrollFunc(t Transport) ClearScroll {
 
 // ClearScroll explicitly clears the search context for a scroll.
 //
-// See full documentation at https://www.elastic.co/guide/en/elasticsearch/reference/master/search-request-body.html#_clear_scroll_api.
+// See full documentation at https://www.elastic.co/guide/en/elasticsearch/reference/current/clear-scroll-api.html.
 //
 type ClearScroll func(o ...func(*ClearScrollRequest)) (*Response, error)
 

--- a/esapi/test/go.mod
+++ b/esapi/test/go.mod
@@ -5,7 +5,7 @@ go 1.11
 replace github.com/elastic/go-elasticsearch/v8 => ../../
 
 require (
-	github.com/elastic/go-elasticsearch/v8 master
+	github.com/elastic/go-elasticsearch/v8 v8.0.0-20200728144331-527225d8e836
 
 	gopkg.in/yaml.v2 v2.2.2
 )

--- a/internal/cmd/generate/commands/genstruct/command.go
+++ b/internal/cmd/generate/commands/genstruct/command.go
@@ -243,6 +243,19 @@ type API struct {
 			}
 		}
 		b.WriteString("}\n\n")
+
+		b.WriteString(`// New` + n + ` creates a new API client for ` + n + ` APIs` + "\n//\n")
+		b.WriteString(`func New` + n + `(t Transport) *` + n + ` {
+	return &` + n + "{\n")
+		for _, e := range endpoints {
+			name := strings.ReplaceAll(e.Name(), "Request", "")
+			if strings.HasPrefix(strings.ToLower(name), strings.ToLower(n)) {
+				methodName := strings.ReplaceAll(name, n, "")
+				b.WriteString(fmt.Sprintf("\t\t%s: new%sFunc(t),\n", methodName, name))
+			}
+		}
+		b.WriteString("\t}\n")
+		b.WriteString("}\n\n")
 	}
 
 	b.WriteString(`// New creates new API
@@ -266,15 +279,7 @@ func New(t Transport) *API {
 	}
 
 	for _, n := range namespaces {
-		b.WriteString(fmt.Sprintf("\t\t%[1]s: &%[1]s{\n", n))
-		for _, e := range endpoints {
-			name := strings.ReplaceAll(e.Name(), "Request", "")
-			if strings.HasPrefix(strings.ToLower(name), strings.ToLower(n)) {
-				methodName := strings.ReplaceAll(name, n, "")
-				b.WriteString(fmt.Sprintf("\t\t\t%s: new%sFunc(t),\n", methodName, name))
-			}
-		}
-		b.WriteString("\t\t},\n")
+		b.WriteString(fmt.Sprintf("\t\t%[1]s: New%[1]s(t),\n", n))
 	}
 
 	b.WriteString(`	}


### PR DESCRIPTION
I believe this is one of the major asks in https://github.com/elastic/go-elasticsearch/issues/172, the other being something like an `elasticsearch.NewTransport` function that you could pass to each of these if you so desired. Basically rather than having one giant API object, we also expose the ability to decompose the client into individual APIs so someone can use just what they want and avoid the penalty of instantiating every client.