### PR TITLE
Add `Get` struct to `BulkIndexerResponseItem` to retrieve updated document when using `_source=true` in update request

### DIFF
--- a/esutil/bulk_indexer.go
+++ b/esutil/bulk_indexer.go
@@ -146,6 +146,13 @@ type BulkIndexerResponseItem struct {
 			Reason string `json:"reason"`
 		} `json:"caused_by"`
 	} `json:"error,omitempty"`
+	
+	Get struct {
+		SeqNo    int64                  `json:"_seq_no"`
+		PrimTerm int64                  `json:"_primary_term"`
+		Found    bool                   `json:"found"`
+		Source   map[string]interface{} `json:"_source"`
+	} `json:"get"`
 }
 
 // BulkResponseJSONDecoder defines the interface for custom JSON decoders.


### PR DESCRIPTION
I want to retrieve updated document when executing update bulk request as describe here with `_source`: https://www.elastic.co/guide/en/elasticsearch/reference/current/docs-update.html#docs-update-api-query-params

I added  `Source:        []string{"true"},` in my `BulkIndexerConfig` but `BulkIndexerResponseItem` struct was not able to retrieve updated document, so I added these fields.