### PR TITLE
Favor POST method if GET and POST are available

### DIFF
--- a/internal/build/cmd/generate/commands/gensource/generator.go
+++ b/internal/build/cmd/generate/commands/gensource/generator.go
@@ -478,7 +478,6 @@ func (r ` + g.Endpoint.MethodWithNamespace() + `Request) Do(ctx context.Context,
 		params  map[string]string
 	)` + "\n\n")
 
-	// Generate the HTTP method
 	switch g.Endpoint.Name {
 	case "index":
 		g.w("\t")
@@ -489,7 +488,16 @@ func (r ` + g.Endpoint.MethodWithNamespace() + `Request) Do(ctx context.Context,
 	}`)
 		g.w("\n\n")
 	default:
-		g.w("\t" + `method = "` + g.Endpoint.URL.Paths[0].Methods[0] + `"` + "\n\n")
+		var httpMethod string
+		// If endpoint has both GET and POST available
+		// Prefer POST usage in order to prevent go routine leak
+		// See https://github.com/golang/go/issues/29246
+		if g.Endpoint.URL.ContainsMethods("GET", "POST") {
+			httpMethod = "POST"
+		} else {
+			httpMethod = g.Endpoint.URL.Paths[0].Methods[0]
+		}
+		g.w("\t" + `method = "` + httpMethod + `"` + "\n\n")
 	}
 
 	// Get default part values for specific APIs

--- a/internal/build/cmd/generate/commands/gensource/model.go
+++ b/internal/build/cmd/generate/commands/gensource/model.go
@@ -498,3 +498,28 @@ func (p *MethodArgument) GoName() string {
 func (p *MethodArgument) GoType(comment ...bool) string {
 	return utils.TypeToGo(p.Type)
 }
+
+// ContainsMethods return true if every method passed in argument is present in every Path
+func (u *URL) ContainsMethods(methods ...string) bool {
+	for _, path := range u.Paths {
+		// Fast exit if both collections are not the same size
+		if len(methods) != len(path.Methods) {
+			return false
+		}
+
+		// We iterate over every items
+		items := make(map[string]struct{})
+		for _, v := range path.Methods {
+			items[v] = struct{}{}
+		}
+
+		for _, method := range methods {
+			if _, ok := items[method]; ok {
+				continue
+			}
+			return false
+		}
+		continue
+	}
+	return true
+}


### PR DESCRIPTION
Whenever an endpoint has both GET and POST method available
favor the POST method to avoid leaking goroutine as documented in #250. 

This change impacts the following APIs :
 * EqlSearch
 * GraphExplore
 * IndicesReloadSearchAnalyzers
 * MLGetBuckets
 * MLGetCalendars
 * MLGetCategories
 * MLGetInfluencers
 * MLGetModelSnapshots
 * MLGetOverallBuckets
 * MLGetRecords
 * MLPreviewDatafeed
 * RollupRollupSearch
 * SecurityHasPrivileges
 * WatcherQueryWatches
