### PR TITLE
should compare  the value of the key in header

### DIFF
--- a/estransport/estransport.go
+++ b/estransport/estransport.go
@@ -490,7 +490,7 @@ func (c *Client) setReqUserAgent(req *http.Request) *http.Request {
 func (c *Client) setReqGlobalHeader(req *http.Request) *http.Request {
 	if len(c.header) > 0 {
 		for k, v := range c.header {
-			if req.Header.Get(k) != k {
+			if req.Header.Get(k) != v {
 				for _, vv := range v {
 					req.Header.Add(k, vv)
 				}


### PR DESCRIPTION
It must be a typo I guess.
`for k, v := range c.header {
			if req.Header.Get(k) != k {
				for _, vv := range v {
					req.Header.Add(k, vv)
				}
			}
		}
`
the header value is obviously not equal the key