### PR TITLE
Update generator

### DIFF
--- a/esapi/api._.go
+++ b/esapi/api._.go
@@ -1,4 +1,4 @@
-// Code generated from specification version 8.0.0 (e56673015cb): DO NOT EDIT
+// Code generated from specification version 8.0.0 (03492665170): DO NOT EDIT
 
 package esapi
 
@@ -72,6 +72,9 @@ type API struct {
 	GraphExplore                                  GraphExplore
 	Index                                         Index
 	Info                                          Info
+	LogstashDeletePipeline                        LogstashDeletePipeline
+	LogstashGetPipeline                           LogstashGetPipeline
+	LogstashPutPipeline                           LogstashPutPipeline
 	Mget                                          Mget
 	Msearch                                       Msearch
 	MsearchTemplate                               MsearchTemplate
@@ -102,6 +105,7 @@ type API struct {
 	SlmStart                                      SlmStart
 	SlmStop                                       SlmStop
 	Termvectors                                   Termvectors
+	TextStructureFindStructure                    TextStructureFindStructure
 	TransformDeleteTransform                      TransformDeleteTransform
 	TransformGetTransform                         TransformGetTransform
 	TransformGetTransformStats                    TransformGetTransformStats
@@ -195,7 +199,9 @@ type Indices struct {
 	GetSettings           IndicesGetSettings
 	GetTemplate           IndicesGetTemplate
 	GetUpgrade            IndicesGetUpgrade
+	MigrateToDataStream   IndicesMigrateToDataStream
 	Open                  IndicesOpen
+	PromoteDataStream     IndicesPromoteDataStream
 	PutAlias              IndicesPutAlias
 	PutIndexTemplate      IndicesPutIndexTemplate
 	PutMapping            IndicesPutMapping
@@ -267,6 +273,7 @@ type Tasks struct {
 type AsyncSearch struct {
 	Delete AsyncSearchDelete
 	Get    AsyncSearchGet
+	Status AsyncSearchStatus
 	Submit AsyncSearchSubmit
 }
 
@@ -377,6 +384,7 @@ type ML struct {
 	UpdateFilter               MLUpdateFilter
 	UpdateJob                  MLUpdateJob
 	UpdateModelSnapshot        MLUpdateModelSnapshot
+	UpgradeJobSnapshot         MLUpgradeJobSnapshot
 	ValidateDetector           MLValidateDetector
 	Validate                   MLValidate
 }
@@ -393,6 +401,7 @@ type Rollup struct {
 	GetCaps      RollupGetRollupCaps
 	GetIndexCaps RollupGetRollupIndexCaps
 	PutJob       RollupPutJob
+	Rollup       RollupRollup
 	Search       RollupRollupSearch
 	StartJob     RollupStartJob
 	StopJob      RollupStopJob
@@ -452,6 +461,7 @@ type Watcher struct {
 	ExecuteWatch    WatcherExecuteWatch
 	GetWatch        WatcherGetWatch
 	PutWatch        WatcherPutWatch
+	QueryWatches    WatcherQueryWatches
 	Start           WatcherStart
 	Stats           WatcherStats
 	Stop            WatcherStop
@@ -512,6 +522,9 @@ func New(t Transport) *API {
 		GraphExplore:                                  newGraphExploreFunc(t),
 		Index:                                         newIndexFunc(t),
 		Info:                                          newInfoFunc(t),
+		LogstashDeletePipeline:                        newLogstashDeletePipelineFunc(t),
+		LogstashGetPipeline:                           newLogstashGetPipelineFunc(t),
+		LogstashPutPipeline:                           newLogstashPutPipelineFunc(t),
 		Mget:                                          newMgetFunc(t),
 		Msearch:                                       newMsearchFunc(t),
 		MsearchTemplate:                               newMsearchTemplateFunc(t),
@@ -542,6 +555,7 @@ func New(t Transport) *API {
 		SlmStart:                                      newSlmStartFunc(t),
 		SlmStop:                                       newSlmStopFunc(t),
 		Termvectors:                                   newTermvectorsFunc(t),
+		TextStructureFindStructure:                    newTextStructureFindStructureFunc(t),
 		TransformDeleteTransform:                      newTransformDeleteTransformFunc(t),
 		TransformGetTransform:                         newTransformGetTransformFunc(t),
 		TransformGetTransformStats:                    newTransformGetTransformStatsFunc(t),
@@ -628,7 +642,9 @@ func New(t Transport) *API {
 			GetSettings:           newIndicesGetSettingsFunc(t),
 			GetTemplate:           newIndicesGetTemplateFunc(t),
 			GetUpgrade:            newIndicesGetUpgradeFunc(t),
+			MigrateToDataStream:   newIndicesMigrateToDataStreamFunc(t),
 			Open:                  newIndicesOpenFunc(t),
+			PromoteDataStream:     newIndicesPromoteDataStreamFunc(t),
 			PutAlias:              newIndicesPutAliasFunc(t),
 			PutIndexTemplate:      newIndicesPutIndexTemplateFunc(t),
 			PutMapping:            newIndicesPutMappingFunc(t),
@@ -687,6 +703,7 @@ func New(t Transport) *API {
 		AsyncSearch: &AsyncSearch{
 			Delete: newAsyncSearchDeleteFunc(t),
 			Get:    newAsyncSearchGetFunc(t),
+			Status: newAsyncSearchStatusFunc(t),
 			Submit: newAsyncSearchSubmitFunc(t),
 		},
 		CCR: &CCR{
@@ -787,6 +804,7 @@ func New(t Transport) *API {
 			UpdateFilter:               newMLUpdateFilterFunc(t),
 			UpdateJob:                  newMLUpdateJobFunc(t),
 			UpdateModelSnapshot:        newMLUpdateModelSnapshotFunc(t),
+			UpgradeJobSnapshot:         newMLUpgradeJobSnapshotFunc(t),
 			ValidateDetector:           newMLValidateDetectorFunc(t),
 			Validate:                   newMLValidateFunc(t),
 		},
@@ -799,6 +817,7 @@ func New(t Transport) *API {
 			GetCaps:      newRollupGetRollupCapsFunc(t),
 			GetIndexCaps: newRollupGetRollupIndexCapsFunc(t),
 			PutJob:       newRollupPutJobFunc(t),
+			Rollup:       newRollupRollupFunc(t),
 			Search:       newRollupRollupSearchFunc(t),
 			StartJob:     newRollupStartJobFunc(t),
 			StopJob:      newRollupStopJobFunc(t),
@@ -850,6 +869,7 @@ func New(t Transport) *API {
 			ExecuteWatch:    newWatcherExecuteWatchFunc(t),
 			GetWatch:        newWatcherGetWatchFunc(t),
 			PutWatch:        newWatcherPutWatchFunc(t),
+			QueryWatches:    newWatcherQueryWatchesFunc(t),
 			Start:           newWatcherStartFunc(t),
 			Stats:           newWatcherStatsFunc(t),
 			Stop:            newWatcherStopFunc(t),

--- a/esapi/api.cat.indices.go
+++ b/esapi/api.cat.indices.go
@@ -44,7 +44,6 @@ type CatIndicesRequest struct {
 	Health                  string
 	Help                    *bool
 	IncludeUnloadedSegments *bool
-	Local                   *bool
 	MasterTimeout           time.Duration
 	Pri                     *bool
 	S                       []string
@@ -110,10 +109,6 @@ func (r CatIndicesRequest) Do(ctx context.Context, transport Transport) (*Respon
 
 	if r.IncludeUnloadedSegments != nil {
 		params["include_unloaded_segments"] = strconv.FormatBool(*r.IncludeUnloadedSegments)
-	}
-
-	if r.Local != nil {
-		params["local"] = strconv.FormatBool(*r.Local)
 	}
 
 	if r.MasterTimeout != 0 {
@@ -264,14 +259,6 @@ func (f CatIndices) WithHelp(v bool) func(*CatIndicesRequest) {
 func (f CatIndices) WithIncludeUnloadedSegments(v bool) func(*CatIndicesRequest) {
 	return func(r *CatIndicesRequest) {
 		r.IncludeUnloadedSegments = &v
-	}
-}
-
-// WithLocal - return local information, do not retrieve the state from master node (default: false).
-//
-func (f CatIndices) WithLocal(v bool) func(*CatIndicesRequest) {
-	return func(r *CatIndicesRequest) {
-		r.Local = &v
 	}
 }
 

--- a/esapi/api.cat.plugins.go
+++ b/esapi/api.cat.plugins.go
@@ -35,13 +35,14 @@ type CatPlugins func(o ...func(*CatPluginsRequest)) (*Response, error)
 // CatPluginsRequest configures the Cat Plugins API request.
 //
 type CatPluginsRequest struct {
-	Format        string
-	H             []string
-	Help          *bool
-	Local         *bool
-	MasterTimeout time.Duration
-	S             []string
-	V             *bool
+	Format           string
+	H                []string
+	Help             *bool
+	IncludeBootstrap *bool
+	Local            *bool
+	MasterTimeout    time.Duration
+	S                []string
+	V                *bool
 
 	Pretty     bool
 	Human      bool
@@ -79,6 +80,10 @@ func (r CatPluginsRequest) Do(ctx context.Context, transport Transport) (*Respon
 
 	if r.Help != nil {
 		params["help"] = strconv.FormatBool(*r.Help)
+	}
+
+	if r.IncludeBootstrap != nil {
+		params["include_bootstrap"] = strconv.FormatBool(*r.IncludeBootstrap)
 	}
 
 	if r.Local != nil {
@@ -185,6 +190,14 @@ func (f CatPlugins) WithH(v ...string) func(*CatPluginsRequest) {
 func (f CatPlugins) WithHelp(v bool) func(*CatPluginsRequest) {
 	return func(r *CatPluginsRequest) {
 		r.Help = &v
+	}
+}
+
+// WithIncludeBootstrap - include bootstrap plugins in the response.
+//
+func (f CatPlugins) WithIncludeBootstrap(v bool) func(*CatPluginsRequest) {
+	return func(r *CatPluginsRequest) {
+		r.IncludeBootstrap = &v
 	}
 }
 

--- a/esapi/api.cat.shards.go
+++ b/esapi/api.cat.shards.go
@@ -41,7 +41,6 @@ type CatShardsRequest struct {
 	Format        string
 	H             []string
 	Help          *bool
-	Local         *bool
 	MasterTimeout time.Duration
 	S             []string
 	Time          string
@@ -94,10 +93,6 @@ func (r CatShardsRequest) Do(ctx context.Context, transport Transport) (*Respons
 
 	if r.Help != nil {
 		params["help"] = strconv.FormatBool(*r.Help)
-	}
-
-	if r.Local != nil {
-		params["local"] = strconv.FormatBool(*r.Local)
 	}
 
 	if r.MasterTimeout != 0 {
@@ -220,14 +215,6 @@ func (f CatShards) WithH(v ...string) func(*CatShardsRequest) {
 func (f CatShards) WithHelp(v bool) func(*CatShardsRequest) {
 	return func(r *CatShardsRequest) {
 		r.Help = &v
-	}
-}
-
-// WithLocal - return local information, do not retrieve the state from master node (default: false).
-//
-func (f CatShards) WithLocal(v bool) func(*CatShardsRequest) {
-	return func(r *CatShardsRequest) {
-		r.Local = &v
 	}
 }
 

--- a/esapi/api.cat.tasks.go
+++ b/esapi/api.cat.tasks.go
@@ -27,6 +27,8 @@ func newCatTasksFunc(t Transport) CatTasks {
 
 // CatTasks returns information about the tasks currently executing on one or more nodes in the cluster.
 //
+// This API is experimental.
+//
 // See full documentation at https://www.elastic.co/guide/en/elasticsearch/reference/master/tasks.html.
 //
 type CatTasks func(o ...func(*CatTasksRequest)) (*Response, error)
@@ -34,16 +36,16 @@ type CatTasks func(o ...func(*CatTasksRequest)) (*Response, error)
 // CatTasksRequest configures the Cat Tasks API request.
 //
 type CatTasksRequest struct {
-	Actions    []string
-	Detailed   *bool
-	Format     string
-	H          []string
-	Help       *bool
-	NodeID     []string
-	ParentTask *int
-	S          []string
-	Time       string
-	V          *bool
+	Actions      []string
+	Detailed     *bool
+	Format       string
+	H            []string
+	Help         *bool
+	Nodes        []string
+	ParentTaskID string
+	S            []string
+	Time         string
+	V            *bool
 
 	Pretty     bool
 	Human      bool
@@ -91,12 +93,12 @@ func (r CatTasksRequest) Do(ctx context.Context, transport Transport) (*Response
 		params["help"] = strconv.FormatBool(*r.Help)
 	}
 
-	if len(r.NodeID) > 0 {
-		params["node_id"] = strings.Join(r.NodeID, ",")
+	if len(r.Nodes) > 0 {
+		params["nodes"] = strings.Join(r.Nodes, ",")
 	}
 
-	if r.ParentTask != nil {
-		params["parent_task"] = strconv.FormatInt(int64(*r.ParentTask), 10)
+	if r.ParentTaskID != "" {
+		params["parent_task_id"] = r.ParentTaskID
 	}
 
 	if len(r.S) > 0 {
@@ -218,19 +220,19 @@ func (f CatTasks) WithHelp(v bool) func(*CatTasksRequest) {
 	}
 }
 
-// WithNodeID - a list of node ids or names to limit the returned information; use `_local` to return information from the node you're connecting to, leave empty to get information from all nodes.
+// WithNodes - a list of node ids or names to limit the returned information; use `_local` to return information from the node you're connecting to, leave empty to get information from all nodes.
 //
-func (f CatTasks) WithNodeID(v ...string) func(*CatTasksRequest) {
+func (f CatTasks) WithNodes(v ...string) func(*CatTasksRequest) {
 	return func(r *CatTasksRequest) {
-		r.NodeID = v
+		r.Nodes = v
 	}
 }
 
-// WithParentTask - return tasks with specified parent task ID. set to -1 to return all..
+// WithParentTaskID - return tasks with specified parent task ID (node_id:task_number). set to -1 to return all..
 //
-func (f CatTasks) WithParentTask(v int) func(*CatTasksRequest) {
+func (f CatTasks) WithParentTaskID(v string) func(*CatTasksRequest) {
 	return func(r *CatTasksRequest) {
-		r.ParentTask = &v
+		r.ParentTaskID = v
 	}
 }
 

--- a/esapi/api.cluster.delete_component_template.go
+++ b/esapi/api.cluster.delete_component_template.go
@@ -27,8 +27,6 @@ func newClusterDeleteComponentTemplateFunc(t Transport) ClusterDeleteComponentTe
 
 // ClusterDeleteComponentTemplate deletes a component template
 //
-// This API is experimental.
-//
 // See full documentation at https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-component-template.html.
 //
 type ClusterDeleteComponentTemplate func(name string, o ...func(*ClusterDeleteComponentTemplateRequest)) (*Response, error)

--- a/esapi/api.cluster.exists_component_template.go
+++ b/esapi/api.cluster.exists_component_template.go
@@ -28,8 +28,6 @@ func newClusterExistsComponentTemplateFunc(t Transport) ClusterExistsComponentTe
 
 // ClusterExistsComponentTemplate returns information about whether a particular component template exist
 //
-// This API is experimental.
-//
 // See full documentation at https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-component-template.html.
 //
 type ClusterExistsComponentTemplate func(name string, o ...func(*ClusterExistsComponentTemplateRequest)) (*Response, error)

--- a/esapi/api.cluster.get_component_template.go
+++ b/esapi/api.cluster.get_component_template.go
@@ -28,8 +28,6 @@ func newClusterGetComponentTemplateFunc(t Transport) ClusterGetComponentTemplate
 
 // ClusterGetComponentTemplate returns one or more component templates
 //
-// This API is experimental.
-//
 // See full documentation at https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-component-template.html.
 //
 type ClusterGetComponentTemplate func(o ...func(*ClusterGetComponentTemplateRequest)) (*Response, error)

--- a/esapi/api.cluster.put_component_template.go
+++ b/esapi/api.cluster.put_component_template.go
@@ -29,8 +29,6 @@ func newClusterPutComponentTemplateFunc(t Transport) ClusterPutComponentTemplate
 
 // ClusterPutComponentTemplate creates or updates a component template
 //
-// This API is experimental.
-//
 // See full documentation at https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-component-template.html.
 //
 type ClusterPutComponentTemplate func(name string, body io.Reader, o ...func(*ClusterPutComponentTemplateRequest)) (*Response, error)

--- a/esapi/api.indices.delete_index_template.go
+++ b/esapi/api.indices.delete_index_template.go
@@ -27,8 +27,6 @@ func newIndicesDeleteIndexTemplateFunc(t Transport) IndicesDeleteIndexTemplate {
 
 // IndicesDeleteIndexTemplate deletes an index template.
 //
-// This API is experimental.
-//
 // See full documentation at https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-templates.html.
 //
 type IndicesDeleteIndexTemplate func(name string, o ...func(*IndicesDeleteIndexTemplateRequest)) (*Response, error)

--- a/esapi/api.indices.exists_index_template.go
+++ b/esapi/api.indices.exists_index_template.go
@@ -28,8 +28,6 @@ func newIndicesExistsIndexTemplateFunc(t Transport) IndicesExistsIndexTemplate {
 
 // IndicesExistsIndexTemplate returns information about whether a particular index template exists.
 //
-// This API is experimental.
-//
 // See full documentation at https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-templates.html.
 //
 type IndicesExistsIndexTemplate func(name string, o ...func(*IndicesExistsIndexTemplateRequest)) (*Response, error)

--- a/esapi/api.indices.get_index_template.go
+++ b/esapi/api.indices.get_index_template.go
@@ -28,8 +28,6 @@ func newIndicesGetIndexTemplateFunc(t Transport) IndicesGetIndexTemplate {
 
 // IndicesGetIndexTemplate returns an index template.
 //
-// This API is experimental.
-//
 // See full documentation at https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-templates.html.
 //
 type IndicesGetIndexTemplate func(o ...func(*IndicesGetIndexTemplateRequest)) (*Response, error)

--- a/esapi/api.indices.put_index_template.go
+++ b/esapi/api.indices.put_index_template.go
@@ -29,8 +29,6 @@ func newIndicesPutIndexTemplateFunc(t Transport) IndicesPutIndexTemplate {
 
 // IndicesPutIndexTemplate creates or updates an index template.
 //
-// This API is experimental.
-//
 // See full documentation at https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-templates.html.
 //
 type IndicesPutIndexTemplate func(name string, body io.Reader, o ...func(*IndicesPutIndexTemplateRequest)) (*Response, error)

--- a/esapi/api.indices.simulate_index_template.go
+++ b/esapi/api.indices.simulate_index_template.go
@@ -29,8 +29,6 @@ func newIndicesSimulateIndexTemplateFunc(t Transport) IndicesSimulateIndexTempla
 
 // IndicesSimulateIndexTemplate simulate matching the given index name against the index templates in the system
 //
-// This API is experimental.
-//
 // See full documentation at https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-templates.html.
 //
 type IndicesSimulateIndexTemplate func(name string, o ...func(*IndicesSimulateIndexTemplateRequest)) (*Response, error)

--- a/esapi/api.indices.simulate_template.go
+++ b/esapi/api.indices.simulate_template.go
@@ -29,8 +29,6 @@ func newIndicesSimulateTemplateFunc(t Transport) IndicesSimulateTemplate {
 
 // IndicesSimulateTemplate simulate resolving the given template name or body
 //
-// This API is experimental.
-//
 // See full documentation at https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-templates.html.
 //
 type IndicesSimulateTemplate func(o ...func(*IndicesSimulateTemplateRequest)) (*Response, error)

--- a/esapi/api.indices.stats.go
+++ b/esapi/api.indices.stats.go
@@ -207,7 +207,7 @@ func (f IndicesStats) WithMetric(v ...string) func(*IndicesStatsRequest) {
 	}
 }
 
-// WithCompletionFields - a list of fields for `fielddata` and `suggest` index metric (supports wildcards).
+// WithCompletionFields - a list of fields for the `completion` index metric (supports wildcards).
 //
 func (f IndicesStats) WithCompletionFields(v ...string) func(*IndicesStatsRequest) {
 	return func(r *IndicesStatsRequest) {
@@ -223,7 +223,7 @@ func (f IndicesStats) WithExpandWildcards(v string) func(*IndicesStatsRequest) {
 	}
 }
 
-// WithFielddataFields - a list of fields for `fielddata` index metric (supports wildcards).
+// WithFielddataFields - a list of fields for the `fielddata` index metric (supports wildcards).
 //
 func (f IndicesStats) WithFielddataFields(v ...string) func(*IndicesStatsRequest) {
 	return func(r *IndicesStatsRequest) {

--- a/esapi/api.nodes.stats.go
+++ b/esapi/api.nodes.stats.go
@@ -212,7 +212,7 @@ func (f NodesStats) WithNodeID(v ...string) func(*NodesStatsRequest) {
 	}
 }
 
-// WithCompletionFields - a list of fields for `fielddata` and `suggest` index metric (supports wildcards).
+// WithCompletionFields - a list of fields for the `completion` index metric (supports wildcards).
 //
 func (f NodesStats) WithCompletionFields(v ...string) func(*NodesStatsRequest) {
 	return func(r *NodesStatsRequest) {
@@ -220,7 +220,7 @@ func (f NodesStats) WithCompletionFields(v ...string) func(*NodesStatsRequest) {
 	}
 }
 
-// WithFielddataFields - a list of fields for `fielddata` index metric (supports wildcards).
+// WithFielddataFields - a list of fields for the `fielddata` index metric (supports wildcards).
 //
 func (f NodesStats) WithFielddataFields(v ...string) func(*NodesStatsRequest) {
 	return func(r *NodesStatsRequest) {

--- a/esapi/api.search.go
+++ b/esapi/api.search.go
@@ -57,6 +57,7 @@ type SearchRequest struct {
 	IgnoreUnavailable          *bool
 	Lenient                    *bool
 	MaxConcurrentShardRequests *int
+	MinCompatibleShardNode     string
 	Preference                 string
 	PreFilterShardSize         *int
 	Query                      string
@@ -177,6 +178,10 @@ func (r SearchRequest) Do(ctx context.Context, transport Transport) (*Response, 
 
 	if r.MaxConcurrentShardRequests != nil {
 		params["max_concurrent_shard_requests"] = strconv.FormatInt(int64(*r.MaxConcurrentShardRequests), 10)
+	}
+
+	if r.MinCompatibleShardNode != "" {
+		params["min_compatible_shard_node"] = r.MinCompatibleShardNode
 	}
 
 	if r.Preference != "" {
@@ -495,6 +500,14 @@ func (f Search) WithLenient(v bool) func(*SearchRequest) {
 func (f Search) WithMaxConcurrentShardRequests(v int) func(*SearchRequest) {
 	return func(r *SearchRequest) {
 		r.MaxConcurrentShardRequests = &v
+	}
+}
+
+// WithMinCompatibleShardNode - the minimum compatible version that all shards involved in search should have for this request to be successful.
+//
+func (f Search) WithMinCompatibleShardNode(v string) func(*SearchRequest) {
+	return func(r *SearchRequest) {
+		r.MinCompatibleShardNode = v
 	}
 }
 

--- a/esapi/api.tasks.cancel.go
+++ b/esapi/api.tasks.cancel.go
@@ -27,6 +27,8 @@ func newTasksCancelFunc(t Transport) TasksCancel {
 
 // TasksCancel cancels a task, if it can be cancelled through an API.
 //
+// This API is experimental.
+//
 // See full documentation at https://www.elastic.co/guide/en/elasticsearch/reference/master/tasks.html.
 //
 type TasksCancel func(o ...func(*TasksCancelRequest)) (*Response, error)

--- a/esapi/api.tasks.list.go
+++ b/esapi/api.tasks.list.go
@@ -28,6 +28,8 @@ func newTasksListFunc(t Transport) TasksList {
 
 // TasksList returns a list of tasks.
 //
+// This API is experimental.
+//
 // See full documentation at https://www.elastic.co/guide/en/elasticsearch/reference/master/tasks.html.
 //
 type TasksList func(o ...func(*TasksListRequest)) (*Response, error)

--- a/esapi/api.xpack.async_search.status.go
+++ b/esapi/api.xpack.async_search.status.go
@@ -12,9 +12,9 @@ import (
 	"strings"
 )
 
-func newIndicesGetDataStreamFunc(t Transport) IndicesGetDataStream {
-	return func(o ...func(*IndicesGetDataStreamRequest)) (*Response, error) {
-		var r = IndicesGetDataStreamRequest{}
+func newAsyncSearchStatusFunc(t Transport) AsyncSearchStatus {
+	return func(id string, o ...func(*AsyncSearchStatusRequest)) (*Response, error) {
+		var r = AsyncSearchStatusRequest{DocumentID: id}
 		for _, f := range o {
 			f(&r)
 		}
@@ -24,18 +24,16 @@ func newIndicesGetDataStreamFunc(t Transport) IndicesGetDataStream {
 
 // ----- API Definition -------------------------------------------------------
 
-// IndicesGetDataStream - Returns data streams.
+// AsyncSearchStatus - Retrieves the status of a previously submitted async search request given its ID.
 //
-// See full documentation at https://www.elastic.co/guide/en/elasticsearch/reference/master/data-streams.html.
+// See full documentation at https://www.elastic.co/guide/en/elasticsearch/reference/current/async-search.html.
 //
-type IndicesGetDataStream func(o ...func(*IndicesGetDataStreamRequest)) (*Response, error)
+type AsyncSearchStatus func(id string, o ...func(*AsyncSearchStatusRequest)) (*Response, error)
 
-// IndicesGetDataStreamRequest configures the Indices Get Data Stream API request.
+// AsyncSearchStatusRequest configures the Async Search Status API request.
 //
-type IndicesGetDataStreamRequest struct {
-	Name []string
-
-	ExpandWildcards string
+type AsyncSearchStatusRequest struct {
+	DocumentID string
 
 	Pretty     bool
 	Human      bool
@@ -49,7 +47,7 @@ type IndicesGetDataStreamRequest struct {
 
 // Do executes the request and returns response or error.
 //
-func (r IndicesGetDataStreamRequest) Do(ctx context.Context, transport Transport) (*Response, error) {
+func (r AsyncSearchStatusRequest) Do(ctx context.Context, transport Transport) (*Response, error) {
 	var (
 		method string
 		path   strings.Builder
@@ -58,19 +56,15 @@ func (r IndicesGetDataStreamRequest) Do(ctx context.Context, transport Transport
 
 	method = "GET"
 
-	path.Grow(1 + len("_data_stream") + 1 + len(strings.Join(r.Name, ",")))
+	path.Grow(1 + len("_async_search") + 1 + len("status") + 1 + len(r.DocumentID))
 	path.WriteString("/")
-	path.WriteString("_data_stream")
-	if len(r.Name) > 0 {
-		path.WriteString("/")
-		path.WriteString(strings.Join(r.Name, ","))
-	}
+	path.WriteString("_async_search")
+	path.WriteString("/")
+	path.WriteString("status")
+	path.WriteString("/")
+	path.WriteString(r.DocumentID)
 
 	params = make(map[string]string)
-
-	if r.ExpandWildcards != "" {
-		params["expand_wildcards"] = r.ExpandWildcards
-	}
 
 	if r.Pretty {
 		params["pretty"] = "true"
@@ -133,64 +127,48 @@ func (r IndicesGetDataStreamRequest) Do(ctx context.Context, transport Transport
 
 // WithContext sets the request context.
 //
-func (f IndicesGetDataStream) WithContext(v context.Context) func(*IndicesGetDataStreamRequest) {
-	return func(r *IndicesGetDataStreamRequest) {
+func (f AsyncSearchStatus) WithContext(v context.Context) func(*AsyncSearchStatusRequest) {
+	return func(r *AsyncSearchStatusRequest) {
 		r.ctx = v
-	}
-}
-
-// WithName - a list of data streams to get; use `*` to get all data streams.
-//
-func (f IndicesGetDataStream) WithName(v ...string) func(*IndicesGetDataStreamRequest) {
-	return func(r *IndicesGetDataStreamRequest) {
-		r.Name = v
-	}
-}
-
-// WithExpandWildcards - whether wildcard expressions should get expanded to open or closed indices (default: open).
-//
-func (f IndicesGetDataStream) WithExpandWildcards(v string) func(*IndicesGetDataStreamRequest) {
-	return func(r *IndicesGetDataStreamRequest) {
-		r.ExpandWildcards = v
 	}
 }
 
 // WithPretty makes the response body pretty-printed.
 //
-func (f IndicesGetDataStream) WithPretty() func(*IndicesGetDataStreamRequest) {
-	return func(r *IndicesGetDataStreamRequest) {
+func (f AsyncSearchStatus) WithPretty() func(*AsyncSearchStatusRequest) {
+	return func(r *AsyncSearchStatusRequest) {
 		r.Pretty = true
 	}
 }
 
 // WithHuman makes statistical values human-readable.
 //
-func (f IndicesGetDataStream) WithHuman() func(*IndicesGetDataStreamRequest) {
-	return func(r *IndicesGetDataStreamRequest) {
+func (f AsyncSearchStatus) WithHuman() func(*AsyncSearchStatusRequest) {
+	return func(r *AsyncSearchStatusRequest) {
 		r.Human = true
 	}
 }
 
 // WithErrorTrace includes the stack trace for errors in the response body.
 //
-func (f IndicesGetDataStream) WithErrorTrace() func(*IndicesGetDataStreamRequest) {
-	return func(r *IndicesGetDataStreamRequest) {
+func (f AsyncSearchStatus) WithErrorTrace() func(*AsyncSearchStatusRequest) {
+	return func(r *AsyncSearchStatusRequest) {
 		r.ErrorTrace = true
 	}
 }
 
 // WithFilterPath filters the properties of the response body.
 //
-func (f IndicesGetDataStream) WithFilterPath(v ...string) func(*IndicesGetDataStreamRequest) {
-	return func(r *IndicesGetDataStreamRequest) {
+func (f AsyncSearchStatus) WithFilterPath(v ...string) func(*AsyncSearchStatusRequest) {
+	return func(r *AsyncSearchStatusRequest) {
 		r.FilterPath = v
 	}
 }
 
 // WithHeader adds the headers to the HTTP request.
 //
-func (f IndicesGetDataStream) WithHeader(h map[string]string) func(*IndicesGetDataStreamRequest) {
-	return func(r *IndicesGetDataStreamRequest) {
+func (f AsyncSearchStatus) WithHeader(h map[string]string) func(*AsyncSearchStatusRequest) {
+	return func(r *AsyncSearchStatusRequest) {
 		if r.Header == nil {
 			r.Header = make(http.Header)
 		}
@@ -202,8 +180,8 @@ func (f IndicesGetDataStream) WithHeader(h map[string]string) func(*IndicesGetDa
 
 // WithOpaqueID adds the X-Opaque-Id header to the HTTP request.
 //
-func (f IndicesGetDataStream) WithOpaqueID(s string) func(*IndicesGetDataStreamRequest) {
-	return func(r *IndicesGetDataStreamRequest) {
+func (f AsyncSearchStatus) WithOpaqueID(s string) func(*AsyncSearchStatusRequest) {
+	return func(r *AsyncSearchStatusRequest) {
 		if r.Header == nil {
 			r.Header = make(http.Header)
 		}

--- a/esapi/api.xpack.autoscaling.get_autoscaling_capacity.go
+++ b/esapi/api.xpack.autoscaling.get_autoscaling_capacity.go
@@ -24,9 +24,7 @@ func newAutoscalingGetAutoscalingCapacityFunc(t Transport) AutoscalingGetAutosca
 
 // ----- API Definition -------------------------------------------------------
 
-// AutoscalingGetAutoscalingCapacity - Gets the current autoscaling capacity based on the configured autoscaling policy.
-//
-// This API is experimental.
+// AutoscalingGetAutoscalingCapacity - Gets the current autoscaling capacity based on the configured autoscaling policy. Designed for indirect use by ECE/ESS and ECK. Direct use is not supported.
 //
 // See full documentation at https://www.elastic.co/guide/en/elasticsearch/reference/current/autoscaling-get-autoscaling-capacity.html.
 //

--- a/esapi/api.xpack.autoscaling.get_autoscaling_policy.go
+++ b/esapi/api.xpack.autoscaling.get_autoscaling_policy.go
@@ -24,9 +24,7 @@ func newAutoscalingGetAutoscalingPolicyFunc(t Transport) AutoscalingGetAutoscali
 
 // ----- API Definition -------------------------------------------------------
 
-// AutoscalingGetAutoscalingPolicy - Retrieves an autoscaling policy.
-//
-// This API is experimental.
+// AutoscalingGetAutoscalingPolicy - Retrieves an autoscaling policy. Designed for indirect use by ECE/ESS and ECK. Direct use is not supported.
 //
 // See full documentation at https://www.elastic.co/guide/en/elasticsearch/reference/current/autoscaling-get-autoscaling-policy.html.
 //

--- a/esapi/api.xpack.eql.delete.go
+++ b/esapi/api.xpack.eql.delete.go
@@ -26,8 +26,6 @@ func newEqlDeleteFunc(t Transport) EqlDelete {
 
 // EqlDelete - Deletes an async EQL search by ID. If the search is still running, the search request will be cancelled. Otherwise, the saved search results are deleted.
 //
-// This API is beta.
-//
 // See full documentation at https://www.elastic.co/guide/en/elasticsearch/reference/current/eql-search-api.html.
 //
 type EqlDelete func(id string, o ...func(*EqlDeleteRequest)) (*Response, error)

--- a/esapi/api.xpack.eql.get.go
+++ b/esapi/api.xpack.eql.get.go
@@ -27,8 +27,6 @@ func newEqlGetFunc(t Transport) EqlGet {
 
 // EqlGet - Returns async results from previously executed Event Query Language (EQL) search
 //
-// This API is beta.
-//
 // See full documentation at https://www.elastic.co/guide/en/elasticsearch/reference/current/eql-search-api.html.
 //
 type EqlGet func(id string, o ...func(*EqlGetRequest)) (*Response, error)

--- a/esapi/api.xpack.eql.search.go
+++ b/esapi/api.xpack.eql.search.go
@@ -29,8 +29,6 @@ func newEqlSearchFunc(t Transport) EqlSearch {
 
 // EqlSearch - Returns results matching a query expressed in Event Query Language (EQL)
 //
-// This API is beta.
-//
 // See full documentation at https://www.elastic.co/guide/en/elasticsearch/reference/current/eql-search-api.html.
 //
 type EqlSearch func(index string, body io.Reader, o ...func(*EqlSearchRequest)) (*Response, error)

--- a/esapi/api.xpack.indices.delete_data_stream.go
+++ b/esapi/api.xpack.indices.delete_data_stream.go
@@ -35,6 +35,8 @@ type IndicesDeleteDataStream func(name []string, o ...func(*IndicesDeleteDataStr
 type IndicesDeleteDataStreamRequest struct {
 	Name []string
 
+	ExpandWildcards string
+
 	Pretty     bool
 	Human      bool
 	ErrorTrace bool
@@ -63,6 +65,10 @@ func (r IndicesDeleteDataStreamRequest) Do(ctx context.Context, transport Transp
 	path.WriteString(strings.Join(r.Name, ","))
 
 	params = make(map[string]string)
+
+	if r.ExpandWildcards != "" {
+		params["expand_wildcards"] = r.ExpandWildcards
+	}
 
 	if r.Pretty {
 		params["pretty"] = "true"
@@ -128,6 +134,14 @@ func (r IndicesDeleteDataStreamRequest) Do(ctx context.Context, transport Transp
 func (f IndicesDeleteDataStream) WithContext(v context.Context) func(*IndicesDeleteDataStreamRequest) {
 	return func(r *IndicesDeleteDataStreamRequest) {
 		r.ctx = v
+	}
+}
+
+// WithExpandWildcards - whether wildcard expressions should get expanded to open or closed indices (default: open).
+//
+func (f IndicesDeleteDataStream) WithExpandWildcards(v string) func(*IndicesDeleteDataStreamRequest) {
+	return func(r *IndicesDeleteDataStreamRequest) {
+		r.ExpandWildcards = v
 	}
 }
 

--- a/esapi/api.xpack.indices.migrate_to_data_stream.go
+++ b/esapi/api.xpack.indices.migrate_to_data_stream.go
@@ -12,9 +12,9 @@ import (
 	"strings"
 )
 
-func newIndicesGetDataStreamFunc(t Transport) IndicesGetDataStream {
-	return func(o ...func(*IndicesGetDataStreamRequest)) (*Response, error) {
-		var r = IndicesGetDataStreamRequest{}
+func newIndicesMigrateToDataStreamFunc(t Transport) IndicesMigrateToDataStream {
+	return func(name string, o ...func(*IndicesMigrateToDataStreamRequest)) (*Response, error) {
+		var r = IndicesMigrateToDataStreamRequest{Name: name}
 		for _, f := range o {
 			f(&r)
 		}
@@ -24,18 +24,16 @@ func newIndicesGetDataStreamFunc(t Transport) IndicesGetDataStream {
 
 // ----- API Definition -------------------------------------------------------
 
-// IndicesGetDataStream - Returns data streams.
+// IndicesMigrateToDataStream - Migrates an alias to a data stream
 //
 // See full documentation at https://www.elastic.co/guide/en/elasticsearch/reference/master/data-streams.html.
 //
-type IndicesGetDataStream func(o ...func(*IndicesGetDataStreamRequest)) (*Response, error)
+type IndicesMigrateToDataStream func(name string, o ...func(*IndicesMigrateToDataStreamRequest)) (*Response, error)
 
-// IndicesGetDataStreamRequest configures the Indices Get Data Stream API request.
+// IndicesMigrateToDataStreamRequest configures the Indices Migrate To Data Stream API request.
 //
-type IndicesGetDataStreamRequest struct {
-	Name []string
-
-	ExpandWildcards string
+type IndicesMigrateToDataStreamRequest struct {
+	Name string
 
 	Pretty     bool
 	Human      bool
@@ -49,28 +47,24 @@ type IndicesGetDataStreamRequest struct {
 
 // Do executes the request and returns response or error.
 //
-func (r IndicesGetDataStreamRequest) Do(ctx context.Context, transport Transport) (*Response, error) {
+func (r IndicesMigrateToDataStreamRequest) Do(ctx context.Context, transport Transport) (*Response, error) {
 	var (
 		method string
 		path   strings.Builder
 		params map[string]string
 	)
 
-	method = "GET"
+	method = "POST"
 
-	path.Grow(1 + len("_data_stream") + 1 + len(strings.Join(r.Name, ",")))
+	path.Grow(1 + len("_data_stream") + 1 + len("_migrate") + 1 + len(r.Name))
 	path.WriteString("/")
 	path.WriteString("_data_stream")
-	if len(r.Name) > 0 {
-		path.WriteString("/")
-		path.WriteString(strings.Join(r.Name, ","))
-	}
+	path.WriteString("/")
+	path.WriteString("_migrate")
+	path.WriteString("/")
+	path.WriteString(r.Name)
 
 	params = make(map[string]string)
-
-	if r.ExpandWildcards != "" {
-		params["expand_wildcards"] = r.ExpandWildcards
-	}
 
 	if r.Pretty {
 		params["pretty"] = "true"
@@ -133,64 +127,48 @@ func (r IndicesGetDataStreamRequest) Do(ctx context.Context, transport Transport
 
 // WithContext sets the request context.
 //
-func (f IndicesGetDataStream) WithContext(v context.Context) func(*IndicesGetDataStreamRequest) {
-	return func(r *IndicesGetDataStreamRequest) {
+func (f IndicesMigrateToDataStream) WithContext(v context.Context) func(*IndicesMigrateToDataStreamRequest) {
+	return func(r *IndicesMigrateToDataStreamRequest) {
 		r.ctx = v
-	}
-}
-
-// WithName - a list of data streams to get; use `*` to get all data streams.
-//
-func (f IndicesGetDataStream) WithName(v ...string) func(*IndicesGetDataStreamRequest) {
-	return func(r *IndicesGetDataStreamRequest) {
-		r.Name = v
-	}
-}
-
-// WithExpandWildcards - whether wildcard expressions should get expanded to open or closed indices (default: open).
-//
-func (f IndicesGetDataStream) WithExpandWildcards(v string) func(*IndicesGetDataStreamRequest) {
-	return func(r *IndicesGetDataStreamRequest) {
-		r.ExpandWildcards = v
 	}
 }
 
 // WithPretty makes the response body pretty-printed.
 //
-func (f IndicesGetDataStream) WithPretty() func(*IndicesGetDataStreamRequest) {
-	return func(r *IndicesGetDataStreamRequest) {
+func (f IndicesMigrateToDataStream) WithPretty() func(*IndicesMigrateToDataStreamRequest) {
+	return func(r *IndicesMigrateToDataStreamRequest) {
 		r.Pretty = true
 	}
 }
 
 // WithHuman makes statistical values human-readable.
 //
-func (f IndicesGetDataStream) WithHuman() func(*IndicesGetDataStreamRequest) {
-	return func(r *IndicesGetDataStreamRequest) {
+func (f IndicesMigrateToDataStream) WithHuman() func(*IndicesMigrateToDataStreamRequest) {
+	return func(r *IndicesMigrateToDataStreamRequest) {
 		r.Human = true
 	}
 }
 
 // WithErrorTrace includes the stack trace for errors in the response body.
 //
-func (f IndicesGetDataStream) WithErrorTrace() func(*IndicesGetDataStreamRequest) {
-	return func(r *IndicesGetDataStreamRequest) {
+func (f IndicesMigrateToDataStream) WithErrorTrace() func(*IndicesMigrateToDataStreamRequest) {
+	return func(r *IndicesMigrateToDataStreamRequest) {
 		r.ErrorTrace = true
 	}
 }
 
 // WithFilterPath filters the properties of the response body.
 //
-func (f IndicesGetDataStream) WithFilterPath(v ...string) func(*IndicesGetDataStreamRequest) {
-	return func(r *IndicesGetDataStreamRequest) {
+func (f IndicesMigrateToDataStream) WithFilterPath(v ...string) func(*IndicesMigrateToDataStreamRequest) {
+	return func(r *IndicesMigrateToDataStreamRequest) {
 		r.FilterPath = v
 	}
 }
 
 // WithHeader adds the headers to the HTTP request.
 //
-func (f IndicesGetDataStream) WithHeader(h map[string]string) func(*IndicesGetDataStreamRequest) {
-	return func(r *IndicesGetDataStreamRequest) {
+func (f IndicesMigrateToDataStream) WithHeader(h map[string]string) func(*IndicesMigrateToDataStreamRequest) {
+	return func(r *IndicesMigrateToDataStreamRequest) {
 		if r.Header == nil {
 			r.Header = make(http.Header)
 		}
@@ -202,8 +180,8 @@ func (f IndicesGetDataStream) WithHeader(h map[string]string) func(*IndicesGetDa
 
 // WithOpaqueID adds the X-Opaque-Id header to the HTTP request.
 //
-func (f IndicesGetDataStream) WithOpaqueID(s string) func(*IndicesGetDataStreamRequest) {
-	return func(r *IndicesGetDataStreamRequest) {
+func (f IndicesMigrateToDataStream) WithOpaqueID(s string) func(*IndicesMigrateToDataStreamRequest) {
+	return func(r *IndicesMigrateToDataStreamRequest) {
 		if r.Header == nil {
 			r.Header = make(http.Header)
 		}

--- a/esapi/api.xpack.indices.promote_data_stream.go
+++ b/esapi/api.xpack.indices.promote_data_stream.go
@@ -12,9 +12,9 @@ import (
 	"strings"
 )
 
-func newIndicesGetDataStreamFunc(t Transport) IndicesGetDataStream {
-	return func(o ...func(*IndicesGetDataStreamRequest)) (*Response, error) {
-		var r = IndicesGetDataStreamRequest{}
+func newIndicesPromoteDataStreamFunc(t Transport) IndicesPromoteDataStream {
+	return func(name string, o ...func(*IndicesPromoteDataStreamRequest)) (*Response, error) {
+		var r = IndicesPromoteDataStreamRequest{Name: name}
 		for _, f := range o {
 			f(&r)
 		}
@@ -24,18 +24,16 @@ func newIndicesGetDataStreamFunc(t Transport) IndicesGetDataStream {
 
 // ----- API Definition -------------------------------------------------------
 
-// IndicesGetDataStream - Returns data streams.
+// IndicesPromoteDataStream - Promotes a data stream from a replicated data stream managed by CCR to a regular data stream
 //
 // See full documentation at https://www.elastic.co/guide/en/elasticsearch/reference/master/data-streams.html.
 //
-type IndicesGetDataStream func(o ...func(*IndicesGetDataStreamRequest)) (*Response, error)
+type IndicesPromoteDataStream func(name string, o ...func(*IndicesPromoteDataStreamRequest)) (*Response, error)
 
-// IndicesGetDataStreamRequest configures the Indices Get Data Stream API request.
+// IndicesPromoteDataStreamRequest configures the Indices Promote Data Stream API request.
 //
-type IndicesGetDataStreamRequest struct {
-	Name []string
-
-	ExpandWildcards string
+type IndicesPromoteDataStreamRequest struct {
+	Name string
 
 	Pretty     bool
 	Human      bool
@@ -49,28 +47,24 @@ type IndicesGetDataStreamRequest struct {
 
 // Do executes the request and returns response or error.
 //
-func (r IndicesGetDataStreamRequest) Do(ctx context.Context, transport Transport) (*Response, error) {
+func (r IndicesPromoteDataStreamRequest) Do(ctx context.Context, transport Transport) (*Response, error) {
 	var (
 		method string
 		path   strings.Builder
 		params map[string]string
 	)
 
-	method = "GET"
+	method = "POST"
 
-	path.Grow(1 + len("_data_stream") + 1 + len(strings.Join(r.Name, ",")))
+	path.Grow(1 + len("_data_stream") + 1 + len("_promote") + 1 + len(r.Name))
 	path.WriteString("/")
 	path.WriteString("_data_stream")
-	if len(r.Name) > 0 {
-		path.WriteString("/")
-		path.WriteString(strings.Join(r.Name, ","))
-	}
+	path.WriteString("/")
+	path.WriteString("_promote")
+	path.WriteString("/")
+	path.WriteString(r.Name)
 
 	params = make(map[string]string)
-
-	if r.ExpandWildcards != "" {
-		params["expand_wildcards"] = r.ExpandWildcards
-	}
 
 	if r.Pretty {
 		params["pretty"] = "true"
@@ -133,64 +127,48 @@ func (r IndicesGetDataStreamRequest) Do(ctx context.Context, transport Transport
 
 // WithContext sets the request context.
 //
-func (f IndicesGetDataStream) WithContext(v context.Context) func(*IndicesGetDataStreamRequest) {
-	return func(r *IndicesGetDataStreamRequest) {
+func (f IndicesPromoteDataStream) WithContext(v context.Context) func(*IndicesPromoteDataStreamRequest) {
+	return func(r *IndicesPromoteDataStreamRequest) {
 		r.ctx = v
-	}
-}
-
-// WithName - a list of data streams to get; use `*` to get all data streams.
-//
-func (f IndicesGetDataStream) WithName(v ...string) func(*IndicesGetDataStreamRequest) {
-	return func(r *IndicesGetDataStreamRequest) {
-		r.Name = v
-	}
-}
-
-// WithExpandWildcards - whether wildcard expressions should get expanded to open or closed indices (default: open).
-//
-func (f IndicesGetDataStream) WithExpandWildcards(v string) func(*IndicesGetDataStreamRequest) {
-	return func(r *IndicesGetDataStreamRequest) {
-		r.ExpandWildcards = v
 	}
 }
 
 // WithPretty makes the response body pretty-printed.
 //
-func (f IndicesGetDataStream) WithPretty() func(*IndicesGetDataStreamRequest) {
-	return func(r *IndicesGetDataStreamRequest) {
+func (f IndicesPromoteDataStream) WithPretty() func(*IndicesPromoteDataStreamRequest) {
+	return func(r *IndicesPromoteDataStreamRequest) {
 		r.Pretty = true
 	}
 }
 
 // WithHuman makes statistical values human-readable.
 //
-func (f IndicesGetDataStream) WithHuman() func(*IndicesGetDataStreamRequest) {
-	return func(r *IndicesGetDataStreamRequest) {
+func (f IndicesPromoteDataStream) WithHuman() func(*IndicesPromoteDataStreamRequest) {
+	return func(r *IndicesPromoteDataStreamRequest) {
 		r.Human = true
 	}
 }
 
 // WithErrorTrace includes the stack trace for errors in the response body.
 //
-func (f IndicesGetDataStream) WithErrorTrace() func(*IndicesGetDataStreamRequest) {
-	return func(r *IndicesGetDataStreamRequest) {
+func (f IndicesPromoteDataStream) WithErrorTrace() func(*IndicesPromoteDataStreamRequest) {
+	return func(r *IndicesPromoteDataStreamRequest) {
 		r.ErrorTrace = true
 	}
 }
 
 // WithFilterPath filters the properties of the response body.
 //
-func (f IndicesGetDataStream) WithFilterPath(v ...string) func(*IndicesGetDataStreamRequest) {
-	return func(r *IndicesGetDataStreamRequest) {
+func (f IndicesPromoteDataStream) WithFilterPath(v ...string) func(*IndicesPromoteDataStreamRequest) {
+	return func(r *IndicesPromoteDataStreamRequest) {
 		r.FilterPath = v
 	}
 }
 
 // WithHeader adds the headers to the HTTP request.
 //
-func (f IndicesGetDataStream) WithHeader(h map[string]string) func(*IndicesGetDataStreamRequest) {
-	return func(r *IndicesGetDataStreamRequest) {
+func (f IndicesPromoteDataStream) WithHeader(h map[string]string) func(*IndicesPromoteDataStreamRequest) {
+	return func(r *IndicesPromoteDataStreamRequest) {
 		if r.Header == nil {
 			r.Header = make(http.Header)
 		}
@@ -202,8 +180,8 @@ func (f IndicesGetDataStream) WithHeader(h map[string]string) func(*IndicesGetDa
 
 // WithOpaqueID adds the X-Opaque-Id header to the HTTP request.
 //
-func (f IndicesGetDataStream) WithOpaqueID(s string) func(*IndicesGetDataStreamRequest) {
-	return func(r *IndicesGetDataStreamRequest) {
+func (f IndicesPromoteDataStream) WithOpaqueID(s string) func(*IndicesPromoteDataStreamRequest) {
+	return func(r *IndicesPromoteDataStreamRequest) {
 		if r.Header == nil {
 			r.Header = make(http.Header)
 		}

--- a/esapi/api.xpack.logstash.delete_pipeline.go
+++ b/esapi/api.xpack.logstash.delete_pipeline.go
@@ -12,9 +12,9 @@ import (
 	"strings"
 )
 
-func newAutoscalingDeleteAutoscalingPolicyFunc(t Transport) AutoscalingDeleteAutoscalingPolicy {
-	return func(name string, o ...func(*AutoscalingDeleteAutoscalingPolicyRequest)) (*Response, error) {
-		var r = AutoscalingDeleteAutoscalingPolicyRequest{Name: name}
+func newLogstashDeletePipelineFunc(t Transport) LogstashDeletePipeline {
+	return func(id string, o ...func(*LogstashDeletePipelineRequest)) (*Response, error) {
+		var r = LogstashDeletePipelineRequest{DocumentID: id}
 		for _, f := range o {
 			f(&r)
 		}
@@ -24,16 +24,16 @@ func newAutoscalingDeleteAutoscalingPolicyFunc(t Transport) AutoscalingDeleteAut
 
 // ----- API Definition -------------------------------------------------------
 
-// AutoscalingDeleteAutoscalingPolicy - Deletes an autoscaling policy. Designed for indirect use by ECE/ESS and ECK. Direct use is not supported.
+// LogstashDeletePipeline - Deletes Logstash Pipelines used by Central Management
 //
-// See full documentation at https://www.elastic.co/guide/en/elasticsearch/reference/current/autoscaling-delete-autoscaling-policy.html.
+// See full documentation at https://www.elastic.co/guide/en/elasticsearch/reference/current/logstash-api-delete-pipeline.html.
 //
-type AutoscalingDeleteAutoscalingPolicy func(name string, o ...func(*AutoscalingDeleteAutoscalingPolicyRequest)) (*Response, error)
+type LogstashDeletePipeline func(id string, o ...func(*LogstashDeletePipelineRequest)) (*Response, error)
 
-// AutoscalingDeleteAutoscalingPolicyRequest configures the Autoscaling Delete Autoscaling Policy API request.
+// LogstashDeletePipelineRequest configures the Logstash Delete Pipeline API request.
 //
-type AutoscalingDeleteAutoscalingPolicyRequest struct {
-	Name string
+type LogstashDeletePipelineRequest struct {
+	DocumentID string
 
 	Pretty     bool
 	Human      bool
@@ -47,7 +47,7 @@ type AutoscalingDeleteAutoscalingPolicyRequest struct {
 
 // Do executes the request and returns response or error.
 //
-func (r AutoscalingDeleteAutoscalingPolicyRequest) Do(ctx context.Context, transport Transport) (*Response, error) {
+func (r LogstashDeletePipelineRequest) Do(ctx context.Context, transport Transport) (*Response, error) {
 	var (
 		method string
 		path   strings.Builder
@@ -56,13 +56,13 @@ func (r AutoscalingDeleteAutoscalingPolicyRequest) Do(ctx context.Context, trans
 
 	method = "DELETE"
 
-	path.Grow(1 + len("_autoscaling") + 1 + len("policy") + 1 + len(r.Name))
+	path.Grow(1 + len("_logstash") + 1 + len("pipeline") + 1 + len(r.DocumentID))
 	path.WriteString("/")
-	path.WriteString("_autoscaling")
+	path.WriteString("_logstash")
 	path.WriteString("/")
-	path.WriteString("policy")
+	path.WriteString("pipeline")
 	path.WriteString("/")
-	path.WriteString(r.Name)
+	path.WriteString(r.DocumentID)
 
 	params = make(map[string]string)
 
@@ -127,48 +127,48 @@ func (r AutoscalingDeleteAutoscalingPolicyRequest) Do(ctx context.Context, trans
 
 // WithContext sets the request context.
 //
-func (f AutoscalingDeleteAutoscalingPolicy) WithContext(v context.Context) func(*AutoscalingDeleteAutoscalingPolicyRequest) {
-	return func(r *AutoscalingDeleteAutoscalingPolicyRequest) {
+func (f LogstashDeletePipeline) WithContext(v context.Context) func(*LogstashDeletePipelineRequest) {
+	return func(r *LogstashDeletePipelineRequest) {
 		r.ctx = v
 	}
 }
 
 // WithPretty makes the response body pretty-printed.
 //
-func (f AutoscalingDeleteAutoscalingPolicy) WithPretty() func(*AutoscalingDeleteAutoscalingPolicyRequest) {
-	return func(r *AutoscalingDeleteAutoscalingPolicyRequest) {
+func (f LogstashDeletePipeline) WithPretty() func(*LogstashDeletePipelineRequest) {
+	return func(r *LogstashDeletePipelineRequest) {
 		r.Pretty = true
 	}
 }
 
 // WithHuman makes statistical values human-readable.
 //
-func (f AutoscalingDeleteAutoscalingPolicy) WithHuman() func(*AutoscalingDeleteAutoscalingPolicyRequest) {
-	return func(r *AutoscalingDeleteAutoscalingPolicyRequest) {
+func (f LogstashDeletePipeline) WithHuman() func(*LogstashDeletePipelineRequest) {
+	return func(r *LogstashDeletePipelineRequest) {
 		r.Human = true
 	}
 }
 
 // WithErrorTrace includes the stack trace for errors in the response body.
 //
-func (f AutoscalingDeleteAutoscalingPolicy) WithErrorTrace() func(*AutoscalingDeleteAutoscalingPolicyRequest) {
-	return func(r *AutoscalingDeleteAutoscalingPolicyRequest) {
+func (f LogstashDeletePipeline) WithErrorTrace() func(*LogstashDeletePipelineRequest) {
+	return func(r *LogstashDeletePipelineRequest) {
 		r.ErrorTrace = true
 	}
 }
 
 // WithFilterPath filters the properties of the response body.
 //
-func (f AutoscalingDeleteAutoscalingPolicy) WithFilterPath(v ...string) func(*AutoscalingDeleteAutoscalingPolicyRequest) {
-	return func(r *AutoscalingDeleteAutoscalingPolicyRequest) {
+func (f LogstashDeletePipeline) WithFilterPath(v ...string) func(*LogstashDeletePipelineRequest) {
+	return func(r *LogstashDeletePipelineRequest) {
 		r.FilterPath = v
 	}
 }
 
 // WithHeader adds the headers to the HTTP request.
 //
-func (f AutoscalingDeleteAutoscalingPolicy) WithHeader(h map[string]string) func(*AutoscalingDeleteAutoscalingPolicyRequest) {
-	return func(r *AutoscalingDeleteAutoscalingPolicyRequest) {
+func (f LogstashDeletePipeline) WithHeader(h map[string]string) func(*LogstashDeletePipelineRequest) {
+	return func(r *LogstashDeletePipelineRequest) {
 		if r.Header == nil {
 			r.Header = make(http.Header)
 		}
@@ -180,8 +180,8 @@ func (f AutoscalingDeleteAutoscalingPolicy) WithHeader(h map[string]string) func
 
 // WithOpaqueID adds the X-Opaque-Id header to the HTTP request.
 //
-func (f AutoscalingDeleteAutoscalingPolicy) WithOpaqueID(s string) func(*AutoscalingDeleteAutoscalingPolicyRequest) {
-	return func(r *AutoscalingDeleteAutoscalingPolicyRequest) {
+func (f LogstashDeletePipeline) WithOpaqueID(s string) func(*LogstashDeletePipelineRequest) {
+	return func(r *LogstashDeletePipelineRequest) {
 		if r.Header == nil {
 			r.Header = make(http.Header)
 		}

--- a/esapi/api.xpack.logstash.get_pipeline.go
+++ b/esapi/api.xpack.logstash.get_pipeline.go
@@ -12,9 +12,9 @@ import (
 	"strings"
 )
 
-func newIndicesGetDataStreamFunc(t Transport) IndicesGetDataStream {
-	return func(o ...func(*IndicesGetDataStreamRequest)) (*Response, error) {
-		var r = IndicesGetDataStreamRequest{}
+func newLogstashGetPipelineFunc(t Transport) LogstashGetPipeline {
+	return func(id string, o ...func(*LogstashGetPipelineRequest)) (*Response, error) {
+		var r = LogstashGetPipelineRequest{DocumentID: id}
 		for _, f := range o {
 			f(&r)
 		}
@@ -24,18 +24,16 @@ func newIndicesGetDataStreamFunc(t Transport) IndicesGetDataStream {
 
 // ----- API Definition -------------------------------------------------------
 
-// IndicesGetDataStream - Returns data streams.
+// LogstashGetPipeline - Retrieves Logstash Pipelines used by Central Management
 //
-// See full documentation at https://www.elastic.co/guide/en/elasticsearch/reference/master/data-streams.html.
+// See full documentation at https://www.elastic.co/guide/en/elasticsearch/reference/current/logstash-api-get-pipeline.html.
 //
-type IndicesGetDataStream func(o ...func(*IndicesGetDataStreamRequest)) (*Response, error)
+type LogstashGetPipeline func(id string, o ...func(*LogstashGetPipelineRequest)) (*Response, error)
 
-// IndicesGetDataStreamRequest configures the Indices Get Data Stream API request.
+// LogstashGetPipelineRequest configures the Logstash Get Pipeline API request.
 //
-type IndicesGetDataStreamRequest struct {
-	Name []string
-
-	ExpandWildcards string
+type LogstashGetPipelineRequest struct {
+	DocumentID string
 
 	Pretty     bool
 	Human      bool
@@ -49,7 +47,7 @@ type IndicesGetDataStreamRequest struct {
 
 // Do executes the request and returns response or error.
 //
-func (r IndicesGetDataStreamRequest) Do(ctx context.Context, transport Transport) (*Response, error) {
+func (r LogstashGetPipelineRequest) Do(ctx context.Context, transport Transport) (*Response, error) {
 	var (
 		method string
 		path   strings.Builder
@@ -58,19 +56,15 @@ func (r IndicesGetDataStreamRequest) Do(ctx context.Context, transport Transport
 
 	method = "GET"
 
-	path.Grow(1 + len("_data_stream") + 1 + len(strings.Join(r.Name, ",")))
+	path.Grow(1 + len("_logstash") + 1 + len("pipeline") + 1 + len(r.DocumentID))
 	path.WriteString("/")
-	path.WriteString("_data_stream")
-	if len(r.Name) > 0 {
-		path.WriteString("/")
-		path.WriteString(strings.Join(r.Name, ","))
-	}
+	path.WriteString("_logstash")
+	path.WriteString("/")
+	path.WriteString("pipeline")
+	path.WriteString("/")
+	path.WriteString(r.DocumentID)
 
 	params = make(map[string]string)
-
-	if r.ExpandWildcards != "" {
-		params["expand_wildcards"] = r.ExpandWildcards
-	}
 
 	if r.Pretty {
 		params["pretty"] = "true"
@@ -133,64 +127,48 @@ func (r IndicesGetDataStreamRequest) Do(ctx context.Context, transport Transport
 
 // WithContext sets the request context.
 //
-func (f IndicesGetDataStream) WithContext(v context.Context) func(*IndicesGetDataStreamRequest) {
-	return func(r *IndicesGetDataStreamRequest) {
+func (f LogstashGetPipeline) WithContext(v context.Context) func(*LogstashGetPipelineRequest) {
+	return func(r *LogstashGetPipelineRequest) {
 		r.ctx = v
-	}
-}
-
-// WithName - a list of data streams to get; use `*` to get all data streams.
-//
-func (f IndicesGetDataStream) WithName(v ...string) func(*IndicesGetDataStreamRequest) {
-	return func(r *IndicesGetDataStreamRequest) {
-		r.Name = v
-	}
-}
-
-// WithExpandWildcards - whether wildcard expressions should get expanded to open or closed indices (default: open).
-//
-func (f IndicesGetDataStream) WithExpandWildcards(v string) func(*IndicesGetDataStreamRequest) {
-	return func(r *IndicesGetDataStreamRequest) {
-		r.ExpandWildcards = v
 	}
 }
 
 // WithPretty makes the response body pretty-printed.
 //
-func (f IndicesGetDataStream) WithPretty() func(*IndicesGetDataStreamRequest) {
-	return func(r *IndicesGetDataStreamRequest) {
+func (f LogstashGetPipeline) WithPretty() func(*LogstashGetPipelineRequest) {
+	return func(r *LogstashGetPipelineRequest) {
 		r.Pretty = true
 	}
 }
 
 // WithHuman makes statistical values human-readable.
 //
-func (f IndicesGetDataStream) WithHuman() func(*IndicesGetDataStreamRequest) {
-	return func(r *IndicesGetDataStreamRequest) {
+func (f LogstashGetPipeline) WithHuman() func(*LogstashGetPipelineRequest) {
+	return func(r *LogstashGetPipelineRequest) {
 		r.Human = true
 	}
 }
 
 // WithErrorTrace includes the stack trace for errors in the response body.
 //
-func (f IndicesGetDataStream) WithErrorTrace() func(*IndicesGetDataStreamRequest) {
-	return func(r *IndicesGetDataStreamRequest) {
+func (f LogstashGetPipeline) WithErrorTrace() func(*LogstashGetPipelineRequest) {
+	return func(r *LogstashGetPipelineRequest) {
 		r.ErrorTrace = true
 	}
 }
 
 // WithFilterPath filters the properties of the response body.
 //
-func (f IndicesGetDataStream) WithFilterPath(v ...string) func(*IndicesGetDataStreamRequest) {
-	return func(r *IndicesGetDataStreamRequest) {
+func (f LogstashGetPipeline) WithFilterPath(v ...string) func(*LogstashGetPipelineRequest) {
+	return func(r *LogstashGetPipelineRequest) {
 		r.FilterPath = v
 	}
 }
 
 // WithHeader adds the headers to the HTTP request.
 //
-func (f IndicesGetDataStream) WithHeader(h map[string]string) func(*IndicesGetDataStreamRequest) {
-	return func(r *IndicesGetDataStreamRequest) {
+func (f LogstashGetPipeline) WithHeader(h map[string]string) func(*LogstashGetPipelineRequest) {
+	return func(r *LogstashGetPipelineRequest) {
 		if r.Header == nil {
 			r.Header = make(http.Header)
 		}
@@ -202,8 +180,8 @@ func (f IndicesGetDataStream) WithHeader(h map[string]string) func(*IndicesGetDa
 
 // WithOpaqueID adds the X-Opaque-Id header to the HTTP request.
 //
-func (f IndicesGetDataStream) WithOpaqueID(s string) func(*IndicesGetDataStreamRequest) {
-	return func(r *IndicesGetDataStreamRequest) {
+func (f LogstashGetPipeline) WithOpaqueID(s string) func(*LogstashGetPipelineRequest) {
+	return func(r *LogstashGetPipelineRequest) {
 		if r.Header == nil {
 			r.Header = make(http.Header)
 		}

--- a/esapi/api.xpack.logstash.put_pipeline.go
+++ b/esapi/api.xpack.logstash.put_pipeline.go
@@ -13,9 +13,9 @@ import (
 	"strings"
 )
 
-func newAutoscalingPutAutoscalingPolicyFunc(t Transport) AutoscalingPutAutoscalingPolicy {
-	return func(name string, body io.Reader, o ...func(*AutoscalingPutAutoscalingPolicyRequest)) (*Response, error) {
-		var r = AutoscalingPutAutoscalingPolicyRequest{Name: name, Body: body}
+func newLogstashPutPipelineFunc(t Transport) LogstashPutPipeline {
+	return func(id string, body io.Reader, o ...func(*LogstashPutPipelineRequest)) (*Response, error) {
+		var r = LogstashPutPipelineRequest{DocumentID: id, Body: body}
 		for _, f := range o {
 			f(&r)
 		}
@@ -25,18 +25,18 @@ func newAutoscalingPutAutoscalingPolicyFunc(t Transport) AutoscalingPutAutoscali
 
 // ----- API Definition -------------------------------------------------------
 
-// AutoscalingPutAutoscalingPolicy - Creates a new autoscaling policy. Designed for indirect use by ECE/ESS and ECK. Direct use is not supported.
+// LogstashPutPipeline - Adds and updates Logstash Pipelines used for Central Management
 //
-// See full documentation at https://www.elastic.co/guide/en/elasticsearch/reference/current/autoscaling-put-autoscaling-policy.html.
+// See full documentation at https://www.elastic.co/guide/en/elasticsearch/reference/current/logstash-api-put-pipeline.html.
 //
-type AutoscalingPutAutoscalingPolicy func(name string, body io.Reader, o ...func(*AutoscalingPutAutoscalingPolicyRequest)) (*Response, error)
+type LogstashPutPipeline func(id string, body io.Reader, o ...func(*LogstashPutPipelineRequest)) (*Response, error)
 
-// AutoscalingPutAutoscalingPolicyRequest configures the Autoscaling Put Autoscaling Policy API request.
+// LogstashPutPipelineRequest configures the Logstash Put Pipeline API request.
 //
-type AutoscalingPutAutoscalingPolicyRequest struct {
+type LogstashPutPipelineRequest struct {
+	DocumentID string
+
 	Body io.Reader
-
-	Name string
 
 	Pretty     bool
 	Human      bool
@@ -50,7 +50,7 @@ type AutoscalingPutAutoscalingPolicyRequest struct {
 
 // Do executes the request and returns response or error.
 //
-func (r AutoscalingPutAutoscalingPolicyRequest) Do(ctx context.Context, transport Transport) (*Response, error) {
+func (r LogstashPutPipelineRequest) Do(ctx context.Context, transport Transport) (*Response, error) {
 	var (
 		method string
 		path   strings.Builder
@@ -59,13 +59,13 @@ func (r AutoscalingPutAutoscalingPolicyRequest) Do(ctx context.Context, transpor
 
 	method = "PUT"
 
-	path.Grow(1 + len("_autoscaling") + 1 + len("policy") + 1 + len(r.Name))
+	path.Grow(1 + len("_logstash") + 1 + len("pipeline") + 1 + len(r.DocumentID))
 	path.WriteString("/")
-	path.WriteString("_autoscaling")
+	path.WriteString("_logstash")
 	path.WriteString("/")
-	path.WriteString("policy")
+	path.WriteString("pipeline")
 	path.WriteString("/")
-	path.WriteString(r.Name)
+	path.WriteString(r.DocumentID)
 
 	params = make(map[string]string)
 
@@ -134,48 +134,48 @@ func (r AutoscalingPutAutoscalingPolicyRequest) Do(ctx context.Context, transpor
 
 // WithContext sets the request context.
 //
-func (f AutoscalingPutAutoscalingPolicy) WithContext(v context.Context) func(*AutoscalingPutAutoscalingPolicyRequest) {
-	return func(r *AutoscalingPutAutoscalingPolicyRequest) {
+func (f LogstashPutPipeline) WithContext(v context.Context) func(*LogstashPutPipelineRequest) {
+	return func(r *LogstashPutPipelineRequest) {
 		r.ctx = v
 	}
 }
 
 // WithPretty makes the response body pretty-printed.
 //
-func (f AutoscalingPutAutoscalingPolicy) WithPretty() func(*AutoscalingPutAutoscalingPolicyRequest) {
-	return func(r *AutoscalingPutAutoscalingPolicyRequest) {
+func (f LogstashPutPipeline) WithPretty() func(*LogstashPutPipelineRequest) {
+	return func(r *LogstashPutPipelineRequest) {
 		r.Pretty = true
 	}
 }
 
 // WithHuman makes statistical values human-readable.
 //
-func (f AutoscalingPutAutoscalingPolicy) WithHuman() func(*AutoscalingPutAutoscalingPolicyRequest) {
-	return func(r *AutoscalingPutAutoscalingPolicyRequest) {
+func (f LogstashPutPipeline) WithHuman() func(*LogstashPutPipelineRequest) {
+	return func(r *LogstashPutPipelineRequest) {
 		r.Human = true
 	}
 }
 
 // WithErrorTrace includes the stack trace for errors in the response body.
 //
-func (f AutoscalingPutAutoscalingPolicy) WithErrorTrace() func(*AutoscalingPutAutoscalingPolicyRequest) {
-	return func(r *AutoscalingPutAutoscalingPolicyRequest) {
+func (f LogstashPutPipeline) WithErrorTrace() func(*LogstashPutPipelineRequest) {
+	return func(r *LogstashPutPipelineRequest) {
 		r.ErrorTrace = true
 	}
 }
 
 // WithFilterPath filters the properties of the response body.
 //
-func (f AutoscalingPutAutoscalingPolicy) WithFilterPath(v ...string) func(*AutoscalingPutAutoscalingPolicyRequest) {
-	return func(r *AutoscalingPutAutoscalingPolicyRequest) {
+func (f LogstashPutPipeline) WithFilterPath(v ...string) func(*LogstashPutPipelineRequest) {
+	return func(r *LogstashPutPipelineRequest) {
 		r.FilterPath = v
 	}
 }
 
 // WithHeader adds the headers to the HTTP request.
 //
-func (f AutoscalingPutAutoscalingPolicy) WithHeader(h map[string]string) func(*AutoscalingPutAutoscalingPolicyRequest) {
-	return func(r *AutoscalingPutAutoscalingPolicyRequest) {
+func (f LogstashPutPipeline) WithHeader(h map[string]string) func(*LogstashPutPipelineRequest) {
+	return func(r *LogstashPutPipelineRequest) {
 		if r.Header == nil {
 			r.Header = make(http.Header)
 		}
@@ -187,8 +187,8 @@ func (f AutoscalingPutAutoscalingPolicy) WithHeader(h map[string]string) func(*A
 
 // WithOpaqueID adds the X-Opaque-Id header to the HTTP request.
 //
-func (f AutoscalingPutAutoscalingPolicy) WithOpaqueID(s string) func(*AutoscalingPutAutoscalingPolicyRequest) {
-	return func(r *AutoscalingPutAutoscalingPolicyRequest) {
+func (f LogstashPutPipeline) WithOpaqueID(s string) func(*LogstashPutPipelineRequest) {
+	return func(r *LogstashPutPipelineRequest) {
 		if r.Header == nil {
 			r.Header = make(http.Header)
 		}

--- a/esapi/api.xpack.ml.upgrade_job_snapshot.go
+++ b/esapi/api.xpack.ml.upgrade_job_snapshot.go
@@ -14,9 +14,9 @@ import (
 	"time"
 )
 
-func newTasksGetFunc(t Transport) TasksGet {
-	return func(task_id string, o ...func(*TasksGetRequest)) (*Response, error) {
-		var r = TasksGetRequest{TaskID: task_id}
+func newMLUpgradeJobSnapshotFunc(t Transport) MLUpgradeJobSnapshot {
+	return func(snapshot_id string, job_id string, o ...func(*MLUpgradeJobSnapshotRequest)) (*Response, error) {
+		var r = MLUpgradeJobSnapshotRequest{SnapshotID: snapshot_id, JobID: job_id}
 		for _, f := range o {
 			f(&r)
 		}
@@ -26,18 +26,17 @@ func newTasksGetFunc(t Transport) TasksGet {
 
 // ----- API Definition -------------------------------------------------------
 
-// TasksGet returns information about a task.
+// MLUpgradeJobSnapshot - Upgrades a given job snapshot to the current major version.
 //
-// This API is experimental.
+// See full documentation at https://www.elastic.co/guide/en/elasticsearch/reference/current/ml-upgrade-job-model-snapshot.html.
 //
-// See full documentation at https://www.elastic.co/guide/en/elasticsearch/reference/master/tasks.html.
-//
-type TasksGet func(task_id string, o ...func(*TasksGetRequest)) (*Response, error)
+type MLUpgradeJobSnapshot func(snapshot_id string, job_id string, o ...func(*MLUpgradeJobSnapshotRequest)) (*Response, error)
 
-// TasksGetRequest configures the Tasks Get API request.
+// MLUpgradeJobSnapshotRequest configures the ML Upgrade Job Snapshot API request.
 //
-type TasksGetRequest struct {
-	TaskID string
+type MLUpgradeJobSnapshotRequest struct {
+	JobID      string
+	SnapshotID string
 
 	Timeout           time.Duration
 	WaitForCompletion *bool
@@ -54,20 +53,28 @@ type TasksGetRequest struct {
 
 // Do executes the request and returns response or error.
 //
-func (r TasksGetRequest) Do(ctx context.Context, transport Transport) (*Response, error) {
+func (r MLUpgradeJobSnapshotRequest) Do(ctx context.Context, transport Transport) (*Response, error) {
 	var (
 		method string
 		path   strings.Builder
 		params map[string]string
 	)
 
-	method = "GET"
+	method = "POST"
 
-	path.Grow(1 + len("_tasks") + 1 + len(r.TaskID))
+	path.Grow(1 + len("_ml") + 1 + len("anomaly_detectors") + 1 + len(r.JobID) + 1 + len("model_snapshots") + 1 + len(r.SnapshotID) + 1 + len("_upgrade"))
 	path.WriteString("/")
-	path.WriteString("_tasks")
+	path.WriteString("_ml")
 	path.WriteString("/")
-	path.WriteString(r.TaskID)
+	path.WriteString("anomaly_detectors")
+	path.WriteString("/")
+	path.WriteString(r.JobID)
+	path.WriteString("/")
+	path.WriteString("model_snapshots")
+	path.WriteString("/")
+	path.WriteString(r.SnapshotID)
+	path.WriteString("/")
+	path.WriteString("_upgrade")
 
 	params = make(map[string]string)
 
@@ -140,64 +147,64 @@ func (r TasksGetRequest) Do(ctx context.Context, transport Transport) (*Response
 
 // WithContext sets the request context.
 //
-func (f TasksGet) WithContext(v context.Context) func(*TasksGetRequest) {
-	return func(r *TasksGetRequest) {
+func (f MLUpgradeJobSnapshot) WithContext(v context.Context) func(*MLUpgradeJobSnapshotRequest) {
+	return func(r *MLUpgradeJobSnapshotRequest) {
 		r.ctx = v
 	}
 }
 
-// WithTimeout - explicit operation timeout.
+// WithTimeout - how long should the api wait for the job to be opened and the old snapshot to be loaded..
 //
-func (f TasksGet) WithTimeout(v time.Duration) func(*TasksGetRequest) {
-	return func(r *TasksGetRequest) {
+func (f MLUpgradeJobSnapshot) WithTimeout(v time.Duration) func(*MLUpgradeJobSnapshotRequest) {
+	return func(r *MLUpgradeJobSnapshotRequest) {
 		r.Timeout = v
 	}
 }
 
-// WithWaitForCompletion - wait for the matching tasks to complete (default: false).
+// WithWaitForCompletion - should the request wait until the task is complete before responding to the caller. default is false..
 //
-func (f TasksGet) WithWaitForCompletion(v bool) func(*TasksGetRequest) {
-	return func(r *TasksGetRequest) {
+func (f MLUpgradeJobSnapshot) WithWaitForCompletion(v bool) func(*MLUpgradeJobSnapshotRequest) {
+	return func(r *MLUpgradeJobSnapshotRequest) {
 		r.WaitForCompletion = &v
 	}
 }
 
 // WithPretty makes the response body pretty-printed.
 //
-func (f TasksGet) WithPretty() func(*TasksGetRequest) {
-	return func(r *TasksGetRequest) {
+func (f MLUpgradeJobSnapshot) WithPretty() func(*MLUpgradeJobSnapshotRequest) {
+	return func(r *MLUpgradeJobSnapshotRequest) {
 		r.Pretty = true
 	}
 }
 
 // WithHuman makes statistical values human-readable.
 //
-func (f TasksGet) WithHuman() func(*TasksGetRequest) {
-	return func(r *TasksGetRequest) {
+func (f MLUpgradeJobSnapshot) WithHuman() func(*MLUpgradeJobSnapshotRequest) {
+	return func(r *MLUpgradeJobSnapshotRequest) {
 		r.Human = true
 	}
 }
 
 // WithErrorTrace includes the stack trace for errors in the response body.
 //
-func (f TasksGet) WithErrorTrace() func(*TasksGetRequest) {
-	return func(r *TasksGetRequest) {
+func (f MLUpgradeJobSnapshot) WithErrorTrace() func(*MLUpgradeJobSnapshotRequest) {
+	return func(r *MLUpgradeJobSnapshotRequest) {
 		r.ErrorTrace = true
 	}
 }
 
 // WithFilterPath filters the properties of the response body.
 //
-func (f TasksGet) WithFilterPath(v ...string) func(*TasksGetRequest) {
-	return func(r *TasksGetRequest) {
+func (f MLUpgradeJobSnapshot) WithFilterPath(v ...string) func(*MLUpgradeJobSnapshotRequest) {
+	return func(r *MLUpgradeJobSnapshotRequest) {
 		r.FilterPath = v
 	}
 }
 
 // WithHeader adds the headers to the HTTP request.
 //
-func (f TasksGet) WithHeader(h map[string]string) func(*TasksGetRequest) {
-	return func(r *TasksGetRequest) {
+func (f MLUpgradeJobSnapshot) WithHeader(h map[string]string) func(*MLUpgradeJobSnapshotRequest) {
+	return func(r *MLUpgradeJobSnapshotRequest) {
 		if r.Header == nil {
 			r.Header = make(http.Header)
 		}
@@ -209,8 +216,8 @@ func (f TasksGet) WithHeader(h map[string]string) func(*TasksGetRequest) {
 
 // WithOpaqueID adds the X-Opaque-Id header to the HTTP request.
 //
-func (f TasksGet) WithOpaqueID(s string) func(*TasksGetRequest) {
-	return func(r *TasksGetRequest) {
+func (f MLUpgradeJobSnapshot) WithOpaqueID(s string) func(*MLUpgradeJobSnapshotRequest) {
+	return func(r *MLUpgradeJobSnapshotRequest) {
 		if r.Header == nil {
 			r.Header = make(http.Header)
 		}

--- a/esapi/api.xpack.rollup.rollup.go
+++ b/esapi/api.xpack.rollup.rollup.go
@@ -13,9 +13,9 @@ import (
 	"strings"
 )
 
-func newAutoscalingPutAutoscalingPolicyFunc(t Transport) AutoscalingPutAutoscalingPolicy {
-	return func(name string, body io.Reader, o ...func(*AutoscalingPutAutoscalingPolicyRequest)) (*Response, error) {
-		var r = AutoscalingPutAutoscalingPolicyRequest{Name: name, Body: body}
+func newRollupRollupFunc(t Transport) RollupRollup {
+	return func(index string, body io.Reader, rollup_index string, o ...func(*RollupRollupRequest)) (*Response, error) {
+		var r = RollupRollupRequest{Index: index, Body: body, RollupIndex: rollup_index}
 		for _, f := range o {
 			f(&r)
 		}
@@ -25,18 +25,20 @@ func newAutoscalingPutAutoscalingPolicyFunc(t Transport) AutoscalingPutAutoscali
 
 // ----- API Definition -------------------------------------------------------
 
-// AutoscalingPutAutoscalingPolicy - Creates a new autoscaling policy. Designed for indirect use by ECE/ESS and ECK. Direct use is not supported.
+// RollupRollup - Rollup an index
 //
-// See full documentation at https://www.elastic.co/guide/en/elasticsearch/reference/current/autoscaling-put-autoscaling-policy.html.
+// See full documentation at https://www.elastic.co/guide/en/elasticsearch/reference/master/rollup-api.html.
 //
-type AutoscalingPutAutoscalingPolicy func(name string, body io.Reader, o ...func(*AutoscalingPutAutoscalingPolicyRequest)) (*Response, error)
+type RollupRollup func(index string, body io.Reader, rollup_index string, o ...func(*RollupRollupRequest)) (*Response, error)
 
-// AutoscalingPutAutoscalingPolicyRequest configures the Autoscaling Put Autoscaling Policy API request.
+// RollupRollupRequest configures the Rollup Rollup API request.
 //
-type AutoscalingPutAutoscalingPolicyRequest struct {
+type RollupRollupRequest struct {
+	Index string
+
 	Body io.Reader
 
-	Name string
+	RollupIndex string
 
 	Pretty     bool
 	Human      bool
@@ -50,22 +52,22 @@ type AutoscalingPutAutoscalingPolicyRequest struct {
 
 // Do executes the request and returns response or error.
 //
-func (r AutoscalingPutAutoscalingPolicyRequest) Do(ctx context.Context, transport Transport) (*Response, error) {
+func (r RollupRollupRequest) Do(ctx context.Context, transport Transport) (*Response, error) {
 	var (
 		method string
 		path   strings.Builder
 		params map[string]string
 	)
 
-	method = "PUT"
+	method = "POST"
 
-	path.Grow(1 + len("_autoscaling") + 1 + len("policy") + 1 + len(r.Name))
+	path.Grow(1 + len(r.Index) + 1 + len("_rollup") + 1 + len(r.RollupIndex))
 	path.WriteString("/")
-	path.WriteString("_autoscaling")
+	path.WriteString(r.Index)
 	path.WriteString("/")
-	path.WriteString("policy")
+	path.WriteString("_rollup")
 	path.WriteString("/")
-	path.WriteString(r.Name)
+	path.WriteString(r.RollupIndex)
 
 	params = make(map[string]string)
 
@@ -134,48 +136,48 @@ func (r AutoscalingPutAutoscalingPolicyRequest) Do(ctx context.Context, transpor
 
 // WithContext sets the request context.
 //
-func (f AutoscalingPutAutoscalingPolicy) WithContext(v context.Context) func(*AutoscalingPutAutoscalingPolicyRequest) {
-	return func(r *AutoscalingPutAutoscalingPolicyRequest) {
+func (f RollupRollup) WithContext(v context.Context) func(*RollupRollupRequest) {
+	return func(r *RollupRollupRequest) {
 		r.ctx = v
 	}
 }
 
 // WithPretty makes the response body pretty-printed.
 //
-func (f AutoscalingPutAutoscalingPolicy) WithPretty() func(*AutoscalingPutAutoscalingPolicyRequest) {
-	return func(r *AutoscalingPutAutoscalingPolicyRequest) {
+func (f RollupRollup) WithPretty() func(*RollupRollupRequest) {
+	return func(r *RollupRollupRequest) {
 		r.Pretty = true
 	}
 }
 
 // WithHuman makes statistical values human-readable.
 //
-func (f AutoscalingPutAutoscalingPolicy) WithHuman() func(*AutoscalingPutAutoscalingPolicyRequest) {
-	return func(r *AutoscalingPutAutoscalingPolicyRequest) {
+func (f RollupRollup) WithHuman() func(*RollupRollupRequest) {
+	return func(r *RollupRollupRequest) {
 		r.Human = true
 	}
 }
 
 // WithErrorTrace includes the stack trace for errors in the response body.
 //
-func (f AutoscalingPutAutoscalingPolicy) WithErrorTrace() func(*AutoscalingPutAutoscalingPolicyRequest) {
-	return func(r *AutoscalingPutAutoscalingPolicyRequest) {
+func (f RollupRollup) WithErrorTrace() func(*RollupRollupRequest) {
+	return func(r *RollupRollupRequest) {
 		r.ErrorTrace = true
 	}
 }
 
 // WithFilterPath filters the properties of the response body.
 //
-func (f AutoscalingPutAutoscalingPolicy) WithFilterPath(v ...string) func(*AutoscalingPutAutoscalingPolicyRequest) {
-	return func(r *AutoscalingPutAutoscalingPolicyRequest) {
+func (f RollupRollup) WithFilterPath(v ...string) func(*RollupRollupRequest) {
+	return func(r *RollupRollupRequest) {
 		r.FilterPath = v
 	}
 }
 
 // WithHeader adds the headers to the HTTP request.
 //
-func (f AutoscalingPutAutoscalingPolicy) WithHeader(h map[string]string) func(*AutoscalingPutAutoscalingPolicyRequest) {
-	return func(r *AutoscalingPutAutoscalingPolicyRequest) {
+func (f RollupRollup) WithHeader(h map[string]string) func(*RollupRollupRequest) {
+	return func(r *RollupRollupRequest) {
 		if r.Header == nil {
 			r.Header = make(http.Header)
 		}
@@ -187,8 +189,8 @@ func (f AutoscalingPutAutoscalingPolicy) WithHeader(h map[string]string) func(*A
 
 // WithOpaqueID adds the X-Opaque-Id header to the HTTP request.
 //
-func (f AutoscalingPutAutoscalingPolicy) WithOpaqueID(s string) func(*AutoscalingPutAutoscalingPolicyRequest) {
-	return func(r *AutoscalingPutAutoscalingPolicyRequest) {
+func (f RollupRollup) WithOpaqueID(s string) func(*RollupRollupRequest) {
+	return func(r *RollupRollupRequest) {
 		if r.Header == nil {
 			r.Header = make(http.Header)
 		}

--- a/esapi/api.xpack.searchable_snapshots.mount.go
+++ b/esapi/api.xpack.searchable_snapshots.mount.go
@@ -44,6 +44,7 @@ type SearchableSnapshotsMountRequest struct {
 	Snapshot   string
 
 	MasterTimeout     time.Duration
+	Storage           string
 	WaitForCompletion *bool
 
 	Pretty     bool
@@ -81,6 +82,10 @@ func (r SearchableSnapshotsMountRequest) Do(ctx context.Context, transport Trans
 
 	if r.MasterTimeout != 0 {
 		params["master_timeout"] = formatDuration(r.MasterTimeout)
+	}
+
+	if r.Storage != "" {
+		params["storage"] = r.Storage
 	}
 
 	if r.WaitForCompletion != nil {
@@ -163,6 +168,14 @@ func (f SearchableSnapshotsMount) WithContext(v context.Context) func(*Searchabl
 func (f SearchableSnapshotsMount) WithMasterTimeout(v time.Duration) func(*SearchableSnapshotsMountRequest) {
 	return func(r *SearchableSnapshotsMountRequest) {
 		r.MasterTimeout = v
+	}
+}
+
+// WithStorage - selects the kind of local storage used to accelerate searches. experimental, and defaults to `full_copy`.
+//
+func (f SearchableSnapshotsMount) WithStorage(v string) func(*SearchableSnapshotsMountRequest) {
+	return func(r *SearchableSnapshotsMountRequest) {
+		r.Storage = v
 	}
 }
 

--- a/esapi/api.xpack.text_structure.find_structure.go
+++ b/esapi/api.xpack.text_structure.find_structure.go
@@ -1,0 +1,377 @@
+// Licensed to Elasticsearch B.V under one or more agreements.
+// Elasticsearch B.V. licenses this file to you under the Apache 2.0 License.
+// See the LICENSE file in the project root for more information.
+//
+// Code generated from specification version 8.0.0: DO NOT EDIT
+
+package esapi
+
+import (
+	"context"
+	"io"
+	"net/http"
+	"strconv"
+	"strings"
+	"time"
+)
+
+func newTextStructureFindStructureFunc(t Transport) TextStructureFindStructure {
+	return func(body io.Reader, o ...func(*TextStructureFindStructureRequest)) (*Response, error) {
+		var r = TextStructureFindStructureRequest{Body: body}
+		for _, f := range o {
+			f(&r)
+		}
+		return r.Do(r.ctx, t)
+	}
+}
+
+// ----- API Definition -------------------------------------------------------
+
+// TextStructureFindStructure - Finds the structure of a text file. The text file must contain data that is suitable to be ingested into Elasticsearch.
+//
+// This API is experimental.
+//
+// See full documentation at https://www.elastic.co/guide/en/elasticsearch/reference/current/find-structure.html.
+//
+type TextStructureFindStructure func(body io.Reader, o ...func(*TextStructureFindStructureRequest)) (*Response, error)
+
+// TextStructureFindStructureRequest configures the Text Structure Find Structure API request.
+//
+type TextStructureFindStructureRequest struct {
+	Body io.Reader
+
+	Charset            string
+	ColumnNames        []string
+	Delimiter          string
+	Explain            *bool
+	Format             string
+	GrokPattern        string
+	HasHeaderRow       *bool
+	LineMergeSizeLimit *int
+	LinesToSample      *int
+	Quote              string
+	ShouldTrimFields   *bool
+	Timeout            time.Duration
+	TimestampField     string
+	TimestampFormat    string
+
+	Pretty     bool
+	Human      bool
+	ErrorTrace bool
+	FilterPath []string
+
+	Header http.Header
+
+	ctx context.Context
+}
+
+// Do executes the request and returns response or error.
+//
+func (r TextStructureFindStructureRequest) Do(ctx context.Context, transport Transport) (*Response, error) {
+	var (
+		method string
+		path   strings.Builder
+		params map[string]string
+	)
+
+	method = "POST"
+
+	path.Grow(len("/_text_structure/find_structure"))
+	path.WriteString("/_text_structure/find_structure")
+
+	params = make(map[string]string)
+
+	if r.Charset != "" {
+		params["charset"] = r.Charset
+	}
+
+	if len(r.ColumnNames) > 0 {
+		params["column_names"] = strings.Join(r.ColumnNames, ",")
+	}
+
+	if r.Delimiter != "" {
+		params["delimiter"] = r.Delimiter
+	}
+
+	if r.Explain != nil {
+		params["explain"] = strconv.FormatBool(*r.Explain)
+	}
+
+	if r.Format != "" {
+		params["format"] = r.Format
+	}
+
+	if r.GrokPattern != "" {
+		params["grok_pattern"] = r.GrokPattern
+	}
+
+	if r.HasHeaderRow != nil {
+		params["has_header_row"] = strconv.FormatBool(*r.HasHeaderRow)
+	}
+
+	if r.LineMergeSizeLimit != nil {
+		params["line_merge_size_limit"] = strconv.FormatInt(int64(*r.LineMergeSizeLimit), 10)
+	}
+
+	if r.LinesToSample != nil {
+		params["lines_to_sample"] = strconv.FormatInt(int64(*r.LinesToSample), 10)
+	}
+
+	if r.Quote != "" {
+		params["quote"] = r.Quote
+	}
+
+	if r.ShouldTrimFields != nil {
+		params["should_trim_fields"] = strconv.FormatBool(*r.ShouldTrimFields)
+	}
+
+	if r.Timeout != 0 {
+		params["timeout"] = formatDuration(r.Timeout)
+	}
+
+	if r.TimestampField != "" {
+		params["timestamp_field"] = r.TimestampField
+	}
+
+	if r.TimestampFormat != "" {
+		params["timestamp_format"] = r.TimestampFormat
+	}
+
+	if r.Pretty {
+		params["pretty"] = "true"
+	}
+
+	if r.Human {
+		params["human"] = "true"
+	}
+
+	if r.ErrorTrace {
+		params["error_trace"] = "true"
+	}
+
+	if len(r.FilterPath) > 0 {
+		params["filter_path"] = strings.Join(r.FilterPath, ",")
+	}
+
+	req, err := newRequest(method, path.String(), r.Body)
+	if err != nil {
+		return nil, err
+	}
+
+	if len(params) > 0 {
+		q := req.URL.Query()
+		for k, v := range params {
+			q.Set(k, v)
+		}
+		req.URL.RawQuery = q.Encode()
+	}
+
+	if r.Body != nil {
+		req.Header[headerContentType] = headerContentTypeJSON
+	}
+
+	if len(r.Header) > 0 {
+		if len(req.Header) == 0 {
+			req.Header = r.Header
+		} else {
+			for k, vv := range r.Header {
+				for _, v := range vv {
+					req.Header.Add(k, v)
+				}
+			}
+		}
+	}
+
+	if ctx != nil {
+		req = req.WithContext(ctx)
+	}
+
+	res, err := transport.Perform(req)
+	if err != nil {
+		return nil, err
+	}
+
+	response := Response{
+		StatusCode: res.StatusCode,
+		Body:       res.Body,
+		Header:     res.Header,
+	}
+
+	return &response, nil
+}
+
+// WithContext sets the request context.
+//
+func (f TextStructureFindStructure) WithContext(v context.Context) func(*TextStructureFindStructureRequest) {
+	return func(r *TextStructureFindStructureRequest) {
+		r.ctx = v
+	}
+}
+
+// WithCharset - optional parameter to specify the character set of the file.
+//
+func (f TextStructureFindStructure) WithCharset(v string) func(*TextStructureFindStructureRequest) {
+	return func(r *TextStructureFindStructureRequest) {
+		r.Charset = v
+	}
+}
+
+// WithColumnNames - optional parameter containing a comma separated list of the column names for a delimited file.
+//
+func (f TextStructureFindStructure) WithColumnNames(v ...string) func(*TextStructureFindStructureRequest) {
+	return func(r *TextStructureFindStructureRequest) {
+		r.ColumnNames = v
+	}
+}
+
+// WithDelimiter - optional parameter to specify the delimiter character for a delimited file - must be a single character.
+//
+func (f TextStructureFindStructure) WithDelimiter(v string) func(*TextStructureFindStructureRequest) {
+	return func(r *TextStructureFindStructureRequest) {
+		r.Delimiter = v
+	}
+}
+
+// WithExplain - whether to include a commentary on how the structure was derived.
+//
+func (f TextStructureFindStructure) WithExplain(v bool) func(*TextStructureFindStructureRequest) {
+	return func(r *TextStructureFindStructureRequest) {
+		r.Explain = &v
+	}
+}
+
+// WithFormat - optional parameter to specify the high level file format.
+//
+func (f TextStructureFindStructure) WithFormat(v string) func(*TextStructureFindStructureRequest) {
+	return func(r *TextStructureFindStructureRequest) {
+		r.Format = v
+	}
+}
+
+// WithGrokPattern - optional parameter to specify the grok pattern that should be used to extract fields from messages in a semi-structured text file.
+//
+func (f TextStructureFindStructure) WithGrokPattern(v string) func(*TextStructureFindStructureRequest) {
+	return func(r *TextStructureFindStructureRequest) {
+		r.GrokPattern = v
+	}
+}
+
+// WithHasHeaderRow - optional parameter to specify whether a delimited file includes the column names in its first row.
+//
+func (f TextStructureFindStructure) WithHasHeaderRow(v bool) func(*TextStructureFindStructureRequest) {
+	return func(r *TextStructureFindStructureRequest) {
+		r.HasHeaderRow = &v
+	}
+}
+
+// WithLineMergeSizeLimit - maximum number of characters permitted in a single message when lines are merged to create messages..
+//
+func (f TextStructureFindStructure) WithLineMergeSizeLimit(v int) func(*TextStructureFindStructureRequest) {
+	return func(r *TextStructureFindStructureRequest) {
+		r.LineMergeSizeLimit = &v
+	}
+}
+
+// WithLinesToSample - how many lines of the file should be included in the analysis.
+//
+func (f TextStructureFindStructure) WithLinesToSample(v int) func(*TextStructureFindStructureRequest) {
+	return func(r *TextStructureFindStructureRequest) {
+		r.LinesToSample = &v
+	}
+}
+
+// WithQuote - optional parameter to specify the quote character for a delimited file - must be a single character.
+//
+func (f TextStructureFindStructure) WithQuote(v string) func(*TextStructureFindStructureRequest) {
+	return func(r *TextStructureFindStructureRequest) {
+		r.Quote = v
+	}
+}
+
+// WithShouldTrimFields - optional parameter to specify whether the values between delimiters in a delimited file should have whitespace trimmed from them.
+//
+func (f TextStructureFindStructure) WithShouldTrimFields(v bool) func(*TextStructureFindStructureRequest) {
+	return func(r *TextStructureFindStructureRequest) {
+		r.ShouldTrimFields = &v
+	}
+}
+
+// WithTimeout - timeout after which the analysis will be aborted.
+//
+func (f TextStructureFindStructure) WithTimeout(v time.Duration) func(*TextStructureFindStructureRequest) {
+	return func(r *TextStructureFindStructureRequest) {
+		r.Timeout = v
+	}
+}
+
+// WithTimestampField - optional parameter to specify the timestamp field in the file.
+//
+func (f TextStructureFindStructure) WithTimestampField(v string) func(*TextStructureFindStructureRequest) {
+	return func(r *TextStructureFindStructureRequest) {
+		r.TimestampField = v
+	}
+}
+
+// WithTimestampFormat - optional parameter to specify the timestamp format in the file - may be either a joda or java time format.
+//
+func (f TextStructureFindStructure) WithTimestampFormat(v string) func(*TextStructureFindStructureRequest) {
+	return func(r *TextStructureFindStructureRequest) {
+		r.TimestampFormat = v
+	}
+}
+
+// WithPretty makes the response body pretty-printed.
+//
+func (f TextStructureFindStructure) WithPretty() func(*TextStructureFindStructureRequest) {
+	return func(r *TextStructureFindStructureRequest) {
+		r.Pretty = true
+	}
+}
+
+// WithHuman makes statistical values human-readable.
+//
+func (f TextStructureFindStructure) WithHuman() func(*TextStructureFindStructureRequest) {
+	return func(r *TextStructureFindStructureRequest) {
+		r.Human = true
+	}
+}
+
+// WithErrorTrace includes the stack trace for errors in the response body.
+//
+func (f TextStructureFindStructure) WithErrorTrace() func(*TextStructureFindStructureRequest) {
+	return func(r *TextStructureFindStructureRequest) {
+		r.ErrorTrace = true
+	}
+}
+
+// WithFilterPath filters the properties of the response body.
+//
+func (f TextStructureFindStructure) WithFilterPath(v ...string) func(*TextStructureFindStructureRequest) {
+	return func(r *TextStructureFindStructureRequest) {
+		r.FilterPath = v
+	}
+}
+
+// WithHeader adds the headers to the HTTP request.
+//
+func (f TextStructureFindStructure) WithHeader(h map[string]string) func(*TextStructureFindStructureRequest) {
+	return func(r *TextStructureFindStructureRequest) {
+		if r.Header == nil {
+			r.Header = make(http.Header)
+		}
+		for k, v := range h {
+			r.Header.Add(k, v)
+		}
+	}
+}
+
+// WithOpaqueID adds the X-Opaque-Id header to the HTTP request.
+//
+func (f TextStructureFindStructure) WithOpaqueID(s string) func(*TextStructureFindStructureRequest) {
+	return func(r *TextStructureFindStructureRequest) {
+		if r.Header == nil {
+			r.Header = make(http.Header)
+		}
+		r.Header.Set("X-Opaque-Id", s)
+	}
+}

--- a/esapi/api.xpack.watcher.query_watches.go
+++ b/esapi/api.xpack.watcher.query_watches.go
@@ -13,9 +13,9 @@ import (
 	"strings"
 )
 
-func newAutoscalingPutAutoscalingPolicyFunc(t Transport) AutoscalingPutAutoscalingPolicy {
-	return func(name string, body io.Reader, o ...func(*AutoscalingPutAutoscalingPolicyRequest)) (*Response, error) {
-		var r = AutoscalingPutAutoscalingPolicyRequest{Name: name, Body: body}
+func newWatcherQueryWatchesFunc(t Transport) WatcherQueryWatches {
+	return func(o ...func(*WatcherQueryWatchesRequest)) (*Response, error) {
+		var r = WatcherQueryWatchesRequest{}
 		for _, f := range o {
 			f(&r)
 		}
@@ -25,18 +25,16 @@ func newAutoscalingPutAutoscalingPolicyFunc(t Transport) AutoscalingPutAutoscali
 
 // ----- API Definition -------------------------------------------------------
 
-// AutoscalingPutAutoscalingPolicy - Creates a new autoscaling policy. Designed for indirect use by ECE/ESS and ECK. Direct use is not supported.
+// WatcherQueryWatches - Retrieves stored watches.
 //
-// See full documentation at https://www.elastic.co/guide/en/elasticsearch/reference/current/autoscaling-put-autoscaling-policy.html.
+// See full documentation at https://www.elastic.co/guide/en/elasticsearch/reference/current/watcher-api-query-watches.html.
 //
-type AutoscalingPutAutoscalingPolicy func(name string, body io.Reader, o ...func(*AutoscalingPutAutoscalingPolicyRequest)) (*Response, error)
+type WatcherQueryWatches func(o ...func(*WatcherQueryWatchesRequest)) (*Response, error)
 
-// AutoscalingPutAutoscalingPolicyRequest configures the Autoscaling Put Autoscaling Policy API request.
+// WatcherQueryWatchesRequest configures the Watcher Query Watches API request.
 //
-type AutoscalingPutAutoscalingPolicyRequest struct {
+type WatcherQueryWatchesRequest struct {
 	Body io.Reader
-
-	Name string
 
 	Pretty     bool
 	Human      bool
@@ -50,22 +48,17 @@ type AutoscalingPutAutoscalingPolicyRequest struct {
 
 // Do executes the request and returns response or error.
 //
-func (r AutoscalingPutAutoscalingPolicyRequest) Do(ctx context.Context, transport Transport) (*Response, error) {
+func (r WatcherQueryWatchesRequest) Do(ctx context.Context, transport Transport) (*Response, error) {
 	var (
 		method string
 		path   strings.Builder
 		params map[string]string
 	)
 
-	method = "PUT"
+	method = "GET"
 
-	path.Grow(1 + len("_autoscaling") + 1 + len("policy") + 1 + len(r.Name))
-	path.WriteString("/")
-	path.WriteString("_autoscaling")
-	path.WriteString("/")
-	path.WriteString("policy")
-	path.WriteString("/")
-	path.WriteString(r.Name)
+	path.Grow(len("/_watcher/_query/watches"))
+	path.WriteString("/_watcher/_query/watches")
 
 	params = make(map[string]string)
 
@@ -134,48 +127,56 @@ func (r AutoscalingPutAutoscalingPolicyRequest) Do(ctx context.Context, transpor
 
 // WithContext sets the request context.
 //
-func (f AutoscalingPutAutoscalingPolicy) WithContext(v context.Context) func(*AutoscalingPutAutoscalingPolicyRequest) {
-	return func(r *AutoscalingPutAutoscalingPolicyRequest) {
+func (f WatcherQueryWatches) WithContext(v context.Context) func(*WatcherQueryWatchesRequest) {
+	return func(r *WatcherQueryWatchesRequest) {
 		r.ctx = v
+	}
+}
+
+// WithBody - From, size, query, sort and search_after.
+//
+func (f WatcherQueryWatches) WithBody(v io.Reader) func(*WatcherQueryWatchesRequest) {
+	return func(r *WatcherQueryWatchesRequest) {
+		r.Body = v
 	}
 }
 
 // WithPretty makes the response body pretty-printed.
 //
-func (f AutoscalingPutAutoscalingPolicy) WithPretty() func(*AutoscalingPutAutoscalingPolicyRequest) {
-	return func(r *AutoscalingPutAutoscalingPolicyRequest) {
+func (f WatcherQueryWatches) WithPretty() func(*WatcherQueryWatchesRequest) {
+	return func(r *WatcherQueryWatchesRequest) {
 		r.Pretty = true
 	}
 }
 
 // WithHuman makes statistical values human-readable.
 //
-func (f AutoscalingPutAutoscalingPolicy) WithHuman() func(*AutoscalingPutAutoscalingPolicyRequest) {
-	return func(r *AutoscalingPutAutoscalingPolicyRequest) {
+func (f WatcherQueryWatches) WithHuman() func(*WatcherQueryWatchesRequest) {
+	return func(r *WatcherQueryWatchesRequest) {
 		r.Human = true
 	}
 }
 
 // WithErrorTrace includes the stack trace for errors in the response body.
 //
-func (f AutoscalingPutAutoscalingPolicy) WithErrorTrace() func(*AutoscalingPutAutoscalingPolicyRequest) {
-	return func(r *AutoscalingPutAutoscalingPolicyRequest) {
+func (f WatcherQueryWatches) WithErrorTrace() func(*WatcherQueryWatchesRequest) {
+	return func(r *WatcherQueryWatchesRequest) {
 		r.ErrorTrace = true
 	}
 }
 
 // WithFilterPath filters the properties of the response body.
 //
-func (f AutoscalingPutAutoscalingPolicy) WithFilterPath(v ...string) func(*AutoscalingPutAutoscalingPolicyRequest) {
-	return func(r *AutoscalingPutAutoscalingPolicyRequest) {
+func (f WatcherQueryWatches) WithFilterPath(v ...string) func(*WatcherQueryWatchesRequest) {
+	return func(r *WatcherQueryWatchesRequest) {
 		r.FilterPath = v
 	}
 }
 
 // WithHeader adds the headers to the HTTP request.
 //
-func (f AutoscalingPutAutoscalingPolicy) WithHeader(h map[string]string) func(*AutoscalingPutAutoscalingPolicyRequest) {
-	return func(r *AutoscalingPutAutoscalingPolicyRequest) {
+func (f WatcherQueryWatches) WithHeader(h map[string]string) func(*WatcherQueryWatchesRequest) {
+	return func(r *WatcherQueryWatchesRequest) {
 		if r.Header == nil {
 			r.Header = make(http.Header)
 		}
@@ -187,8 +188,8 @@ func (f AutoscalingPutAutoscalingPolicy) WithHeader(h map[string]string) func(*A
 
 // WithOpaqueID adds the X-Opaque-Id header to the HTTP request.
 //
-func (f AutoscalingPutAutoscalingPolicy) WithOpaqueID(s string) func(*AutoscalingPutAutoscalingPolicyRequest) {
-	return func(r *AutoscalingPutAutoscalingPolicyRequest) {
+func (f WatcherQueryWatches) WithOpaqueID(s string) func(*WatcherQueryWatchesRequest) {
+	return func(r *WatcherQueryWatchesRequest) {
 		if r.Header == nil {
 			r.Header = make(http.Header)
 		}

--- a/internal/cmd/generate/commands/genstruct/command.go
+++ b/internal/cmd/generate/commands/genstruct/command.go
@@ -238,7 +238,7 @@ type API struct {
 		for _, e := range endpoints {
 			name := strings.ReplaceAll(e.Name(), "Request", "")
 			if strings.HasPrefix(strings.ToLower(name), strings.ToLower(n)) {
-				methodName := strings.ReplaceAll(name, n, "")
+				methodName := cmd.stripNamespace(name, n)
 				b.WriteString(fmt.Sprintf("\t%s %s\n", methodName, name))
 			}
 		}
@@ -270,7 +270,7 @@ func New(t Transport) *API {
 		for _, e := range endpoints {
 			name := strings.ReplaceAll(e.Name(), "Request", "")
 			if strings.HasPrefix(strings.ToLower(name), strings.ToLower(n)) {
-				methodName := strings.ReplaceAll(name, n, "")
+				methodName := cmd.stripNamespace(name, n)
 				b.WriteString(fmt.Sprintf("\t\t\t%s: new%sFunc(t),\n", methodName, name))
 			}
 		}
@@ -340,4 +340,15 @@ func New(t Transport) *API {
 		return fmt.Errorf("error closing file: %s", err)
 	}
 	return nil
+}
+
+// stripNamespace Returns a stripped method name both for struct and API mapping
+//
+// Returns the original value if the namespace is equivalent to the method name.
+func (cmd *Command) stripNamespace(methodName, namespace string) string {
+	newMethodName := strings.ReplaceAll(methodName, namespace, "")
+	if len(newMethodName) == 0 {
+		newMethodName = namespace
+	}
+	return newMethodName
 }


### PR DESCRIPTION
The generator hangs on the Rollup func being named the same as the Rollup namespace.

This fixes that and generate a new set of apis based on the updated spec.