### PR TITLE
Generator: Add integer url parameters handling

### DIFF
--- a/internal/build/cmd/generate/commands/gensource/generator.go
+++ b/internal/build/cmd/generate/commands/gensource/generator.go
@@ -622,6 +622,9 @@ func (r ` + g.Endpoint.MethodWithNamespace() + `Request) Do(ctx context.Context,
 						pathGrow.WriteString(`1 + `)
 						pathContent.WriteString(`	path.WriteString("/")` + "\n")
 						switch a.Type {
+						case "int":
+							pathGrow.WriteString(`len(strconv.Itoa(*r.` + p + `)) + `)
+							pathContent.WriteString(`	path.WriteString(strconv.Itoa(*r.` + p + `))` + "\n")
 						case "string":
 							pathGrow.WriteString(`len(r.` + p + `) + `)
 							pathContent.WriteString(`	path.WriteString(r.` + p + `)` + "\n")


### PR DESCRIPTION
This allows the integer parameters found in `search_mvt` to be handled correctly.