### PR TITLE
Add option to enable gzip compression on request bodies

### DIFF
--- a/elasticsearch.go
+++ b/elasticsearch.go
@@ -63,6 +63,8 @@ type Config struct {
 	EnableRetryOnTimeout bool  // Default: false.
 	MaxRetries           int   // Default: 3.
 
+	CompressRequestBody bool // Default: false.
+
 	DiscoverNodesOnStart  bool          // Discover nodes when initializing the client. Default: false.
 	DiscoverNodesInterval time.Duration // Discover nodes periodically. Default: disabled.
 
@@ -166,6 +168,8 @@ func NewClient(cfg Config) (*Client, error) {
 		EnableRetryOnTimeout: cfg.EnableRetryOnTimeout,
 		MaxRetries:           cfg.MaxRetries,
 		RetryBackoff:         cfg.RetryBackoff,
+
+		CompressRequestBody: cfg.CompressRequestBody,
 
 		EnableMetrics:     cfg.EnableMetrics,
 		EnableDebugLogger: cfg.EnableDebugLogger,

--- a/estransport/estransport.go
+++ b/estransport/estransport.go
@@ -48,10 +48,10 @@ const (
 )
 
 var (
-	userAgent           string
-	metaHeader          string
+	userAgent   string
+	metaHeader  string
 	compatibilityHeader bool
-	reGoVersion         = regexp.MustCompile(`go(\d+\.\d+\..+)`)
+	reGoVersion = regexp.MustCompile(`go(\d+\.\d+\..+)`)
 
 	defaultMaxRetries    = 3
 	defaultRetryOnStatus = [...]int{502, 503, 504}

--- a/estransport/estransport_internal_test.go
+++ b/estransport/estransport_internal_test.go
@@ -993,7 +993,7 @@ func TestCompatibilityHeader(t *testing.T) {
 	}
 }
 
-func TestTransportCompression(t *testing.T) {
+func TestRequestCompression(t *testing.T) {
 
 	tests := []struct {
 		name            string

--- a/estransport/estransport_internal_test.go
+++ b/estransport/estransport_internal_test.go
@@ -937,19 +937,19 @@ func TestCompatibilityHeader(t *testing.T) {
 		{
 			name:                "Compatibility header disabled",
 			compatibilityHeader: false,
-			bodyPresent:         false,
+			bodyPresent: false,
 			expectsHeader:       []string{"application/json"},
 		},
 		{
 			name:                "Compatibility header enabled",
 			compatibilityHeader: true,
-			bodyPresent:         false,
+			bodyPresent: false,
 			expectsHeader:       []string{"application/vnd.elasticsearch+json;compatible-with=7"},
 		},
 		{
-			name:                "Compatibility header enabled with body",
+			name: "Compatibility header enabled with body",
 			compatibilityHeader: true,
-			bodyPresent:         true,
+			bodyPresent: true,
 			expectsHeader:       []string{"application/vnd.elasticsearch+json;compatible-with=7"},
 		},
 	}

--- a/estransport/estransport_internal_test.go
+++ b/estransport/estransport_internal_test.go
@@ -1025,14 +1025,20 @@ func TestRequestCompression(t *testing.T) {
 						}
 
 						var buf bytes.Buffer
-						if !test.compressionFlag {
-							buf.ReadFrom(req.Body)
-						} else {
-							zr, err := gzip.NewReader(req.Body)
+						buf.ReadFrom(req.Body)
+
+						if req.ContentLength != int64(buf.Len()) {
+							return nil, fmt.Errorf("mismatched Content-Length: %d vs actual %d", req.ContentLength, buf.Len())
+						}
+
+						if test.compressionFlag {
+							var unBuf bytes.Buffer
+							zr, err := gzip.NewReader(&buf)
 							if err != nil {
 								return nil, fmt.Errorf("decompression error: %v", err)
 							}
-							buf.ReadFrom(zr)
+							unBuf.ReadFrom(zr)
+							buf = unBuf
 						}
 
 						if buf.String() != test.inputBody {

--- a/estransport/estransport_internal_test.go
+++ b/estransport/estransport_internal_test.go
@@ -999,7 +999,6 @@ func TestRequestCompression(t *testing.T) {
 		name            string
 		compressionFlag bool
 		inputBody       string
-		expectedBodyHex string
 	}{
 		{
 			name:            "Uncompressed",


### PR DESCRIPTION
Elasticsearch is able to accept *gzip*-compressed request bodies, but currently this library has no functionality to send compressed request bodies.

Request compression can be important in e.g. the situation where you are pushing a lot of data out from a cloud provider to a self-hosted Elasticsearch instance, and being billed heavily for bandwidth. Issue https://github.com/elastic/go-elasticsearch/issues/217 requests this feature.

This PR adds a client flag `CompressRequestBody` which, if enabled, causes request bodies to be compressed. The flag is disabled by default. Also added a couple of tests for the feature.