### PR TITLE
estransport: Fix data race on subsequent iteration in retry loop

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -37,6 +37,9 @@ endif
 		go test -v $(testintegargs) "./estransport" "./esapi" "./esutil"; \
 	fi;
 
+test-integ-race:
+	docker stop elasticsearch; docker start elasticsearch; for i in {1..50}; do go test -v -race -cover -count=1 -coverprofile=tmp/integration-client.cov -tags='integration' -timeout=1h . -run "DataRace"; done 
+
 test-api:  ## Run generated API integration tests
 	@mkdir -p tmp
 ifdef race

--- a/elasticsearch_integration_test.go
+++ b/elasticsearch_integration_test.go
@@ -265,3 +265,30 @@ func TestClientAPI(t *testing.T) {
 		fmt.Println(d["tagline"])
 	})
 }
+
+func TestDataRaceForRequests(t *testing.T) {
+	t.Run("DataRace", func(t *testing.T) {
+		var wg sync.WaitGroup
+
+		es, err := elasticsearch.NewClient(elasticsearch.Config{
+			DisableRetry: true,
+		})
+		if err != nil {
+			log.Fatalf("Error creating the client: %s\n", err)
+		}
+
+		for i := 1; i <= 5; i++ {
+			wg.Add(1)
+			go func() {
+				defer wg.Done()
+				res, err := es.Ping()
+				if err != nil {
+					log.Printf("Error getting response: %s", err)
+				}
+				t.Log(res)
+			}()
+		}
+
+		wg.Wait()
+	})
+}


### PR DESCRIPTION
This fixes the data race of the http.Request.URL field as it is read in
another goroutine by http.Transport when it tries to write to the
persistent connection. The fix is to clone the request on subsequent
iteration.

Closes #147