### PR TITLE
Add support for HTTP  API compatibility header

### DIFF
--- a/estransport/estransport.go
+++ b/estransport/estransport.go
@@ -60,8 +60,8 @@ func init() {
 	userAgent = initUserAgent()
 	metaHeader = initMetaHeader()
 
-	compatHeaderStr := os.Getenv(esCompatHeader)
-	compatibilityHeader, _ = strconv.ParseBool(compatHeaderStr)
+	compatHeaderEnv := os.Getenv(esCompatHeader)
+	compatibilityHeader, _ = strconv.ParseBool(compatHeaderEnv)
 }
 
 // Interface defines the interface for HTTP client.
@@ -233,9 +233,9 @@ func (c *Client) Perform(req *http.Request) (*http.Response, error) {
 	// Compatibility Header
 	if compatibilityHeader {
 		if req.Body != nil {
-			req.Header["Content-Type"] = []string{"application/vnd.elasticsearch+json;compatible-with=7"}
+			req.Header.Set("Content-Type", "application/vnd.elasticsearch+json;compatible-with=7")
 		}
-		req.Header["Accept"] = []string{"application/vnd.elasticsearch+json;compatible-with=7"}
+		req.Header.Set("Accept", "application/vnd.elasticsearch+json;compatible-with=7")
 	}
 
 	// Record metrics, when enabled


### PR DESCRIPTION
In Elasticsearch 7.13 will be introduced a new compatibility header in the following form:

```
Accept:       application/vnd.elasticsearch+json;compatible-with=7
Content-Type: application/vnd.elasticsearch+json; compatible-with=7
```

This allows the progressive migration from `7.x` to `8.x` as Elasticsearch should be upgraded first after the compatibility header is configured and clients should be upgraded second.

This compatibility header can be enabled by setting the `ELASTIC_CLIENT_APIVERSIONING` to `true` or by passing the before mentioned headers in the request.