### PR TITLE
Dockerfile maintenance

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -18,5 +18,5 @@ ENV TERM xterm-256color
 WORKDIR /go-elasticsearch
 COPY . .
 
-RUN go mod download && go mod vendor && \
-    cd internal/cmd/generate && go mod download && go mod vendor
+RUN go mod download && \
+    cd internal/cmd/generate && go mod download

--- a/Dockerfile
+++ b/Dockerfile
@@ -16,7 +16,10 @@ ENV CGO_ENABLED=0
 ENV TERM xterm-256color
 
 WORKDIR /go/src/github.com/elastic/go-elasticsearch
-COPY . .
+COPY go.mod go.sum ./
+RUN go mod download
 
-RUN go mod download && \
-    cd internal/cmd/generate && go mod download
+COPY internal/cmd/generate/go.mod internal/cmd/generate/go.sum internal/cmd/generate/
+RUN cd internal/cmd/generate && go mod download
+
+COPY . .

--- a/Dockerfile
+++ b/Dockerfile
@@ -15,7 +15,7 @@ VOLUME ["/tmp"]
 ENV CGO_ENABLED=0
 ENV TERM xterm-256color
 
-WORKDIR /go-elasticsearch
+WORKDIR /go/src/github.com/elastic/go-elasticsearch
 COPY . .
 
 RUN go mod download && \


### PR DESCRIPTION
commit: a2481d5 d8af7a9
I remove unnecessary code!

commit: 52a9aa6
I separate module download to use cache easily.

this docker image is equal to original docker image minus `internal/cmd/generate/vender`
