### PR TITLE
Product check: Improve retry mechanism 

### DIFF
--- a/elasticsearch.go
+++ b/elasticsearch.go
@@ -300,16 +300,9 @@ func (c *Client) Perform(req *http.Request) (*http.Response, error) {
 
 	// ResponseCheck path continues, we run the header check on the first answer from ES.
 	if err == nil {
-		checkHeader := func() error {
-			if res != nil {
-				return genuineCheckHeader(res.Header)
-			}
-			return nil
-		}
+		checkHeader := func() error { return genuineCheckHeader(res.Header) }
 		if err := c.doProductCheck(checkHeader); err != nil {
-			if res.Body != nil {
-				res.Body.Close()
-			}
+			res.Body.Close()
 			return nil, err
 		}
 	}

--- a/elasticsearch.go
+++ b/elasticsearch.go
@@ -134,6 +134,7 @@ func (e errContactEs) Error() string {
 	return e.message
 }
 
+// ErrProductCheck is returned if the Elasticsearch cluster is not supported.
 type ErrProductCheck struct {
 	message string
 }

--- a/elasticsearch.go
+++ b/elasticsearch.go
@@ -299,7 +299,7 @@ func (c *Client) Perform(req *http.Request) (*http.Response, error) {
 	res, err := c.Transport.Perform(req)
 
 	// ResponseCheck path continues, we run the header check on the first answer from ES.
-	if c.useResponseCheckOnly {
+	if err == nil {
 		checkHeader := func() error {
 			if res != nil {
 				return genuineCheckHeader(res.Header)

--- a/elasticsearch_internal_test.go
+++ b/elasticsearch_internal_test.go
@@ -646,7 +646,7 @@ func TestResponseCheckOnly(t *testing.T) {
 				StatusCode: http.StatusInternalServerError,
 			},
 			requestErr:           nil,
-			wantErr:              true,
+			wantErr:              false,
 		},
 		{
 			name:                 "Valid request, 404 response",
@@ -655,7 +655,7 @@ func TestResponseCheckOnly(t *testing.T) {
 				StatusCode: http.StatusNotFound,
 			},
 			requestErr:           nil,
-			wantErr:              true,
+			wantErr:              false,
 		},
 	}
 	for _, tt := range tests {
@@ -690,16 +690,57 @@ func TestProductCheckError(t *testing.T) {
 	defer server.Close()
 
 	c, _ := NewClient(Config{Addresses: []string{server.URL}, DisableRetry: true})
-	if _, err := c.Cat.Indices(); err == nil {
-		t.Fatal("expected error")
+	if _, err := c.Cat.Indices(); err != nil {
+		t.Fatal("first unexpected error")
 	}
 	if _, err := c.Cat.Indices(); err != nil {
-		t.Fatalf("unexpected error: %s", err)
+		t.Fatalf("second unexpected error: %s", err)
 	}
-	if n := len(requestPaths); n != 3 {
+	if n := len(requestPaths); n != 4 {
 		t.Fatalf("expected 3 requests, got %d", n)
 	}
-	if !reflect.DeepEqual(requestPaths, []string{"/", "/", "/_cat/indices"}) {
+	if !reflect.DeepEqual(requestPaths, []string{"/", "/_cat/indices", "/", "/_cat/indices"}) {
 		t.Fatalf("unexpected request paths: %s", requestPaths)
+	}
+}
+
+
+func TestProductCheckRetry(t *testing.T) {
+	var requestPaths []string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requestPaths = append(requestPaths, r.URL.Path)
+		if len(requestPaths) < 4 {
+			// Simulate transient error from a proxy on the first request.
+			// This must not be cached by the client.
+			w.WriteHeader(http.StatusBadGateway)
+			return
+		}
+		w.Header().Set("X-Elastic-Product", "Elasticsearch")
+		w.Write([]byte("{}"))
+	}))
+	defer server.Close()
+
+	c, _ := NewClient(Config{Addresses: []string{server.URL}, DisableRetry: true})
+	if _, err := c.Cat.Indices(); err != nil {
+		t.Fatal("first unexpected error")
+	}
+	if _, err := c.Cat.Indices(); err != nil {
+		t.Fatalf("second unexpected error: %s", err)
+	}
+	if c.productCheckSuccess {
+		t.Fatalf("product check should not be valid at this point")
+	}
+	if _, err := c.Cat.Indices(); err != nil {
+		t.Fatalf("third unexpected error: %s", err)
+	}
+	if n := len(requestPaths); n != 6 {
+		t.Fatalf("expected 3 requests, got %d", n)
+	}
+	if !reflect.DeepEqual(requestPaths, []string{"/", "/_cat/indices", "/", "/_cat/indices", "/", "/_cat/indices"}) {
+		t.Fatalf("unexpected request paths: %s", requestPaths)
+	}
+
+	if !c.productCheckSuccess {
+		t.Fatalf("product check should be valid")
 	}
 }

--- a/esapi/esapi_benchmark_test.go
+++ b/esapi/esapi_benchmark_test.go
@@ -38,7 +38,13 @@ var (
 		Body: ioutil.NopCloser(strings.NewReader("MOCK")),
 	}
 	defaultRoundTripFn = func(*http.Request) (*http.Response, error) { return defaultResponse, nil }
-	errorRoundTripFn   = func(*http.Request) (*http.Response, error) {
+	errorRoundTripFn   = func(request *http.Request) (*http.Response, error) {
+		if request.URL.Path == "/" {
+			return &http.Response{
+				StatusCode: 200,
+				Header: http.Header{"X-Elastic-Product": []string{"Elasticsearch"}},
+			}, nil
+		}
 		return &http.Response{
 			Header: http.Header{"X-Elastic-Product": []string{"Elasticsearch"}},
 			StatusCode: 400,


### PR DESCRIPTION
This ensures the product check is not flagged wrongfully as successful if the answer has not been properly validated.
The client will retry product check until success or error. 