### PR TITLE
Implement the X-Elastic-Client-Meta HTTP header (#236)

### DIFF
--- a/elasticsearch.go
+++ b/elasticsearch.go
@@ -55,6 +55,8 @@ type Config struct {
 	EnableMetrics     bool // Enable the metrics collection.
 	EnableDebugLogger bool // Enable the debug logging.
 
+	DisableMetaHeader bool // Disable the additional "X-Elastic-Client-Meta" HTTP header.
+
 	RetryBackoff func(attempt int) time.Duration // Optional backoff duration. Default: nil.
 
 	Transport http.RoundTripper    // The HTTP transport object.
@@ -152,6 +154,8 @@ func NewClient(cfg Config) (*Client, error) {
 
 		EnableMetrics:     cfg.EnableMetrics,
 		EnableDebugLogger: cfg.EnableDebugLogger,
+
+		DisableMetaHeader: cfg.DisableMetaHeader,
 
 		DiscoverNodesInterval: cfg.DiscoverNodesInterval,
 

--- a/estransport/discovery.go
+++ b/estransport/discovery.go
@@ -133,6 +133,10 @@ func (c *Client) getNodesInfo() ([]nodeInfo, error) {
 	c.setReqAuth(conn.URL, req)
 	c.setReqUserAgent(req)
 
+	if c.disableMetaHeader == false {
+		c.setMetaHeader(req)
+	}
+
 	res, err := c.transport.RoundTrip(req)
 	if err != nil {
 		return out, err

--- a/estransport/logger_internal_test.go
+++ b/estransport/logger_internal_test.go
@@ -239,6 +239,7 @@ func TestTransportLogger(t *testing.T) {
 			URLs:      []*url.URL{{Scheme: "http", Host: "foo"}},
 			Transport: newRoundTripper(),
 			Logger:    &CurlLogger{Output: &dst, EnableRequestBody: true, EnableResponseBody: true},
+			DisableMetaHeader: true,
 		})
 
 		req, _ := http.NewRequest("GET", "/abc?q=a,b", nil)
@@ -256,7 +257,6 @@ func TestTransportLogger(t *testing.T) {
 
 		output := dst.String()
 		output = strings.TrimSuffix(output, "\n")
-		// fmt.Println(output)
 
 		lines := strings.Split(output, "\n")
 

--- a/estransport/metaheader.go
+++ b/estransport/metaheader.go
@@ -1,0 +1,64 @@
+package estransport
+
+import (
+	"regexp"
+	"runtime"
+	"strings"
+)
+
+// HeaderClientMeta Key for the HTTP Header related to telemetry data sent with
+// each request to Elasticsearch.
+const HeaderClientMeta = "x-elastic-client-meta"
+
+var metaReVersion = regexp.MustCompile("([0-9.]+)(.*)")
+
+func initMetaHeader() string {
+	var b strings.Builder
+	var strippedGoVersion string
+	var strippedEsVersion string
+
+	strippedEsVersion = buildStrippedVersion(Version)
+	strippedGoVersion = buildStrippedVersion(runtime.Version())
+
+	var duos = [][]string{
+		{
+			"es",
+			strippedEsVersion,
+		},
+		{
+			"go",
+			strippedGoVersion,
+		},
+		{
+			"t",
+			strippedEsVersion,
+		},
+		{
+			"hc",
+			strippedGoVersion,
+		},
+	}
+
+	var arr []string
+	for _, duo := range duos {
+		arr = append(arr, strings.Join(duo, "="))
+	}
+	b.WriteString(strings.Join(arr, ","))
+
+	return b.String()
+}
+
+func buildStrippedVersion(version string) string {
+	v := metaReVersion.FindStringSubmatch(version)
+
+	if len(v) == 3 && !strings.Contains(version, "devel") {
+		switch {
+		case v[2] != "":
+			return v[1] + "p"
+		default:
+			return v[1]
+		}
+	}
+
+	return "0.0p"
+}

--- a/estransport/metaheader_test.go
+++ b/estransport/metaheader_test.go
@@ -1,0 +1,98 @@
+package estransport
+
+import (
+	"regexp"
+	"runtime"
+	"testing"
+
+	"github.com/elastic/go-elasticsearch/v8/internal/version"
+)
+
+var (
+	metaHeaderReValidation = regexp.MustCompile(`^[a-z]{1,}=[a-z0-9\.\-]{1,}(?:,[a-z]{1,}=[a-z0-9\.\-]+)*$`)
+)
+
+func Test_buildStrippedVersion(t *testing.T) {
+	type args struct {
+		version string
+	}
+	tests := []struct {
+		name string
+		args args
+		want string
+	}{
+		{
+			name: "Standard Go version",
+			args: args{version: "go1.16"},
+			want: "1.16",
+		},
+		{
+			name: "Rc Go version",
+			args: args{
+				version: "go1.16rc1",
+			},
+			want: "1.16p",
+		},
+		{
+			name: "Beta Go version (go1.16beta1 example)",
+			args: args{
+				version: "devel +2ff33f5e44 Thu Dec 17 16:03:19 2020 +0000",
+			},
+			want: "0.0p",
+		},
+		{
+			name: "Random mostly good Go version",
+			args: args{
+				version: "1.16",
+			},
+			want: "1.16",
+		},
+		{
+			name: "Client package version",
+			args: args{
+				version: "8.0.0",
+			},
+			want: "8.0.0",
+		},
+		{
+			name: "Client pre release version",
+			args: args{
+				version: "8.0.0-SNAPSHOT",
+			},
+			want: "8.0.0p",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := buildStrippedVersion(tt.args.version); got != tt.want {
+				t.Errorf("buildStrippedVersion() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func Test_initMetaHeader(t *testing.T) {
+	esVersion := buildStrippedVersion(version.Client)
+	goVersion := buildStrippedVersion(runtime.Version())
+
+	tests := []struct {
+		name string
+		want string
+	}{
+		{
+			name: "Meta header generation",
+			want: "es=" + esVersion + ",go=" + goVersion + ",t=" + esVersion + ",hc=" + goVersion,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if metaHeader != tt.want {
+				t.Errorf("initMetaHeader() = %v, want %v", metaHeader, tt.want)
+			}
+			if valid := metaHeaderReValidation.Match([]byte(metaHeader)); valid != true {
+				t.Errorf("Metaheder doesn't validate regexp format validation, got : %s", metaHeader)
+			}
+		})
+	}
+}

--- a/esutil/bulk_indexer.go
+++ b/esutil/bulk_indexer.go
@@ -9,6 +9,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"github.com/elastic/go-elasticsearch/v8/estransport"
 	"io"
 	"io/ioutil"
 	"net/http"
@@ -493,6 +494,13 @@ func (w *worker) flush(ctx context.Context) error {
 		FilterPath: w.bi.config.FilterPath,
 		Header:     w.bi.config.Header,
 	}
+
+	// Add Header and MetaHeader to config if not already set
+	if req.Header == nil {
+		req.Header = http.Header{}
+	}
+	req.Header.Set(estransport.HeaderClientMeta, "h=bp")
+
 	res, err := req.Do(ctx, w.bi.config.Client)
 	if err != nil {
 		atomic.AddUint64(&w.bi.stats.numFailed, uint64(len(w.items)))

--- a/esutil/bulk_indexer_internal_test.go
+++ b/esutil/bulk_indexer_internal_test.go
@@ -17,6 +17,7 @@ import (
 	"net/http"
 	"os"
 	"reflect"
+	"regexp"
 	"strconv"
 	"strings"
 	"sync"
@@ -626,6 +627,111 @@ func TestBulkIndexer(t *testing.T) {
 					t.Errorf("worker.writeMeta() %s = got [%s], want [%s]", tt.name, w.buf.String(), tt.want)
 				}
 
+			})
+		}
+	})
+
+	t.Run("MetaHeader presence in Request header", func(t *testing.T) {
+		type args struct {
+			disableMetaHeader bool
+			header            http.Header
+		}
+		tests := []struct {
+			name string
+			args args
+			want string
+		}{
+			{
+				name: "Meta header is present in header",
+				args: args{
+					disableMetaHeader: false,
+				},
+				want: `^[a-z]{1,}=[a-z0-9\.\-]{1,}(?:,[a-z]{1,}=[a-z0-9\.\-]+)*,h=bp$`,
+			},
+			{
+				name: "Header should be empty of meta header",
+				args: args{
+					disableMetaHeader: true,
+				},
+				want: ``,
+			},
+			{
+				name: "User has set header",
+				args: args{
+					disableMetaHeader: false,
+					header: http.Header{
+						"X-Test-User": []string{"UserValue"},
+					},
+				},
+			},
+			{
+				name: "User should not temper with Meta Header",
+				args: args{
+					disableMetaHeader: false,
+					header: http.Header{
+						"X-Test-User": []string{"UserValue"},
+						estransport.HeaderClientMeta: []string{"h=shouldntbechanged"},
+					},
+				},
+			},
+		}
+		for _, tt := range tests {
+			t.Run(tt.name, func(t *testing.T) {
+				reValidation := regexp.MustCompile(tt.want)
+
+				esConfig := elasticsearch.Config{
+					DisableMetaHeader: tt.args.disableMetaHeader,
+					Header: tt.args.header,
+					Transport: &mockTransport{
+						RoundTripFunc: func(request *http.Request) (*http.Response, error) {
+							headerMeta := request.Header.Get(estransport.HeaderClientMeta)
+
+							if !reValidation.MatchString(headerMeta) {
+								t.Errorf("Meta Header presence is invalid, got : %s, want : %s", headerMeta, tt.want)
+							}
+
+							if tt.args.disableMetaHeader && headerMeta != "" {
+								t.Errorf("Meta Header is disabled, should be empty, got : %s", headerMeta)
+							}
+
+							if tt.args.header != nil {
+								if userHeader := request.Header.Get("X-Test-User"); userHeader != "UserValue" {
+									t.Errorf("User header should be preserved, got : %s", userHeader)
+								}
+							}
+
+							return &http.Response{
+								StatusCode: http.StatusOK,
+								Status:     "200 OK",
+								Body:       io.NopCloser(bytes.NewBuffer(nil)),
+							}, nil
+						},
+					},
+				}
+
+				client, err := elasticsearch.NewClient(esConfig)
+				if err != nil {
+					log.Fatal(err)
+				}
+
+				cfg := BulkIndexerConfig{
+					Client: client,
+					Header: tt.args.header,
+				}
+				bi, err := NewBulkIndexer(cfg)
+				if err != nil {
+					log.Fatal(err)
+				}
+
+				err = bi.Add(context.Background(), BulkIndexerItem{
+					Action:     "foo",
+					DocumentID: strconv.Itoa(1),
+					Body:       strings.NewReader(fmt.Sprintf(`{"title":"foo-%d"}`, 1)),
+				})
+				if err != nil {
+					log.Fatal(err)
+				}
+				bi.Close(context.Background())
 			})
 		}
 	})


### PR DESCRIPTION
* Transport: Add x-elastic-meta-header to Go client transport and discovery
Util: Add x-elastic-meta-header usage in bulk indexer helper

* Transport: Tests: Enhance precision of expected header value

* Transport: Add Http Client identifier to meta header