### PR TITLE
[DOCS] Adds Features subsection to Overview

### DIFF
--- a/.doc/installation.asciidoc
+++ b/.doc/installation.asciidoc
@@ -57,6 +57,13 @@ The client major versions correspond to the {es} major versions: to connect to
 {es} `7.x`, use a `7.x` version of the client, to connect to {es} `6.x`, use a 
 `6.x` version of the client, and so on.
 
+[NOTE]
+--
+While the 5.x version of the client is available, it is no longer actively 
+maintained, neither the corresponding {es} version. For more information, refer 
+to https://www.elastic.co/support/eol[Elastic product end of life dates].
+--
+
 [%header,cols=2*]
 |===
 |{es} Version

--- a/.doc/installation.asciidoc
+++ b/.doc/installation.asciidoc
@@ -48,3 +48,32 @@ END
 
 go run main.go
 ------------------------------------
+
+
+[discrete]
+=== {es} Version Compatibility
+
+The client major versions correspond to the {es} major versions: to connect to 
+{es} `7.x`, use a `7.x` version of the client, to connect to {es} `6.x`, use a 
+`6.x` version of the client, and so on.
+
+[%header,cols=2*]
+|===
+|{es} Version
+|Client Version
+
+|`master`
+|`master`
+
+|`7.x`
+|`7.x`
+
+|`6.x`
+|`6.x`
+
+|`5.x`
+|`5.x`
+|===
+
+The `master` branch of the client is compatible with the `master` branch of 
+{es}.

--- a/.doc/overview.asciidoc
+++ b/.doc/overview.asciidoc
@@ -8,16 +8,13 @@ https://github.com/elastic/go-elasticsearch[GitHub]
 and https://godoc.org/github.com/elastic/go-elasticsearch[GoDoc]. This 
 documentation provides only an overview of features.
 
-
 [discrete]
-=== {es} Version Compatibility
+=== Features
 
-The client major versions correspond to the {es} major versions:
-to connect to {es} `6.x`, use a `6.x` version of the client,
-to connect to {es} `7.x`, use a `7.x` version of the client, and so on.
-
-The `master` branch of the client is compatible with the `master` branch of 
-{es}.
+* One-to-one mapping with REST API.
+* Generalized, pluggable architecture.
+* Helpers for convenience.
+* Rich set of examples.
 
 
 [discrete]


### PR DESCRIPTION
## Overview

This PR adds a `Features` subsection to the `Overview` that contains a bulleted list of client features.
It also moves the compatibility matrix from `Overview` to `Installation`.

### Preview

[GO Overview](https://go-elasticsearch_195.docs-preview.app.elstc.co/guide/en/elasticsearch/client/go-api/master/overview.html)