### PR TITLE
Only replace methodName prefix if would be empty

### DIFF
--- a/esapi/api._.go
+++ b/esapi/api._.go
@@ -1,4 +1,4 @@
-// Code generated from specification version 8.0.0 (e56673015cb): DO NOT EDIT
+// Code generated from specification version 8.0.0 (bd873698bce): DO NOT EDIT
 
 package esapi
 
@@ -184,6 +184,7 @@ type Indices struct {
 	Exists                IndicesExists
 	ExistsTemplate        IndicesExistsTemplate
 	Flush                 IndicesFlush
+	FlushSynced           IndicesFlushSynced
 	Forcemerge            IndicesForcemerge
 	Freeze                IndicesFreeze
 	GetAlias              IndicesGetAlias
@@ -195,7 +196,9 @@ type Indices struct {
 	GetSettings           IndicesGetSettings
 	GetTemplate           IndicesGetTemplate
 	GetUpgrade            IndicesGetUpgrade
+	MigrateToDataStream   IndicesMigrateToDataStream
 	Open                  IndicesOpen
+	PromoteDataStream     IndicesPromoteDataStream
 	PutAlias              IndicesPutAlias
 	PutIndexTemplate      IndicesPutIndexTemplate
 	PutMapping            IndicesPutMapping
@@ -267,6 +270,7 @@ type Tasks struct {
 type AsyncSearch struct {
 	Delete AsyncSearchDelete
 	Get    AsyncSearchGet
+	Status AsyncSearchStatus
 	Submit AsyncSearchSubmit
 }
 
@@ -377,6 +381,7 @@ type ML struct {
 	UpdateFilter               MLUpdateFilter
 	UpdateJob                  MLUpdateJob
 	UpdateModelSnapshot        MLUpdateModelSnapshot
+	UpgradeJobSnapshot         MLUpgradeJobSnapshot
 	ValidateDetector           MLValidateDetector
 	Validate                   MLValidate
 }
@@ -393,6 +398,7 @@ type Rollup struct {
 	GetCaps      RollupGetRollupCaps
 	GetIndexCaps RollupGetRollupIndexCaps
 	PutJob       RollupPutJob
+	Rollup       RollupRollup
 	Search       RollupRollupSearch
 	StartJob     RollupStartJob
 	StopJob      RollupStopJob
@@ -452,6 +458,7 @@ type Watcher struct {
 	ExecuteWatch    WatcherExecuteWatch
 	GetWatch        WatcherGetWatch
 	PutWatch        WatcherPutWatch
+	QueryWatches    WatcherQueryWatches
 	Start           WatcherStart
 	Stats           WatcherStats
 	Stop            WatcherStop
@@ -617,6 +624,7 @@ func New(t Transport) *API {
 			Exists:                newIndicesExistsFunc(t),
 			ExistsTemplate:        newIndicesExistsTemplateFunc(t),
 			Flush:                 newIndicesFlushFunc(t),
+			FlushSynced:           newIndicesFlushSyncedFunc(t),
 			Forcemerge:            newIndicesForcemergeFunc(t),
 			Freeze:                newIndicesFreezeFunc(t),
 			GetAlias:              newIndicesGetAliasFunc(t),
@@ -628,7 +636,9 @@ func New(t Transport) *API {
 			GetSettings:           newIndicesGetSettingsFunc(t),
 			GetTemplate:           newIndicesGetTemplateFunc(t),
 			GetUpgrade:            newIndicesGetUpgradeFunc(t),
+			MigrateToDataStream:   newIndicesMigrateToDataStreamFunc(t),
 			Open:                  newIndicesOpenFunc(t),
+			PromoteDataStream:     newIndicesPromoteDataStreamFunc(t),
 			PutAlias:              newIndicesPutAliasFunc(t),
 			PutIndexTemplate:      newIndicesPutIndexTemplateFunc(t),
 			PutMapping:            newIndicesPutMappingFunc(t),
@@ -687,6 +697,7 @@ func New(t Transport) *API {
 		AsyncSearch: &AsyncSearch{
 			Delete: newAsyncSearchDeleteFunc(t),
 			Get:    newAsyncSearchGetFunc(t),
+			Status: newAsyncSearchStatusFunc(t),
 			Submit: newAsyncSearchSubmitFunc(t),
 		},
 		CCR: &CCR{
@@ -787,6 +798,7 @@ func New(t Transport) *API {
 			UpdateFilter:               newMLUpdateFilterFunc(t),
 			UpdateJob:                  newMLUpdateJobFunc(t),
 			UpdateModelSnapshot:        newMLUpdateModelSnapshotFunc(t),
+			UpgradeJobSnapshot:         newMLUpgradeJobSnapshotFunc(t),
 			ValidateDetector:           newMLValidateDetectorFunc(t),
 			Validate:                   newMLValidateFunc(t),
 		},
@@ -799,6 +811,7 @@ func New(t Transport) *API {
 			GetCaps:      newRollupGetRollupCapsFunc(t),
 			GetIndexCaps: newRollupGetRollupIndexCapsFunc(t),
 			PutJob:       newRollupPutJobFunc(t),
+			Rollup:       newRollupRollupFunc(t),
 			Search:       newRollupRollupSearchFunc(t),
 			StartJob:     newRollupStartJobFunc(t),
 			StopJob:      newRollupStopJobFunc(t),
@@ -850,6 +863,7 @@ func New(t Transport) *API {
 			ExecuteWatch:    newWatcherExecuteWatchFunc(t),
 			GetWatch:        newWatcherGetWatchFunc(t),
 			PutWatch:        newWatcherPutWatchFunc(t),
+			QueryWatches:    newWatcherQueryWatchesFunc(t),
 			Start:           newWatcherStartFunc(t),
 			Stats:           newWatcherStatsFunc(t),
 			Stop:            newWatcherStopFunc(t),

--- a/esapi/api.cat.indices.go
+++ b/esapi/api.cat.indices.go
@@ -44,7 +44,6 @@ type CatIndicesRequest struct {
 	Health                  string
 	Help                    *bool
 	IncludeUnloadedSegments *bool
-	Local                   *bool
 	MasterTimeout           time.Duration
 	Pri                     *bool
 	S                       []string
@@ -110,10 +109,6 @@ func (r CatIndicesRequest) Do(ctx context.Context, transport Transport) (*Respon
 
 	if r.IncludeUnloadedSegments != nil {
 		params["include_unloaded_segments"] = strconv.FormatBool(*r.IncludeUnloadedSegments)
-	}
-
-	if r.Local != nil {
-		params["local"] = strconv.FormatBool(*r.Local)
 	}
 
 	if r.MasterTimeout != 0 {
@@ -264,14 +259,6 @@ func (f CatIndices) WithHelp(v bool) func(*CatIndicesRequest) {
 func (f CatIndices) WithIncludeUnloadedSegments(v bool) func(*CatIndicesRequest) {
 	return func(r *CatIndicesRequest) {
 		r.IncludeUnloadedSegments = &v
-	}
-}
-
-// WithLocal - return local information, do not retrieve the state from master node (default: false).
-//
-func (f CatIndices) WithLocal(v bool) func(*CatIndicesRequest) {
-	return func(r *CatIndicesRequest) {
-		r.Local = &v
 	}
 }
 

--- a/esapi/api.cat.plugins.go
+++ b/esapi/api.cat.plugins.go
@@ -35,13 +35,14 @@ type CatPlugins func(o ...func(*CatPluginsRequest)) (*Response, error)
 // CatPluginsRequest configures the Cat Plugins API request.
 //
 type CatPluginsRequest struct {
-	Format        string
-	H             []string
-	Help          *bool
-	Local         *bool
-	MasterTimeout time.Duration
-	S             []string
-	V             *bool
+	Format           string
+	H                []string
+	Help             *bool
+	IncludeBootstrap *bool
+	Local            *bool
+	MasterTimeout    time.Duration
+	S                []string
+	V                *bool
 
 	Pretty     bool
 	Human      bool
@@ -79,6 +80,10 @@ func (r CatPluginsRequest) Do(ctx context.Context, transport Transport) (*Respon
 
 	if r.Help != nil {
 		params["help"] = strconv.FormatBool(*r.Help)
+	}
+
+	if r.IncludeBootstrap != nil {
+		params["include_bootstrap"] = strconv.FormatBool(*r.IncludeBootstrap)
 	}
 
 	if r.Local != nil {
@@ -185,6 +190,14 @@ func (f CatPlugins) WithH(v ...string) func(*CatPluginsRequest) {
 func (f CatPlugins) WithHelp(v bool) func(*CatPluginsRequest) {
 	return func(r *CatPluginsRequest) {
 		r.Help = &v
+	}
+}
+
+// WithIncludeBootstrap - include bootstrap plugins in the response.
+//
+func (f CatPlugins) WithIncludeBootstrap(v bool) func(*CatPluginsRequest) {
+	return func(r *CatPluginsRequest) {
+		r.IncludeBootstrap = &v
 	}
 }
 

--- a/esapi/api.cat.shards.go
+++ b/esapi/api.cat.shards.go
@@ -41,7 +41,6 @@ type CatShardsRequest struct {
 	Format        string
 	H             []string
 	Help          *bool
-	Local         *bool
 	MasterTimeout time.Duration
 	S             []string
 	Time          string
@@ -94,10 +93,6 @@ func (r CatShardsRequest) Do(ctx context.Context, transport Transport) (*Respons
 
 	if r.Help != nil {
 		params["help"] = strconv.FormatBool(*r.Help)
-	}
-
-	if r.Local != nil {
-		params["local"] = strconv.FormatBool(*r.Local)
 	}
 
 	if r.MasterTimeout != 0 {
@@ -220,14 +215,6 @@ func (f CatShards) WithH(v ...string) func(*CatShardsRequest) {
 func (f CatShards) WithHelp(v bool) func(*CatShardsRequest) {
 	return func(r *CatShardsRequest) {
 		r.Help = &v
-	}
-}
-
-// WithLocal - return local information, do not retrieve the state from master node (default: false).
-//
-func (f CatShards) WithLocal(v bool) func(*CatShardsRequest) {
-	return func(r *CatShardsRequest) {
-		r.Local = &v
 	}
 }
 

--- a/esapi/api.cat.tasks.go
+++ b/esapi/api.cat.tasks.go
@@ -27,6 +27,8 @@ func newCatTasksFunc(t Transport) CatTasks {
 
 // CatTasks returns information about the tasks currently executing on one or more nodes in the cluster.
 //
+// This API is experimental.
+//
 // See full documentation at https://www.elastic.co/guide/en/elasticsearch/reference/master/tasks.html.
 //
 type CatTasks func(o ...func(*CatTasksRequest)) (*Response, error)
@@ -34,16 +36,16 @@ type CatTasks func(o ...func(*CatTasksRequest)) (*Response, error)
 // CatTasksRequest configures the Cat Tasks API request.
 //
 type CatTasksRequest struct {
-	Actions    []string
-	Detailed   *bool
-	Format     string
-	H          []string
-	Help       *bool
-	NodeID     []string
-	ParentTask *int
-	S          []string
-	Time       string
-	V          *bool
+	Actions      []string
+	Detailed     *bool
+	Format       string
+	H            []string
+	Help         *bool
+	Nodes        []string
+	ParentTaskID string
+	S            []string
+	Time         string
+	V            *bool
 
 	Pretty     bool
 	Human      bool
@@ -91,12 +93,12 @@ func (r CatTasksRequest) Do(ctx context.Context, transport Transport) (*Response
 		params["help"] = strconv.FormatBool(*r.Help)
 	}
 
-	if len(r.NodeID) > 0 {
-		params["node_id"] = strings.Join(r.NodeID, ",")
+	if len(r.Nodes) > 0 {
+		params["nodes"] = strings.Join(r.Nodes, ",")
 	}
 
-	if r.ParentTask != nil {
-		params["parent_task"] = strconv.FormatInt(int64(*r.ParentTask), 10)
+	if r.ParentTaskID != "" {
+		params["parent_task_id"] = r.ParentTaskID
 	}
 
 	if len(r.S) > 0 {
@@ -218,19 +220,19 @@ func (f CatTasks) WithHelp(v bool) func(*CatTasksRequest) {
 	}
 }
 
-// WithNodeID - a list of node ids or names to limit the returned information; use `_local` to return information from the node you're connecting to, leave empty to get information from all nodes.
+// WithNodes - a list of node ids or names to limit the returned information; use `_local` to return information from the node you're connecting to, leave empty to get information from all nodes.
 //
-func (f CatTasks) WithNodeID(v ...string) func(*CatTasksRequest) {
+func (f CatTasks) WithNodes(v ...string) func(*CatTasksRequest) {
 	return func(r *CatTasksRequest) {
-		r.NodeID = v
+		r.Nodes = v
 	}
 }
 
-// WithParentTask - return tasks with specified parent task ID. set to -1 to return all..
+// WithParentTaskID - return tasks with specified parent task ID (node_id:task_number). set to -1 to return all..
 //
-func (f CatTasks) WithParentTask(v int) func(*CatTasksRequest) {
+func (f CatTasks) WithParentTaskID(v string) func(*CatTasksRequest) {
 	return func(r *CatTasksRequest) {
-		r.ParentTask = &v
+		r.ParentTaskID = v
 	}
 }
 

--- a/esapi/api.cluster.delete_component_template.go
+++ b/esapi/api.cluster.delete_component_template.go
@@ -27,8 +27,6 @@ func newClusterDeleteComponentTemplateFunc(t Transport) ClusterDeleteComponentTe
 
 // ClusterDeleteComponentTemplate deletes a component template
 //
-// This API is experimental.
-//
 // See full documentation at https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-component-template.html.
 //
 type ClusterDeleteComponentTemplate func(name string, o ...func(*ClusterDeleteComponentTemplateRequest)) (*Response, error)

--- a/esapi/api.cluster.exists_component_template.go
+++ b/esapi/api.cluster.exists_component_template.go
@@ -28,8 +28,6 @@ func newClusterExistsComponentTemplateFunc(t Transport) ClusterExistsComponentTe
 
 // ClusterExistsComponentTemplate returns information about whether a particular component template exist
 //
-// This API is experimental.
-//
 // See full documentation at https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-component-template.html.
 //
 type ClusterExistsComponentTemplate func(name string, o ...func(*ClusterExistsComponentTemplateRequest)) (*Response, error)

--- a/esapi/api.cluster.get_component_template.go
+++ b/esapi/api.cluster.get_component_template.go
@@ -28,8 +28,6 @@ func newClusterGetComponentTemplateFunc(t Transport) ClusterGetComponentTemplate
 
 // ClusterGetComponentTemplate returns one or more component templates
 //
-// This API is experimental.
-//
 // See full documentation at https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-component-template.html.
 //
 type ClusterGetComponentTemplate func(o ...func(*ClusterGetComponentTemplateRequest)) (*Response, error)

--- a/esapi/api.cluster.put_component_template.go
+++ b/esapi/api.cluster.put_component_template.go
@@ -29,8 +29,6 @@ func newClusterPutComponentTemplateFunc(t Transport) ClusterPutComponentTemplate
 
 // ClusterPutComponentTemplate creates or updates a component template
 //
-// This API is experimental.
-//
 // See full documentation at https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-component-template.html.
 //
 type ClusterPutComponentTemplate func(name string, body io.Reader, o ...func(*ClusterPutComponentTemplateRequest)) (*Response, error)

--- a/esapi/api.indices.delete_index_template.go
+++ b/esapi/api.indices.delete_index_template.go
@@ -27,8 +27,6 @@ func newIndicesDeleteIndexTemplateFunc(t Transport) IndicesDeleteIndexTemplate {
 
 // IndicesDeleteIndexTemplate deletes an index template.
 //
-// This API is experimental.
-//
 // See full documentation at https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-templates.html.
 //
 type IndicesDeleteIndexTemplate func(name string, o ...func(*IndicesDeleteIndexTemplateRequest)) (*Response, error)

--- a/esapi/api.indices.exists_index_template.go
+++ b/esapi/api.indices.exists_index_template.go
@@ -28,8 +28,6 @@ func newIndicesExistsIndexTemplateFunc(t Transport) IndicesExistsIndexTemplate {
 
 // IndicesExistsIndexTemplate returns information about whether a particular index template exists.
 //
-// This API is experimental.
-//
 // See full documentation at https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-templates.html.
 //
 type IndicesExistsIndexTemplate func(name string, o ...func(*IndicesExistsIndexTemplateRequest)) (*Response, error)

--- a/esapi/api.indices.flush_synced.go
+++ b/esapi/api.indices.flush_synced.go
@@ -1,0 +1,241 @@
+// Licensed to Elasticsearch B.V under one or more agreements.
+// Elasticsearch B.V. licenses this file to you under the Apache 2.0 License.
+// See the LICENSE file in the project root for more information.
+//
+// Code generated from specification version 7.11.0: DO NOT EDIT
+
+package esapi
+
+import (
+	"context"
+	"net/http"
+	"strconv"
+	"strings"
+)
+
+func newIndicesFlushSyncedFunc(t Transport) IndicesFlushSynced {
+	return func(o ...func(*IndicesFlushSyncedRequest)) (*Response, error) {
+		var r = IndicesFlushSyncedRequest{}
+		for _, f := range o {
+			f(&r)
+		}
+		return r.Do(r.ctx, t)
+	}
+}
+
+// ----- API Definition -------------------------------------------------------
+
+// IndicesFlushSynced performs a synced flush operation on one or more indices. Synced flush is deprecated and will be removed in 8.0. Use flush instead
+//
+// See full documentation at https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-synced-flush-api.html.
+//
+type IndicesFlushSynced func(o ...func(*IndicesFlushSyncedRequest)) (*Response, error)
+
+// IndicesFlushSyncedRequest configures the Indices Flush Synced API request.
+//
+type IndicesFlushSyncedRequest struct {
+	Index []string
+
+	AllowNoIndices    *bool
+	ExpandWildcards   string
+	IgnoreUnavailable *bool
+
+	Pretty     bool
+	Human      bool
+	ErrorTrace bool
+	FilterPath []string
+
+	Header http.Header
+
+	ctx context.Context
+}
+
+// Do executes the request and returns response or error.
+//
+func (r IndicesFlushSyncedRequest) Do(ctx context.Context, transport Transport) (*Response, error) {
+	var (
+		method string
+		path   strings.Builder
+		params map[string]string
+	)
+
+	method = "POST"
+
+	path.Grow(1 + len(strings.Join(r.Index, ",")) + 1 + len("_flush") + 1 + len("synced"))
+	if len(r.Index) > 0 {
+		path.WriteString("/")
+		path.WriteString(strings.Join(r.Index, ","))
+	}
+	path.WriteString("/")
+	path.WriteString("_flush")
+	path.WriteString("/")
+	path.WriteString("synced")
+
+	params = make(map[string]string)
+
+	if r.AllowNoIndices != nil {
+		params["allow_no_indices"] = strconv.FormatBool(*r.AllowNoIndices)
+	}
+
+	if r.ExpandWildcards != "" {
+		params["expand_wildcards"] = r.ExpandWildcards
+	}
+
+	if r.IgnoreUnavailable != nil {
+		params["ignore_unavailable"] = strconv.FormatBool(*r.IgnoreUnavailable)
+	}
+
+	if r.Pretty {
+		params["pretty"] = "true"
+	}
+
+	if r.Human {
+		params["human"] = "true"
+	}
+
+	if r.ErrorTrace {
+		params["error_trace"] = "true"
+	}
+
+	if len(r.FilterPath) > 0 {
+		params["filter_path"] = strings.Join(r.FilterPath, ",")
+	}
+
+	req, err := newRequest(method, path.String(), nil)
+	if err != nil {
+		return nil, err
+	}
+
+	if len(params) > 0 {
+		q := req.URL.Query()
+		for k, v := range params {
+			q.Set(k, v)
+		}
+		req.URL.RawQuery = q.Encode()
+	}
+
+	if len(r.Header) > 0 {
+		if len(req.Header) == 0 {
+			req.Header = r.Header
+		} else {
+			for k, vv := range r.Header {
+				for _, v := range vv {
+					req.Header.Add(k, v)
+				}
+			}
+		}
+	}
+
+	if ctx != nil {
+		req = req.WithContext(ctx)
+	}
+
+	res, err := transport.Perform(req)
+	if err != nil {
+		return nil, err
+	}
+
+	response := Response{
+		StatusCode: res.StatusCode,
+		Body:       res.Body,
+		Header:     res.Header,
+	}
+
+	return &response, nil
+}
+
+// WithContext sets the request context.
+//
+func (f IndicesFlushSynced) WithContext(v context.Context) func(*IndicesFlushSyncedRequest) {
+	return func(r *IndicesFlushSyncedRequest) {
+		r.ctx = v
+	}
+}
+
+// WithIndex - a list of index names; use _all for all indices.
+//
+func (f IndicesFlushSynced) WithIndex(v ...string) func(*IndicesFlushSyncedRequest) {
+	return func(r *IndicesFlushSyncedRequest) {
+		r.Index = v
+	}
+}
+
+// WithAllowNoIndices - whether to ignore if a wildcard indices expression resolves into no concrete indices. (this includes `_all` string or when no indices have been specified).
+//
+func (f IndicesFlushSynced) WithAllowNoIndices(v bool) func(*IndicesFlushSyncedRequest) {
+	return func(r *IndicesFlushSyncedRequest) {
+		r.AllowNoIndices = &v
+	}
+}
+
+// WithExpandWildcards - whether to expand wildcard expression to concrete indices that are open, closed or both..
+//
+func (f IndicesFlushSynced) WithExpandWildcards(v string) func(*IndicesFlushSyncedRequest) {
+	return func(r *IndicesFlushSyncedRequest) {
+		r.ExpandWildcards = v
+	}
+}
+
+// WithIgnoreUnavailable - whether specified concrete indices should be ignored when unavailable (missing or closed).
+//
+func (f IndicesFlushSynced) WithIgnoreUnavailable(v bool) func(*IndicesFlushSyncedRequest) {
+	return func(r *IndicesFlushSyncedRequest) {
+		r.IgnoreUnavailable = &v
+	}
+}
+
+// WithPretty makes the response body pretty-printed.
+//
+func (f IndicesFlushSynced) WithPretty() func(*IndicesFlushSyncedRequest) {
+	return func(r *IndicesFlushSyncedRequest) {
+		r.Pretty = true
+	}
+}
+
+// WithHuman makes statistical values human-readable.
+//
+func (f IndicesFlushSynced) WithHuman() func(*IndicesFlushSyncedRequest) {
+	return func(r *IndicesFlushSyncedRequest) {
+		r.Human = true
+	}
+}
+
+// WithErrorTrace includes the stack trace for errors in the response body.
+//
+func (f IndicesFlushSynced) WithErrorTrace() func(*IndicesFlushSyncedRequest) {
+	return func(r *IndicesFlushSyncedRequest) {
+		r.ErrorTrace = true
+	}
+}
+
+// WithFilterPath filters the properties of the response body.
+//
+func (f IndicesFlushSynced) WithFilterPath(v ...string) func(*IndicesFlushSyncedRequest) {
+	return func(r *IndicesFlushSyncedRequest) {
+		r.FilterPath = v
+	}
+}
+
+// WithHeader adds the headers to the HTTP request.
+//
+func (f IndicesFlushSynced) WithHeader(h map[string]string) func(*IndicesFlushSyncedRequest) {
+	return func(r *IndicesFlushSyncedRequest) {
+		if r.Header == nil {
+			r.Header = make(http.Header)
+		}
+		for k, v := range h {
+			r.Header.Add(k, v)
+		}
+	}
+}
+
+// WithOpaqueID adds the X-Opaque-Id header to the HTTP request.
+//
+func (f IndicesFlushSynced) WithOpaqueID(s string) func(*IndicesFlushSyncedRequest) {
+	return func(r *IndicesFlushSyncedRequest) {
+		if r.Header == nil {
+			r.Header = make(http.Header)
+		}
+		r.Header.Set("X-Opaque-Id", s)
+	}
+}

--- a/esapi/api.indices.get_index_template.go
+++ b/esapi/api.indices.get_index_template.go
@@ -28,8 +28,6 @@ func newIndicesGetIndexTemplateFunc(t Transport) IndicesGetIndexTemplate {
 
 // IndicesGetIndexTemplate returns an index template.
 //
-// This API is experimental.
-//
 // See full documentation at https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-templates.html.
 //
 type IndicesGetIndexTemplate func(o ...func(*IndicesGetIndexTemplateRequest)) (*Response, error)

--- a/esapi/api.indices.put_index_template.go
+++ b/esapi/api.indices.put_index_template.go
@@ -29,8 +29,6 @@ func newIndicesPutIndexTemplateFunc(t Transport) IndicesPutIndexTemplate {
 
 // IndicesPutIndexTemplate creates or updates an index template.
 //
-// This API is experimental.
-//
 // See full documentation at https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-templates.html.
 //
 type IndicesPutIndexTemplate func(name string, body io.Reader, o ...func(*IndicesPutIndexTemplateRequest)) (*Response, error)

--- a/esapi/api.indices.simulate_index_template.go
+++ b/esapi/api.indices.simulate_index_template.go
@@ -29,8 +29,6 @@ func newIndicesSimulateIndexTemplateFunc(t Transport) IndicesSimulateIndexTempla
 
 // IndicesSimulateIndexTemplate simulate matching the given index name against the index templates in the system
 //
-// This API is experimental.
-//
 // See full documentation at https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-templates.html.
 //
 type IndicesSimulateIndexTemplate func(name string, o ...func(*IndicesSimulateIndexTemplateRequest)) (*Response, error)

--- a/esapi/api.indices.simulate_template.go
+++ b/esapi/api.indices.simulate_template.go
@@ -29,8 +29,6 @@ func newIndicesSimulateTemplateFunc(t Transport) IndicesSimulateTemplate {
 
 // IndicesSimulateTemplate simulate resolving the given template name or body
 //
-// This API is experimental.
-//
 // See full documentation at https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-templates.html.
 //
 type IndicesSimulateTemplate func(o ...func(*IndicesSimulateTemplateRequest)) (*Response, error)

--- a/esapi/api.indices.stats.go
+++ b/esapi/api.indices.stats.go
@@ -207,7 +207,7 @@ func (f IndicesStats) WithMetric(v ...string) func(*IndicesStatsRequest) {
 	}
 }
 
-// WithCompletionFields - a list of fields for `fielddata` and `suggest` index metric (supports wildcards).
+// WithCompletionFields - a list of fields for the `completion` index metric (supports wildcards).
 //
 func (f IndicesStats) WithCompletionFields(v ...string) func(*IndicesStatsRequest) {
 	return func(r *IndicesStatsRequest) {
@@ -223,7 +223,7 @@ func (f IndicesStats) WithExpandWildcards(v string) func(*IndicesStatsRequest) {
 	}
 }
 
-// WithFielddataFields - a list of fields for `fielddata` index metric (supports wildcards).
+// WithFielddataFields - a list of fields for the `fielddata` index metric (supports wildcards).
 //
 func (f IndicesStats) WithFielddataFields(v ...string) func(*IndicesStatsRequest) {
 	return func(r *IndicesStatsRequest) {

--- a/esapi/api.nodes.stats.go
+++ b/esapi/api.nodes.stats.go
@@ -212,7 +212,7 @@ func (f NodesStats) WithNodeID(v ...string) func(*NodesStatsRequest) {
 	}
 }
 
-// WithCompletionFields - a list of fields for `fielddata` and `suggest` index metric (supports wildcards).
+// WithCompletionFields - a list of fields for the `completion` index metric (supports wildcards).
 //
 func (f NodesStats) WithCompletionFields(v ...string) func(*NodesStatsRequest) {
 	return func(r *NodesStatsRequest) {
@@ -220,7 +220,7 @@ func (f NodesStats) WithCompletionFields(v ...string) func(*NodesStatsRequest) {
 	}
 }
 
-// WithFielddataFields - a list of fields for `fielddata` index metric (supports wildcards).
+// WithFielddataFields - a list of fields for the `fielddata` index metric (supports wildcards).
 //
 func (f NodesStats) WithFielddataFields(v ...string) func(*NodesStatsRequest) {
 	return func(r *NodesStatsRequest) {

--- a/esapi/api.tasks.cancel.go
+++ b/esapi/api.tasks.cancel.go
@@ -27,6 +27,8 @@ func newTasksCancelFunc(t Transport) TasksCancel {
 
 // TasksCancel cancels a task, if it can be cancelled through an API.
 //
+// This API is experimental.
+//
 // See full documentation at https://www.elastic.co/guide/en/elasticsearch/reference/master/tasks.html.
 //
 type TasksCancel func(o ...func(*TasksCancelRequest)) (*Response, error)

--- a/esapi/api.tasks.list.go
+++ b/esapi/api.tasks.list.go
@@ -28,6 +28,8 @@ func newTasksListFunc(t Transport) TasksList {
 
 // TasksList returns a list of tasks.
 //
+// This API is experimental.
+//
 // See full documentation at https://www.elastic.co/guide/en/elasticsearch/reference/master/tasks.html.
 //
 type TasksList func(o ...func(*TasksListRequest)) (*Response, error)

--- a/esapi/api.xpack.async_search.status.go
+++ b/esapi/api.xpack.async_search.status.go
@@ -12,9 +12,9 @@ import (
 	"strings"
 )
 
-func newIndicesGetDataStreamFunc(t Transport) IndicesGetDataStream {
-	return func(o ...func(*IndicesGetDataStreamRequest)) (*Response, error) {
-		var r = IndicesGetDataStreamRequest{}
+func newAsyncSearchStatusFunc(t Transport) AsyncSearchStatus {
+	return func(id string, o ...func(*AsyncSearchStatusRequest)) (*Response, error) {
+		var r = AsyncSearchStatusRequest{DocumentID: id}
 		for _, f := range o {
 			f(&r)
 		}
@@ -24,18 +24,16 @@ func newIndicesGetDataStreamFunc(t Transport) IndicesGetDataStream {
 
 // ----- API Definition -------------------------------------------------------
 
-// IndicesGetDataStream - Returns data streams.
+// AsyncSearchStatus - Retrieves the status of a previously submitted async search request given its ID.
 //
-// See full documentation at https://www.elastic.co/guide/en/elasticsearch/reference/master/data-streams.html.
+// See full documentation at https://www.elastic.co/guide/en/elasticsearch/reference/current/async-search.html.
 //
-type IndicesGetDataStream func(o ...func(*IndicesGetDataStreamRequest)) (*Response, error)
+type AsyncSearchStatus func(id string, o ...func(*AsyncSearchStatusRequest)) (*Response, error)
 
-// IndicesGetDataStreamRequest configures the Indices Get Data Stream API request.
+// AsyncSearchStatusRequest configures the Async Search Status API request.
 //
-type IndicesGetDataStreamRequest struct {
-	Name []string
-
-	ExpandWildcards string
+type AsyncSearchStatusRequest struct {
+	DocumentID string
 
 	Pretty     bool
 	Human      bool
@@ -49,7 +47,7 @@ type IndicesGetDataStreamRequest struct {
 
 // Do executes the request and returns response or error.
 //
-func (r IndicesGetDataStreamRequest) Do(ctx context.Context, transport Transport) (*Response, error) {
+func (r AsyncSearchStatusRequest) Do(ctx context.Context, transport Transport) (*Response, error) {
 	var (
 		method string
 		path   strings.Builder
@@ -58,19 +56,15 @@ func (r IndicesGetDataStreamRequest) Do(ctx context.Context, transport Transport
 
 	method = "GET"
 
-	path.Grow(1 + len("_data_stream") + 1 + len(strings.Join(r.Name, ",")))
+	path.Grow(1 + len("_async_search") + 1 + len("status") + 1 + len(r.DocumentID))
 	path.WriteString("/")
-	path.WriteString("_data_stream")
-	if len(r.Name) > 0 {
-		path.WriteString("/")
-		path.WriteString(strings.Join(r.Name, ","))
-	}
+	path.WriteString("_async_search")
+	path.WriteString("/")
+	path.WriteString("status")
+	path.WriteString("/")
+	path.WriteString(r.DocumentID)
 
 	params = make(map[string]string)
-
-	if r.ExpandWildcards != "" {
-		params["expand_wildcards"] = r.ExpandWildcards
-	}
 
 	if r.Pretty {
 		params["pretty"] = "true"
@@ -133,64 +127,48 @@ func (r IndicesGetDataStreamRequest) Do(ctx context.Context, transport Transport
 
 // WithContext sets the request context.
 //
-func (f IndicesGetDataStream) WithContext(v context.Context) func(*IndicesGetDataStreamRequest) {
-	return func(r *IndicesGetDataStreamRequest) {
+func (f AsyncSearchStatus) WithContext(v context.Context) func(*AsyncSearchStatusRequest) {
+	return func(r *AsyncSearchStatusRequest) {
 		r.ctx = v
-	}
-}
-
-// WithName - a list of data streams to get; use `*` to get all data streams.
-//
-func (f IndicesGetDataStream) WithName(v ...string) func(*IndicesGetDataStreamRequest) {
-	return func(r *IndicesGetDataStreamRequest) {
-		r.Name = v
-	}
-}
-
-// WithExpandWildcards - whether wildcard expressions should get expanded to open or closed indices (default: open).
-//
-func (f IndicesGetDataStream) WithExpandWildcards(v string) func(*IndicesGetDataStreamRequest) {
-	return func(r *IndicesGetDataStreamRequest) {
-		r.ExpandWildcards = v
 	}
 }
 
 // WithPretty makes the response body pretty-printed.
 //
-func (f IndicesGetDataStream) WithPretty() func(*IndicesGetDataStreamRequest) {
-	return func(r *IndicesGetDataStreamRequest) {
+func (f AsyncSearchStatus) WithPretty() func(*AsyncSearchStatusRequest) {
+	return func(r *AsyncSearchStatusRequest) {
 		r.Pretty = true
 	}
 }
 
 // WithHuman makes statistical values human-readable.
 //
-func (f IndicesGetDataStream) WithHuman() func(*IndicesGetDataStreamRequest) {
-	return func(r *IndicesGetDataStreamRequest) {
+func (f AsyncSearchStatus) WithHuman() func(*AsyncSearchStatusRequest) {
+	return func(r *AsyncSearchStatusRequest) {
 		r.Human = true
 	}
 }
 
 // WithErrorTrace includes the stack trace for errors in the response body.
 //
-func (f IndicesGetDataStream) WithErrorTrace() func(*IndicesGetDataStreamRequest) {
-	return func(r *IndicesGetDataStreamRequest) {
+func (f AsyncSearchStatus) WithErrorTrace() func(*AsyncSearchStatusRequest) {
+	return func(r *AsyncSearchStatusRequest) {
 		r.ErrorTrace = true
 	}
 }
 
 // WithFilterPath filters the properties of the response body.
 //
-func (f IndicesGetDataStream) WithFilterPath(v ...string) func(*IndicesGetDataStreamRequest) {
-	return func(r *IndicesGetDataStreamRequest) {
+func (f AsyncSearchStatus) WithFilterPath(v ...string) func(*AsyncSearchStatusRequest) {
+	return func(r *AsyncSearchStatusRequest) {
 		r.FilterPath = v
 	}
 }
 
 // WithHeader adds the headers to the HTTP request.
 //
-func (f IndicesGetDataStream) WithHeader(h map[string]string) func(*IndicesGetDataStreamRequest) {
-	return func(r *IndicesGetDataStreamRequest) {
+func (f AsyncSearchStatus) WithHeader(h map[string]string) func(*AsyncSearchStatusRequest) {
+	return func(r *AsyncSearchStatusRequest) {
 		if r.Header == nil {
 			r.Header = make(http.Header)
 		}
@@ -202,8 +180,8 @@ func (f IndicesGetDataStream) WithHeader(h map[string]string) func(*IndicesGetDa
 
 // WithOpaqueID adds the X-Opaque-Id header to the HTTP request.
 //
-func (f IndicesGetDataStream) WithOpaqueID(s string) func(*IndicesGetDataStreamRequest) {
-	return func(r *IndicesGetDataStreamRequest) {
+func (f AsyncSearchStatus) WithOpaqueID(s string) func(*AsyncSearchStatusRequest) {
+	return func(r *AsyncSearchStatusRequest) {
 		if r.Header == nil {
 			r.Header = make(http.Header)
 		}

--- a/esapi/api.xpack.eql.delete.go
+++ b/esapi/api.xpack.eql.delete.go
@@ -26,8 +26,6 @@ func newEqlDeleteFunc(t Transport) EqlDelete {
 
 // EqlDelete - Deletes an async EQL search by ID. If the search is still running, the search request will be cancelled. Otherwise, the saved search results are deleted.
 //
-// This API is beta.
-//
 // See full documentation at https://www.elastic.co/guide/en/elasticsearch/reference/current/eql-search-api.html.
 //
 type EqlDelete func(id string, o ...func(*EqlDeleteRequest)) (*Response, error)

--- a/esapi/api.xpack.eql.get.go
+++ b/esapi/api.xpack.eql.get.go
@@ -27,8 +27,6 @@ func newEqlGetFunc(t Transport) EqlGet {
 
 // EqlGet - Returns async results from previously executed Event Query Language (EQL) search
 //
-// This API is beta.
-//
 // See full documentation at https://www.elastic.co/guide/en/elasticsearch/reference/current/eql-search-api.html.
 //
 type EqlGet func(id string, o ...func(*EqlGetRequest)) (*Response, error)

--- a/esapi/api.xpack.eql.search.go
+++ b/esapi/api.xpack.eql.search.go
@@ -29,8 +29,6 @@ func newEqlSearchFunc(t Transport) EqlSearch {
 
 // EqlSearch - Returns results matching a query expressed in Event Query Language (EQL)
 //
-// This API is beta.
-//
 // See full documentation at https://www.elastic.co/guide/en/elasticsearch/reference/current/eql-search-api.html.
 //
 type EqlSearch func(index string, body io.Reader, o ...func(*EqlSearchRequest)) (*Response, error)

--- a/esapi/api.xpack.indices.migrate_to_data_stream.go
+++ b/esapi/api.xpack.indices.migrate_to_data_stream.go
@@ -12,9 +12,9 @@ import (
 	"strings"
 )
 
-func newIndicesGetDataStreamFunc(t Transport) IndicesGetDataStream {
-	return func(o ...func(*IndicesGetDataStreamRequest)) (*Response, error) {
-		var r = IndicesGetDataStreamRequest{}
+func newIndicesMigrateToDataStreamFunc(t Transport) IndicesMigrateToDataStream {
+	return func(name string, o ...func(*IndicesMigrateToDataStreamRequest)) (*Response, error) {
+		var r = IndicesMigrateToDataStreamRequest{Name: name}
 		for _, f := range o {
 			f(&r)
 		}
@@ -24,18 +24,16 @@ func newIndicesGetDataStreamFunc(t Transport) IndicesGetDataStream {
 
 // ----- API Definition -------------------------------------------------------
 
-// IndicesGetDataStream - Returns data streams.
+// IndicesMigrateToDataStream - Migrates an alias to a data stream
 //
 // See full documentation at https://www.elastic.co/guide/en/elasticsearch/reference/master/data-streams.html.
 //
-type IndicesGetDataStream func(o ...func(*IndicesGetDataStreamRequest)) (*Response, error)
+type IndicesMigrateToDataStream func(name string, o ...func(*IndicesMigrateToDataStreamRequest)) (*Response, error)
 
-// IndicesGetDataStreamRequest configures the Indices Get Data Stream API request.
+// IndicesMigrateToDataStreamRequest configures the Indices Migrate To Data Stream API request.
 //
-type IndicesGetDataStreamRequest struct {
-	Name []string
-
-	ExpandWildcards string
+type IndicesMigrateToDataStreamRequest struct {
+	Name string
 
 	Pretty     bool
 	Human      bool
@@ -49,28 +47,24 @@ type IndicesGetDataStreamRequest struct {
 
 // Do executes the request and returns response or error.
 //
-func (r IndicesGetDataStreamRequest) Do(ctx context.Context, transport Transport) (*Response, error) {
+func (r IndicesMigrateToDataStreamRequest) Do(ctx context.Context, transport Transport) (*Response, error) {
 	var (
 		method string
 		path   strings.Builder
 		params map[string]string
 	)
 
-	method = "GET"
+	method = "POST"
 
-	path.Grow(1 + len("_data_stream") + 1 + len(strings.Join(r.Name, ",")))
+	path.Grow(1 + len("_data_stream") + 1 + len("_migrate") + 1 + len(r.Name))
 	path.WriteString("/")
 	path.WriteString("_data_stream")
-	if len(r.Name) > 0 {
-		path.WriteString("/")
-		path.WriteString(strings.Join(r.Name, ","))
-	}
+	path.WriteString("/")
+	path.WriteString("_migrate")
+	path.WriteString("/")
+	path.WriteString(r.Name)
 
 	params = make(map[string]string)
-
-	if r.ExpandWildcards != "" {
-		params["expand_wildcards"] = r.ExpandWildcards
-	}
 
 	if r.Pretty {
 		params["pretty"] = "true"
@@ -133,64 +127,48 @@ func (r IndicesGetDataStreamRequest) Do(ctx context.Context, transport Transport
 
 // WithContext sets the request context.
 //
-func (f IndicesGetDataStream) WithContext(v context.Context) func(*IndicesGetDataStreamRequest) {
-	return func(r *IndicesGetDataStreamRequest) {
+func (f IndicesMigrateToDataStream) WithContext(v context.Context) func(*IndicesMigrateToDataStreamRequest) {
+	return func(r *IndicesMigrateToDataStreamRequest) {
 		r.ctx = v
-	}
-}
-
-// WithName - a list of data streams to get; use `*` to get all data streams.
-//
-func (f IndicesGetDataStream) WithName(v ...string) func(*IndicesGetDataStreamRequest) {
-	return func(r *IndicesGetDataStreamRequest) {
-		r.Name = v
-	}
-}
-
-// WithExpandWildcards - whether wildcard expressions should get expanded to open or closed indices (default: open).
-//
-func (f IndicesGetDataStream) WithExpandWildcards(v string) func(*IndicesGetDataStreamRequest) {
-	return func(r *IndicesGetDataStreamRequest) {
-		r.ExpandWildcards = v
 	}
 }
 
 // WithPretty makes the response body pretty-printed.
 //
-func (f IndicesGetDataStream) WithPretty() func(*IndicesGetDataStreamRequest) {
-	return func(r *IndicesGetDataStreamRequest) {
+func (f IndicesMigrateToDataStream) WithPretty() func(*IndicesMigrateToDataStreamRequest) {
+	return func(r *IndicesMigrateToDataStreamRequest) {
 		r.Pretty = true
 	}
 }
 
 // WithHuman makes statistical values human-readable.
 //
-func (f IndicesGetDataStream) WithHuman() func(*IndicesGetDataStreamRequest) {
-	return func(r *IndicesGetDataStreamRequest) {
+func (f IndicesMigrateToDataStream) WithHuman() func(*IndicesMigrateToDataStreamRequest) {
+	return func(r *IndicesMigrateToDataStreamRequest) {
 		r.Human = true
 	}
 }
 
 // WithErrorTrace includes the stack trace for errors in the response body.
 //
-func (f IndicesGetDataStream) WithErrorTrace() func(*IndicesGetDataStreamRequest) {
-	return func(r *IndicesGetDataStreamRequest) {
+func (f IndicesMigrateToDataStream) WithErrorTrace() func(*IndicesMigrateToDataStreamRequest) {
+	return func(r *IndicesMigrateToDataStreamRequest) {
 		r.ErrorTrace = true
 	}
 }
 
 // WithFilterPath filters the properties of the response body.
 //
-func (f IndicesGetDataStream) WithFilterPath(v ...string) func(*IndicesGetDataStreamRequest) {
-	return func(r *IndicesGetDataStreamRequest) {
+func (f IndicesMigrateToDataStream) WithFilterPath(v ...string) func(*IndicesMigrateToDataStreamRequest) {
+	return func(r *IndicesMigrateToDataStreamRequest) {
 		r.FilterPath = v
 	}
 }
 
 // WithHeader adds the headers to the HTTP request.
 //
-func (f IndicesGetDataStream) WithHeader(h map[string]string) func(*IndicesGetDataStreamRequest) {
-	return func(r *IndicesGetDataStreamRequest) {
+func (f IndicesMigrateToDataStream) WithHeader(h map[string]string) func(*IndicesMigrateToDataStreamRequest) {
+	return func(r *IndicesMigrateToDataStreamRequest) {
 		if r.Header == nil {
 			r.Header = make(http.Header)
 		}
@@ -202,8 +180,8 @@ func (f IndicesGetDataStream) WithHeader(h map[string]string) func(*IndicesGetDa
 
 // WithOpaqueID adds the X-Opaque-Id header to the HTTP request.
 //
-func (f IndicesGetDataStream) WithOpaqueID(s string) func(*IndicesGetDataStreamRequest) {
-	return func(r *IndicesGetDataStreamRequest) {
+func (f IndicesMigrateToDataStream) WithOpaqueID(s string) func(*IndicesMigrateToDataStreamRequest) {
+	return func(r *IndicesMigrateToDataStreamRequest) {
 		if r.Header == nil {
 			r.Header = make(http.Header)
 		}

--- a/esapi/api.xpack.indices.promote_data_stream.go
+++ b/esapi/api.xpack.indices.promote_data_stream.go
@@ -12,9 +12,9 @@ import (
 	"strings"
 )
 
-func newIndicesGetDataStreamFunc(t Transport) IndicesGetDataStream {
-	return func(o ...func(*IndicesGetDataStreamRequest)) (*Response, error) {
-		var r = IndicesGetDataStreamRequest{}
+func newIndicesPromoteDataStreamFunc(t Transport) IndicesPromoteDataStream {
+	return func(name string, o ...func(*IndicesPromoteDataStreamRequest)) (*Response, error) {
+		var r = IndicesPromoteDataStreamRequest{Name: name}
 		for _, f := range o {
 			f(&r)
 		}
@@ -24,18 +24,16 @@ func newIndicesGetDataStreamFunc(t Transport) IndicesGetDataStream {
 
 // ----- API Definition -------------------------------------------------------
 
-// IndicesGetDataStream - Returns data streams.
+// IndicesPromoteDataStream - Promotes a data stream from a replicated data stream managed by CCR to a regular data stream
 //
 // See full documentation at https://www.elastic.co/guide/en/elasticsearch/reference/master/data-streams.html.
 //
-type IndicesGetDataStream func(o ...func(*IndicesGetDataStreamRequest)) (*Response, error)
+type IndicesPromoteDataStream func(name string, o ...func(*IndicesPromoteDataStreamRequest)) (*Response, error)
 
-// IndicesGetDataStreamRequest configures the Indices Get Data Stream API request.
+// IndicesPromoteDataStreamRequest configures the Indices Promote Data Stream API request.
 //
-type IndicesGetDataStreamRequest struct {
-	Name []string
-
-	ExpandWildcards string
+type IndicesPromoteDataStreamRequest struct {
+	Name string
 
 	Pretty     bool
 	Human      bool
@@ -49,28 +47,24 @@ type IndicesGetDataStreamRequest struct {
 
 // Do executes the request and returns response or error.
 //
-func (r IndicesGetDataStreamRequest) Do(ctx context.Context, transport Transport) (*Response, error) {
+func (r IndicesPromoteDataStreamRequest) Do(ctx context.Context, transport Transport) (*Response, error) {
 	var (
 		method string
 		path   strings.Builder
 		params map[string]string
 	)
 
-	method = "GET"
+	method = "POST"
 
-	path.Grow(1 + len("_data_stream") + 1 + len(strings.Join(r.Name, ",")))
+	path.Grow(1 + len("_data_stream") + 1 + len("_promote") + 1 + len(r.Name))
 	path.WriteString("/")
 	path.WriteString("_data_stream")
-	if len(r.Name) > 0 {
-		path.WriteString("/")
-		path.WriteString(strings.Join(r.Name, ","))
-	}
+	path.WriteString("/")
+	path.WriteString("_promote")
+	path.WriteString("/")
+	path.WriteString(r.Name)
 
 	params = make(map[string]string)
-
-	if r.ExpandWildcards != "" {
-		params["expand_wildcards"] = r.ExpandWildcards
-	}
 
 	if r.Pretty {
 		params["pretty"] = "true"
@@ -133,64 +127,48 @@ func (r IndicesGetDataStreamRequest) Do(ctx context.Context, transport Transport
 
 // WithContext sets the request context.
 //
-func (f IndicesGetDataStream) WithContext(v context.Context) func(*IndicesGetDataStreamRequest) {
-	return func(r *IndicesGetDataStreamRequest) {
+func (f IndicesPromoteDataStream) WithContext(v context.Context) func(*IndicesPromoteDataStreamRequest) {
+	return func(r *IndicesPromoteDataStreamRequest) {
 		r.ctx = v
-	}
-}
-
-// WithName - a list of data streams to get; use `*` to get all data streams.
-//
-func (f IndicesGetDataStream) WithName(v ...string) func(*IndicesGetDataStreamRequest) {
-	return func(r *IndicesGetDataStreamRequest) {
-		r.Name = v
-	}
-}
-
-// WithExpandWildcards - whether wildcard expressions should get expanded to open or closed indices (default: open).
-//
-func (f IndicesGetDataStream) WithExpandWildcards(v string) func(*IndicesGetDataStreamRequest) {
-	return func(r *IndicesGetDataStreamRequest) {
-		r.ExpandWildcards = v
 	}
 }
 
 // WithPretty makes the response body pretty-printed.
 //
-func (f IndicesGetDataStream) WithPretty() func(*IndicesGetDataStreamRequest) {
-	return func(r *IndicesGetDataStreamRequest) {
+func (f IndicesPromoteDataStream) WithPretty() func(*IndicesPromoteDataStreamRequest) {
+	return func(r *IndicesPromoteDataStreamRequest) {
 		r.Pretty = true
 	}
 }
 
 // WithHuman makes statistical values human-readable.
 //
-func (f IndicesGetDataStream) WithHuman() func(*IndicesGetDataStreamRequest) {
-	return func(r *IndicesGetDataStreamRequest) {
+func (f IndicesPromoteDataStream) WithHuman() func(*IndicesPromoteDataStreamRequest) {
+	return func(r *IndicesPromoteDataStreamRequest) {
 		r.Human = true
 	}
 }
 
 // WithErrorTrace includes the stack trace for errors in the response body.
 //
-func (f IndicesGetDataStream) WithErrorTrace() func(*IndicesGetDataStreamRequest) {
-	return func(r *IndicesGetDataStreamRequest) {
+func (f IndicesPromoteDataStream) WithErrorTrace() func(*IndicesPromoteDataStreamRequest) {
+	return func(r *IndicesPromoteDataStreamRequest) {
 		r.ErrorTrace = true
 	}
 }
 
 // WithFilterPath filters the properties of the response body.
 //
-func (f IndicesGetDataStream) WithFilterPath(v ...string) func(*IndicesGetDataStreamRequest) {
-	return func(r *IndicesGetDataStreamRequest) {
+func (f IndicesPromoteDataStream) WithFilterPath(v ...string) func(*IndicesPromoteDataStreamRequest) {
+	return func(r *IndicesPromoteDataStreamRequest) {
 		r.FilterPath = v
 	}
 }
 
 // WithHeader adds the headers to the HTTP request.
 //
-func (f IndicesGetDataStream) WithHeader(h map[string]string) func(*IndicesGetDataStreamRequest) {
-	return func(r *IndicesGetDataStreamRequest) {
+func (f IndicesPromoteDataStream) WithHeader(h map[string]string) func(*IndicesPromoteDataStreamRequest) {
+	return func(r *IndicesPromoteDataStreamRequest) {
 		if r.Header == nil {
 			r.Header = make(http.Header)
 		}
@@ -202,8 +180,8 @@ func (f IndicesGetDataStream) WithHeader(h map[string]string) func(*IndicesGetDa
 
 // WithOpaqueID adds the X-Opaque-Id header to the HTTP request.
 //
-func (f IndicesGetDataStream) WithOpaqueID(s string) func(*IndicesGetDataStreamRequest) {
-	return func(r *IndicesGetDataStreamRequest) {
+func (f IndicesPromoteDataStream) WithOpaqueID(s string) func(*IndicesPromoteDataStreamRequest) {
+	return func(r *IndicesPromoteDataStreamRequest) {
 		if r.Header == nil {
 			r.Header = make(http.Header)
 		}

--- a/esapi/api.xpack.ml.upgrade_job_snapshot.go
+++ b/esapi/api.xpack.ml.upgrade_job_snapshot.go
@@ -14,9 +14,9 @@ import (
 	"time"
 )
 
-func newTasksGetFunc(t Transport) TasksGet {
-	return func(task_id string, o ...func(*TasksGetRequest)) (*Response, error) {
-		var r = TasksGetRequest{TaskID: task_id}
+func newMLUpgradeJobSnapshotFunc(t Transport) MLUpgradeJobSnapshot {
+	return func(snapshot_id string, job_id string, o ...func(*MLUpgradeJobSnapshotRequest)) (*Response, error) {
+		var r = MLUpgradeJobSnapshotRequest{SnapshotID: snapshot_id, JobID: job_id}
 		for _, f := range o {
 			f(&r)
 		}
@@ -26,18 +26,17 @@ func newTasksGetFunc(t Transport) TasksGet {
 
 // ----- API Definition -------------------------------------------------------
 
-// TasksGet returns information about a task.
+// MLUpgradeJobSnapshot - Upgrades a given job snapshot to the current major version.
 //
-// This API is experimental.
+// See full documentation at https://www.elastic.co/guide/en/elasticsearch/reference/current/ml-upgrade-job-model-snapshot.html.
 //
-// See full documentation at https://www.elastic.co/guide/en/elasticsearch/reference/master/tasks.html.
-//
-type TasksGet func(task_id string, o ...func(*TasksGetRequest)) (*Response, error)
+type MLUpgradeJobSnapshot func(snapshot_id string, job_id string, o ...func(*MLUpgradeJobSnapshotRequest)) (*Response, error)
 
-// TasksGetRequest configures the Tasks Get API request.
+// MLUpgradeJobSnapshotRequest configures the ML Upgrade Job Snapshot API request.
 //
-type TasksGetRequest struct {
-	TaskID string
+type MLUpgradeJobSnapshotRequest struct {
+	JobID      string
+	SnapshotID string
 
 	Timeout           time.Duration
 	WaitForCompletion *bool
@@ -54,20 +53,28 @@ type TasksGetRequest struct {
 
 // Do executes the request and returns response or error.
 //
-func (r TasksGetRequest) Do(ctx context.Context, transport Transport) (*Response, error) {
+func (r MLUpgradeJobSnapshotRequest) Do(ctx context.Context, transport Transport) (*Response, error) {
 	var (
 		method string
 		path   strings.Builder
 		params map[string]string
 	)
 
-	method = "GET"
+	method = "POST"
 
-	path.Grow(1 + len("_tasks") + 1 + len(r.TaskID))
+	path.Grow(1 + len("_ml") + 1 + len("anomaly_detectors") + 1 + len(r.JobID) + 1 + len("model_snapshots") + 1 + len(r.SnapshotID) + 1 + len("_upgrade"))
 	path.WriteString("/")
-	path.WriteString("_tasks")
+	path.WriteString("_ml")
 	path.WriteString("/")
-	path.WriteString(r.TaskID)
+	path.WriteString("anomaly_detectors")
+	path.WriteString("/")
+	path.WriteString(r.JobID)
+	path.WriteString("/")
+	path.WriteString("model_snapshots")
+	path.WriteString("/")
+	path.WriteString(r.SnapshotID)
+	path.WriteString("/")
+	path.WriteString("_upgrade")
 
 	params = make(map[string]string)
 
@@ -140,64 +147,64 @@ func (r TasksGetRequest) Do(ctx context.Context, transport Transport) (*Response
 
 // WithContext sets the request context.
 //
-func (f TasksGet) WithContext(v context.Context) func(*TasksGetRequest) {
-	return func(r *TasksGetRequest) {
+func (f MLUpgradeJobSnapshot) WithContext(v context.Context) func(*MLUpgradeJobSnapshotRequest) {
+	return func(r *MLUpgradeJobSnapshotRequest) {
 		r.ctx = v
 	}
 }
 
-// WithTimeout - explicit operation timeout.
+// WithTimeout - how long should the api wait for the job to be opened and the old snapshot to be loaded..
 //
-func (f TasksGet) WithTimeout(v time.Duration) func(*TasksGetRequest) {
-	return func(r *TasksGetRequest) {
+func (f MLUpgradeJobSnapshot) WithTimeout(v time.Duration) func(*MLUpgradeJobSnapshotRequest) {
+	return func(r *MLUpgradeJobSnapshotRequest) {
 		r.Timeout = v
 	}
 }
 
-// WithWaitForCompletion - wait for the matching tasks to complete (default: false).
+// WithWaitForCompletion - should the request wait until the task is complete before responding to the caller. default is false..
 //
-func (f TasksGet) WithWaitForCompletion(v bool) func(*TasksGetRequest) {
-	return func(r *TasksGetRequest) {
+func (f MLUpgradeJobSnapshot) WithWaitForCompletion(v bool) func(*MLUpgradeJobSnapshotRequest) {
+	return func(r *MLUpgradeJobSnapshotRequest) {
 		r.WaitForCompletion = &v
 	}
 }
 
 // WithPretty makes the response body pretty-printed.
 //
-func (f TasksGet) WithPretty() func(*TasksGetRequest) {
-	return func(r *TasksGetRequest) {
+func (f MLUpgradeJobSnapshot) WithPretty() func(*MLUpgradeJobSnapshotRequest) {
+	return func(r *MLUpgradeJobSnapshotRequest) {
 		r.Pretty = true
 	}
 }
 
 // WithHuman makes statistical values human-readable.
 //
-func (f TasksGet) WithHuman() func(*TasksGetRequest) {
-	return func(r *TasksGetRequest) {
+func (f MLUpgradeJobSnapshot) WithHuman() func(*MLUpgradeJobSnapshotRequest) {
+	return func(r *MLUpgradeJobSnapshotRequest) {
 		r.Human = true
 	}
 }
 
 // WithErrorTrace includes the stack trace for errors in the response body.
 //
-func (f TasksGet) WithErrorTrace() func(*TasksGetRequest) {
-	return func(r *TasksGetRequest) {
+func (f MLUpgradeJobSnapshot) WithErrorTrace() func(*MLUpgradeJobSnapshotRequest) {
+	return func(r *MLUpgradeJobSnapshotRequest) {
 		r.ErrorTrace = true
 	}
 }
 
 // WithFilterPath filters the properties of the response body.
 //
-func (f TasksGet) WithFilterPath(v ...string) func(*TasksGetRequest) {
-	return func(r *TasksGetRequest) {
+func (f MLUpgradeJobSnapshot) WithFilterPath(v ...string) func(*MLUpgradeJobSnapshotRequest) {
+	return func(r *MLUpgradeJobSnapshotRequest) {
 		r.FilterPath = v
 	}
 }
 
 // WithHeader adds the headers to the HTTP request.
 //
-func (f TasksGet) WithHeader(h map[string]string) func(*TasksGetRequest) {
-	return func(r *TasksGetRequest) {
+func (f MLUpgradeJobSnapshot) WithHeader(h map[string]string) func(*MLUpgradeJobSnapshotRequest) {
+	return func(r *MLUpgradeJobSnapshotRequest) {
 		if r.Header == nil {
 			r.Header = make(http.Header)
 		}
@@ -209,8 +216,8 @@ func (f TasksGet) WithHeader(h map[string]string) func(*TasksGetRequest) {
 
 // WithOpaqueID adds the X-Opaque-Id header to the HTTP request.
 //
-func (f TasksGet) WithOpaqueID(s string) func(*TasksGetRequest) {
-	return func(r *TasksGetRequest) {
+func (f MLUpgradeJobSnapshot) WithOpaqueID(s string) func(*MLUpgradeJobSnapshotRequest) {
+	return func(r *MLUpgradeJobSnapshotRequest) {
 		if r.Header == nil {
 			r.Header = make(http.Header)
 		}

--- a/esapi/api.xpack.watcher.query_watches.go
+++ b/esapi/api.xpack.watcher.query_watches.go
@@ -8,15 +8,14 @@ package esapi
 
 import (
 	"context"
+	"io"
 	"net/http"
-	"strconv"
 	"strings"
-	"time"
 )
 
-func newTasksGetFunc(t Transport) TasksGet {
-	return func(task_id string, o ...func(*TasksGetRequest)) (*Response, error) {
-		var r = TasksGetRequest{TaskID: task_id}
+func newWatcherQueryWatchesFunc(t Transport) WatcherQueryWatches {
+	return func(o ...func(*WatcherQueryWatchesRequest)) (*Response, error) {
+		var r = WatcherQueryWatchesRequest{}
 		for _, f := range o {
 			f(&r)
 		}
@@ -26,21 +25,16 @@ func newTasksGetFunc(t Transport) TasksGet {
 
 // ----- API Definition -------------------------------------------------------
 
-// TasksGet returns information about a task.
+// WatcherQueryWatches - Retrieves stored watches.
 //
-// This API is experimental.
+// See full documentation at https://www.elastic.co/guide/en/elasticsearch/reference/current/watcher-api-query-watches.html.
 //
-// See full documentation at https://www.elastic.co/guide/en/elasticsearch/reference/master/tasks.html.
-//
-type TasksGet func(task_id string, o ...func(*TasksGetRequest)) (*Response, error)
+type WatcherQueryWatches func(o ...func(*WatcherQueryWatchesRequest)) (*Response, error)
 
-// TasksGetRequest configures the Tasks Get API request.
+// WatcherQueryWatchesRequest configures the Watcher Query Watches API request.
 //
-type TasksGetRequest struct {
-	TaskID string
-
-	Timeout           time.Duration
-	WaitForCompletion *bool
+type WatcherQueryWatchesRequest struct {
+	Body io.Reader
 
 	Pretty     bool
 	Human      bool
@@ -54,7 +48,7 @@ type TasksGetRequest struct {
 
 // Do executes the request and returns response or error.
 //
-func (r TasksGetRequest) Do(ctx context.Context, transport Transport) (*Response, error) {
+func (r WatcherQueryWatchesRequest) Do(ctx context.Context, transport Transport) (*Response, error) {
 	var (
 		method string
 		path   strings.Builder
@@ -63,21 +57,10 @@ func (r TasksGetRequest) Do(ctx context.Context, transport Transport) (*Response
 
 	method = "GET"
 
-	path.Grow(1 + len("_tasks") + 1 + len(r.TaskID))
-	path.WriteString("/")
-	path.WriteString("_tasks")
-	path.WriteString("/")
-	path.WriteString(r.TaskID)
+	path.Grow(len("/_watcher/_query/watches"))
+	path.WriteString("/_watcher/_query/watches")
 
 	params = make(map[string]string)
-
-	if r.Timeout != 0 {
-		params["timeout"] = formatDuration(r.Timeout)
-	}
-
-	if r.WaitForCompletion != nil {
-		params["wait_for_completion"] = strconv.FormatBool(*r.WaitForCompletion)
-	}
 
 	if r.Pretty {
 		params["pretty"] = "true"
@@ -95,7 +78,7 @@ func (r TasksGetRequest) Do(ctx context.Context, transport Transport) (*Response
 		params["filter_path"] = strings.Join(r.FilterPath, ",")
 	}
 
-	req, err := newRequest(method, path.String(), nil)
+	req, err := newRequest(method, path.String(), r.Body)
 	if err != nil {
 		return nil, err
 	}
@@ -106,6 +89,10 @@ func (r TasksGetRequest) Do(ctx context.Context, transport Transport) (*Response
 			q.Set(k, v)
 		}
 		req.URL.RawQuery = q.Encode()
+	}
+
+	if r.Body != nil {
+		req.Header[headerContentType] = headerContentTypeJSON
 	}
 
 	if len(r.Header) > 0 {
@@ -140,64 +127,56 @@ func (r TasksGetRequest) Do(ctx context.Context, transport Transport) (*Response
 
 // WithContext sets the request context.
 //
-func (f TasksGet) WithContext(v context.Context) func(*TasksGetRequest) {
-	return func(r *TasksGetRequest) {
+func (f WatcherQueryWatches) WithContext(v context.Context) func(*WatcherQueryWatchesRequest) {
+	return func(r *WatcherQueryWatchesRequest) {
 		r.ctx = v
 	}
 }
 
-// WithTimeout - explicit operation timeout.
+// WithBody - From, size, query, sort and search_after.
 //
-func (f TasksGet) WithTimeout(v time.Duration) func(*TasksGetRequest) {
-	return func(r *TasksGetRequest) {
-		r.Timeout = v
-	}
-}
-
-// WithWaitForCompletion - wait for the matching tasks to complete (default: false).
-//
-func (f TasksGet) WithWaitForCompletion(v bool) func(*TasksGetRequest) {
-	return func(r *TasksGetRequest) {
-		r.WaitForCompletion = &v
+func (f WatcherQueryWatches) WithBody(v io.Reader) func(*WatcherQueryWatchesRequest) {
+	return func(r *WatcherQueryWatchesRequest) {
+		r.Body = v
 	}
 }
 
 // WithPretty makes the response body pretty-printed.
 //
-func (f TasksGet) WithPretty() func(*TasksGetRequest) {
-	return func(r *TasksGetRequest) {
+func (f WatcherQueryWatches) WithPretty() func(*WatcherQueryWatchesRequest) {
+	return func(r *WatcherQueryWatchesRequest) {
 		r.Pretty = true
 	}
 }
 
 // WithHuman makes statistical values human-readable.
 //
-func (f TasksGet) WithHuman() func(*TasksGetRequest) {
-	return func(r *TasksGetRequest) {
+func (f WatcherQueryWatches) WithHuman() func(*WatcherQueryWatchesRequest) {
+	return func(r *WatcherQueryWatchesRequest) {
 		r.Human = true
 	}
 }
 
 // WithErrorTrace includes the stack trace for errors in the response body.
 //
-func (f TasksGet) WithErrorTrace() func(*TasksGetRequest) {
-	return func(r *TasksGetRequest) {
+func (f WatcherQueryWatches) WithErrorTrace() func(*WatcherQueryWatchesRequest) {
+	return func(r *WatcherQueryWatchesRequest) {
 		r.ErrorTrace = true
 	}
 }
 
 // WithFilterPath filters the properties of the response body.
 //
-func (f TasksGet) WithFilterPath(v ...string) func(*TasksGetRequest) {
-	return func(r *TasksGetRequest) {
+func (f WatcherQueryWatches) WithFilterPath(v ...string) func(*WatcherQueryWatchesRequest) {
+	return func(r *WatcherQueryWatchesRequest) {
 		r.FilterPath = v
 	}
 }
 
 // WithHeader adds the headers to the HTTP request.
 //
-func (f TasksGet) WithHeader(h map[string]string) func(*TasksGetRequest) {
-	return func(r *TasksGetRequest) {
+func (f WatcherQueryWatches) WithHeader(h map[string]string) func(*WatcherQueryWatchesRequest) {
+	return func(r *WatcherQueryWatchesRequest) {
 		if r.Header == nil {
 			r.Header = make(http.Header)
 		}
@@ -209,8 +188,8 @@ func (f TasksGet) WithHeader(h map[string]string) func(*TasksGetRequest) {
 
 // WithOpaqueID adds the X-Opaque-Id header to the HTTP request.
 //
-func (f TasksGet) WithOpaqueID(s string) func(*TasksGetRequest) {
-	return func(r *TasksGetRequest) {
+func (f WatcherQueryWatches) WithOpaqueID(s string) func(*WatcherQueryWatchesRequest) {
+	return func(r *WatcherQueryWatchesRequest) {
 		if r.Header == nil {
 			r.Header = make(http.Header)
 		}

--- a/internal/cmd/generate/commands/genstruct/command.go
+++ b/internal/cmd/generate/commands/genstruct/command.go
@@ -239,6 +239,11 @@ type API struct {
 			name := strings.ReplaceAll(e.Name(), "Request", "")
 			if strings.HasPrefix(strings.ToLower(name), strings.ToLower(n)) {
 				methodName := strings.ReplaceAll(name, n, "")
+				// Some methods are equal to the namespace (like 'rollup.rollup')
+				// and we don't want to have an empty string here.
+				if len(methodName) == 0 {
+				    methodName = strings.Replace(name, n, "", 1)
+				}
 				b.WriteString(fmt.Sprintf("\t%s %s\n", methodName, name))
 			}
 		}
@@ -271,6 +276,11 @@ func New(t Transport) *API {
 			name := strings.ReplaceAll(e.Name(), "Request", "")
 			if strings.HasPrefix(strings.ToLower(name), strings.ToLower(n)) {
 				methodName := strings.ReplaceAll(name, n, "")
+				// Some methods are equal to the namespace (like 'rollup.rollup')
+				// and we don't want to have an empty string here.
+				if len(methodName) == 0 {
+				    methodName = strings.Replace(name, n, "", 1)
+				}
 				b.WriteString(fmt.Sprintf("\t\t\t%s: new%sFunc(t),\n", methodName, name))
 			}
 		}


### PR DESCRIPTION
Some APIs like `rollup.rollup` are the same as their namespace and if we remove all occurrences of the namespace from the `methodName` then it'd result in an empty string. If we hit a situation like this only replace the namespace.