### PR TITLE
Feature/fix actions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -25,7 +25,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
         with: { fetch-depth: 1 }
-      - uses: actions/setup-go@v2-beta
+      - uses: actions/setup-go@v2.1.3
         with: { go-version: '1.x' }
       - name: Install dependencies
         run: go get -u golang.org/x/lint/golint

--- a/.github/workflows/test-api.yml
+++ b/.github/workflows/test-api.yml
@@ -17,7 +17,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
         with: { fetch-depth: 1 }
-      - uses: actions/setup-go@v2-beta
+      - uses: actions/setup-go@v2.1.3
         with: { go-version: '1.x' }
       - run: go version
       - name: Increase system limits
@@ -49,7 +49,7 @@ jobs:
       steps:
         - uses: actions/checkout@v2
           with: { fetch-depth: 1 }
-        - uses: actions/setup-go@v2-beta
+        - uses: actions/setup-go@v2.1.3
           with: { go-version: '1.x' }
         - run: go version
         - name: Increase system limits

--- a/.github/workflows/test-integration.yml
+++ b/.github/workflows/test-integration.yml
@@ -26,7 +26,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
         with: { fetch-depth: 1 }
-      - uses: actions/setup-go@v2-beta
+      - uses: actions/setup-go@v2.1.3
         with: { go-version: '1.x' }
       - run: go version
       - name: Increase system limits
@@ -52,7 +52,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
         with: { fetch-depth: 1 }
-      - uses: actions/setup-go@v2-beta
+      - uses: actions/setup-go@v2.1.3
         with: { go-version: '1.x' }
       - run: go version
       - name: Increase system limits

--- a/.github/workflows/test-unit.yml
+++ b/.github/workflows/test-unit.yml
@@ -30,7 +30,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
         with: { fetch-depth: 1 }
-      - uses: actions/setup-go@v2-beta
+      - uses: actions/setup-go@v2.1.3
         with: { go-version: "${{ matrix.go }}" }
       - run: go version
       - run: make test-unit race=true
@@ -46,7 +46,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
         with: { fetch-depth: 1 }
-      - uses: actions/setup-go@v2-beta
+      - uses: actions/setup-go@v2.1.3
         with: { go-version: '1.x' }
       - run: go version
       - run: make test-bench


### PR DESCRIPTION
Actions fail in current `master` branch. You can see it in `actions` tab or badges on main (README) page.
There are two issues that lead to this [article](https://github.blog/changelog/2020-10-01-github-actions-deprecating-set-env-and-add-path-commands/).

These issues are indirectly related with version of go actions. So the fix is simple: up go actions version.