### PR TITLE
Transport: metrics.Metrics.String remove redundant index increment in the loop

### DIFF
--- a/estransport/metrics.go
+++ b/estransport/metrics.go
@@ -153,7 +153,6 @@ func (m Metrics) String() string {
 		if i+1 < len(m.Connections) {
 			b.WriteString(", ")
 		}
-		i++
 	}
 	b.WriteString("]")
 


### PR DESCRIPTION
The removed line does nothing.
Index `i` increments in `range` clause and increment inside the range clause body doesn't affect it.