### PR TITLE
Allow to overwrite User-Agent http request header

### DIFF
--- a/estransport/estransport.go
+++ b/estransport/estransport.go
@@ -45,6 +45,8 @@ const (
 
 	// esCompatHeader defines the env var for Compatibility header.
 	esCompatHeader = "ELASTIC_CLIENT_APIVERSIONING"
+
+	userAgentHeader = "User-Agent"
 )
 
 var (
@@ -474,7 +476,14 @@ func (c *Client) setReqAuth(u *url.URL, req *http.Request) *http.Request {
 }
 
 func (c *Client) setReqUserAgent(req *http.Request) *http.Request {
-	req.Header.Set("User-Agent", userAgent)
+	if len(c.header) > 0 {
+		ua := c.header.Get(userAgentHeader)
+		if ua != "" {
+			req.Header.Set(userAgentHeader, ua)
+			return req
+		}
+	}
+	req.Header.Set(userAgentHeader, userAgent)
 	return req
 }
 

--- a/estransport/estransport_internal_test.go
+++ b/estransport/estransport_internal_test.go
@@ -398,6 +398,21 @@ func TestTransportPerform(t *testing.T) {
 		}
 	})
 
+	t.Run("Overwrites UserAgent", func(t *testing.T) {
+		u, _ := url.Parse("http://example.com")
+
+		tp, _ := New(Config{URLs: []*url.URL{u}, Header: http.Header{
+			userAgentHeader: []string{"Elastic-Fleet-Server/7.11.1 (darwin; amd64; Go 1.16.6)"},
+		}})
+
+		req, _ := http.NewRequest("GET", "/abc", nil)
+		tp.setReqUserAgent(req)
+
+		if !strings.HasPrefix(req.UserAgent(), "Elastic-Fleet-Server") {
+			t.Errorf("Unexpected user agent: %s", req.UserAgent())
+		}
+	})
+
 	t.Run("Sets global HTTP request headers", func(t *testing.T) {
 		hdr := http.Header{}
 		hdr.Set("X-Foo", "bar")


### PR DESCRIPTION
Allow to overwrite User-Agent http request header

- Related to: https://github.com/elastic/fleet-server/issues/636