### PR TITLE
Transport: remove redundant error in return from getNodeURL

### DIFF
--- a/estransport/discovery.go
+++ b/estransport/discovery.go
@@ -156,18 +156,14 @@ func (c *Client) getNodesInfo() ([]nodeInfo, error) {
 
 	for id, node := range nodes {
 		node.ID = id
-		u, err := c.getNodeURL(node, scheme)
-		if err != nil {
-			return out, err
-		}
-		node.URL = u
+		node.URL = c.getNodeURL(node, scheme)
 		out = append(out, node)
 	}
 
 	return out, nil
 }
 
-func (c *Client) getNodeURL(node nodeInfo, scheme string) (*url.URL, error) {
+func (c *Client) getNodeURL(node nodeInfo, scheme string) *url.URL {
 	var (
 		host string
 		port string
@@ -188,7 +184,7 @@ func (c *Client) getNodeURL(node nodeInfo, scheme string) (*url.URL, error) {
 		Host:   host + ":" + port,
 	}
 
-	return u, nil
+	return u
 }
 
 func (c *Client) scheduleDiscoverNodes(d time.Duration) {


### PR DESCRIPTION
There are no  error prone cases in getNodeURL.
So the second returning parameter looks redundant.