### PR TITLE
Transport: logger LogRoundTrip (check request and response is not nill)

### DIFF
--- a/estransport/logger.go
+++ b/estransport/logger.go
@@ -216,12 +216,13 @@ func (l *CurlLogger) LogRoundTrip(req *http.Request, res *http.Response, err err
 	if req.URL == nil {
 		return errors.New("request URL is empty")
 	}
+	reqURL := req.URL
 
 	var b bytes.Buffer
 
 	var query string
 	qvalues := url.Values{}
-	for k, v := range req.URL.Query() {
+	for k, v := range reqURL.Query() {
 		if k == "pretty" {
 			continue
 		}
@@ -251,7 +252,7 @@ func (l *CurlLogger) LogRoundTrip(req *http.Request, res *http.Response, err err
 	}
 
 	b.WriteString(" 'http://localhost:9200")
-	b.WriteString(req.URL.Path)
+	b.WriteString(reqURL.Path)
 	b.WriteString("?pretty")
 	if query != "" {
 		fmt.Fprintf(&b, "&%s", query)

--- a/estransport/logger.go
+++ b/estransport/logger.go
@@ -19,7 +19,12 @@ import (
 	"time"
 )
 
-var debugLogger DebuggingLogger
+var (
+	debugLogger        DebuggingLogger
+	errRequestEmpty    = errors.New("request is empty")
+	errRequestURLEmpty = errors.New("request URL is empty")
+	errResponseEmpty   = errors.New("response is empty")
+)
 
 // Logger defines an interface for logging request and response.
 //
@@ -82,10 +87,10 @@ type debuggingLogger struct {
 //
 func (l *TextLogger) LogRoundTrip(req *http.Request, res *http.Response, err error, start time.Time, dur time.Duration) error {
 	if req == nil {
-		return errors.New("request is empty")
+		return errRequestEmpty
 	}
 	if req.URL == nil {
-		return errors.New("request URL is empty")
+		return errRequestURLEmpty
 	}
 	fmt.Fprintf(l.Output, "%s %s %s [status:%d request:%s]\n",
 		start.Format(time.RFC3339),
@@ -126,13 +131,13 @@ func (l *TextLogger) ResponseBodyEnabled() bool { return l.EnableResponseBody }
 //
 func (l *ColorLogger) LogRoundTrip(req *http.Request, res *http.Response, err error, start time.Time, dur time.Duration) error {
 	if req == nil {
-		return errors.New("request is empty")
+		return errRequestEmpty
 	}
 	if req.URL == nil {
-		return errors.New("request URL is empty")
+		return errRequestURLEmpty
 	}
 	if res == nil {
-		return errors.New("response is empty")
+		return errResponseEmpty
 	}
 
 	query, _ := url.QueryUnescape(req.URL.RawQuery)
@@ -211,10 +216,10 @@ func (l *ColorLogger) ResponseBodyEnabled() bool { return l.EnableResponseBody }
 //
 func (l *CurlLogger) LogRoundTrip(req *http.Request, res *http.Response, err error, start time.Time, dur time.Duration) error {
 	if req == nil {
-		return errors.New("request is empty")
+		return errRequestEmpty
 	}
 	if req.URL == nil {
-		return errors.New("request URL is empty")
+		return errRequestURLEmpty
 	}
 	reqURL := req.URL
 
@@ -314,10 +319,10 @@ func (l *JSONLogger) LogRoundTrip(req *http.Request, res *http.Response, err err
 	//
 	// TODO(karmi): Research performance optimization of using sync.Pool
 	if req == nil {
-		return errors.New("request is empty")
+		return errRequestEmpty
 	}
 	if req.URL == nil {
-		return errors.New("request URL is empty")
+		return errRequestURLEmpty
 	}
 
 	bsize := 200

--- a/estransport/logger_internal_test.go
+++ b/estransport/logger_internal_test.go
@@ -7,6 +7,7 @@
 package estransport
 
 import (
+	"bytes"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -426,6 +427,103 @@ func TestTransportLogger(t *testing.T) {
 		}
 		if err.Error() != "MOCK ERROR" {
 			t.Errorf("Unexpected error value, expected [ERROR MOCK], got [%s]", err.Error())
+		}
+	})
+}
+
+func TestLoggers(t *testing.T) {
+	start := time.Now()
+	dur := time.Second
+	t.Run("TextLogger req == nil", func(t *testing.T) {
+		var buff bytes.Buffer
+		logger := TextLogger{Output: &buff}
+		err := logger.LogRoundTrip(nil, nil, nil, start, dur)
+		if !errors.Is(err, errRequestEmpty) {
+			t.Errorf("Expected error `%s`, got `%v`", errRequestEmpty, err)
+		}
+	})
+	t.Run("TextLogger req.URL == nil", func(t *testing.T) {
+		var buff bytes.Buffer
+		logger := TextLogger{Output: &buff}
+		req := http.Request{
+			Method: http.MethodGet,
+		}
+
+		err := logger.LogRoundTrip(&req, nil, nil, start, dur)
+		if !errors.Is(err, errRequestURLEmpty) {
+			t.Errorf("Expected error `%s`, got `%v`", errRequestURLEmpty, err)
+		}
+	})
+	t.Run("ColorLogger req == nil", func(t *testing.T) {
+		var buff bytes.Buffer
+		logger := ColorLogger{Output: &buff}
+		err := logger.LogRoundTrip(nil, nil, nil, start, dur)
+		if !errors.Is(err, errRequestEmpty) {
+			t.Errorf("Expected error `%s`, got `%v`", errRequestEmpty, err)
+		}
+	})
+	t.Run("ColorLogger req.URL == nil", func(t *testing.T) {
+		var buff bytes.Buffer
+		logger := ColorLogger{Output: &buff}
+		req := http.Request{
+			Method: http.MethodGet,
+		}
+
+		err := logger.LogRoundTrip(&req, nil, nil, start, dur)
+		if !errors.Is(err, errRequestURLEmpty) {
+			t.Errorf("Expected error `%s`, got `%v`", errRequestURLEmpty, err)
+		}
+	})
+	t.Run("ColorLogger res == nil", func(t *testing.T) {
+		var buff bytes.Buffer
+		logger := ColorLogger{Output: &buff}
+		req, err := http.NewRequest(http.MethodGet, "http:example.com", nil)
+		if err != nil {
+			t.Errorf("Unexpected error: %s", err)
+		}
+		err = logger.LogRoundTrip(req, nil, nil, start, dur)
+		if !errors.Is(err, errResponseEmpty) {
+			t.Errorf("Expected error `%s`, got `%v`", errResponseEmpty, err)
+		}
+	})
+	t.Run("CurlLogger req == nil", func(t *testing.T) {
+		var buff bytes.Buffer
+		logger := CurlLogger{Output: &buff}
+		err := logger.LogRoundTrip(nil, nil, nil, start, dur)
+		if !errors.Is(err, errRequestEmpty) {
+			t.Errorf("Expected error `%s`, got `%v`", errRequestEmpty, err)
+		}
+	})
+	t.Run("CurlLogger req.URL == nil", func(t *testing.T) {
+		var buff bytes.Buffer
+		logger := CurlLogger{Output: &buff}
+		req := http.Request{
+			Method: http.MethodGet,
+		}
+
+		err := logger.LogRoundTrip(&req, nil, nil, start, dur)
+		if !errors.Is(err, errRequestURLEmpty) {
+			t.Errorf("Expected error `%s`, got `%v`", errRequestURLEmpty, err)
+		}
+	})
+	t.Run("JSONLogger req == nil", func(t *testing.T) {
+		var buff bytes.Buffer
+		logger := JSONLogger{Output: &buff}
+		err := logger.LogRoundTrip(nil, nil, nil, start, dur)
+		if !errors.Is(err, errRequestEmpty) {
+			t.Errorf("Expected error `%s`, got `%v`", errRequestEmpty, err)
+		}
+	})
+	t.Run("JSONLogger req.URL == nil", func(t *testing.T) {
+		var buff bytes.Buffer
+		logger := JSONLogger{Output: &buff}
+		req := http.Request{
+			Method: http.MethodGet,
+		}
+
+		err := logger.LogRoundTrip(&req, nil, nil, start, dur)
+		if !errors.Is(err, errRequestURLEmpty) {
+			t.Errorf("Expected error `%s`, got `%v`", errRequestURLEmpty, err)
 		}
 	})
 }


### PR DESCRIPTION
Proposal.

There could be `nil pointer dereference` in these methods.

Check if req, res and req.URL are not `nil`.