### PR TITLE
Fixed invalid json generation when documentid=""

### DIFF
--- a/esutil/bulk_indexer.go
+++ b/esutil/bulk_indexer.go
@@ -395,7 +395,9 @@ func (w *worker) writeMeta(item BulkIndexerItem) error {
 		w.aux = strconv.AppendQuote(w.aux, item.DocumentType)
 		w.buf.Write(w.aux)
 		w.aux = w.aux[:0]
-		w.buf.WriteRune(',')
+		if item.DocumentID != "" {
+			w.buf.WriteRune(',')
+		}
 	}
 	if item.DocumentID != "" {
 		w.buf.WriteString(`"_id":`)


### PR DESCRIPTION
Hello, 

I've found a small bug in version 6.x BulkIndexer:
If you set DocumentType, but do not set DocumentID, then the following JSON will be generated:
```json
{"index":{"_type":"_doc",}}
```
Note the comma after "_doc". 

This small patch fixes it.