### PR TITLE
move away from set-env in test-unit-tip workflow

### DIFF
--- a/.github/workflows/test-unit-tip.yml
+++ b/.github/workflows/test-unit-tip.yml
@@ -29,9 +29,8 @@ jobs:
 
           cd src
           bash make.bash
-
-          echo "::set-env name=GOROOT::$GOROOT"
-          echo "::add-path::$GOROOT/bin"
+          echo "GOROOT=$GOROOT" >> $GITHUB_ENV
+          echo "$GOROOT/bin" >> $GITHUB_PATH
       - uses: actions/checkout@v2
         with: { fetch-depth: 1 }
       - run: go version


### PR DESCRIPTION
Move to new syntax: https://github.com/actions/toolkit/blob/main/docs/commands.md#environment-files