### PR TITLE
check error on elastic init

### DIFF
--- a/elasticsearch.go
+++ b/elasticsearch.go
@@ -124,7 +124,10 @@ func NewClient(cfg Config) (*Client, error) {
 	}
 
 	if len(urls) == 0 {
-		u, _ := url.Parse(defaultURL) // errcheck exclude
+		u, err := url.Parse(defaultURL)
+		if err != nil {
+			return nil, fmt.Errorf("cannot parse url: %v", err)
+		}
 		urls = append(urls, u)
 	}
 


### PR DESCRIPTION
This changes are more as a proposal.

I see the point why this error check is not so important (we parse default url), but error check can help if someone changes the default url wrong way. I know that it's extremely rare case but I can't see any advantage to skip the error check on init. It will not save time and even if it will do, this saved time will be so tiny and it will not have any value because it's only on init elastic (once I mean).

WDYT?
