### PR TITLE
Client: Implement certificate pinning

### DIFF
--- a/elasticsearch.go
+++ b/elasticsearch.go
@@ -51,10 +51,10 @@ type Config struct {
 	Username  string   // Username for HTTP Basic Authentication.
 	Password  string   // Password for HTTP Basic Authentication.
 
-	CloudID      string // Endpoint for the Elastic Service (https://elastic.co/cloud).
-	APIKey       string // Base64-encoded token for authorization; if set, overrides username/password and service token.
-	ServiceToken string // Service token for authorization; if set, overrides username/password.
-	Fingerprint  string // sha256 hex Fingerprint given by Elasticsearch on first launch.
+	CloudID                string // Endpoint for the Elastic Service (https://elastic.co/cloud).
+	APIKey                 string // Base64-encoded token for authorization; if set, overrides username/password and service token.
+	ServiceToken           string // Service token for authorization; if set, overrides username/password.
+	CertificateFingerprint string // SHA256 hex fingerprint given by Elasticsearch on first launch.
 
 	Header http.Header // Global HTTP request header.
 
@@ -162,12 +162,12 @@ func NewClient(cfg Config) (*Client, error) {
 	}
 
 	tp, err := estransport.New(estransport.Config{
-		URLs:         urls,
-		Username:     cfg.Username,
-		Password:     cfg.Password,
-		APIKey:       cfg.APIKey,
-		ServiceToken: cfg.ServiceToken,
-		Fingerprint:  cfg.Fingerprint,
+		URLs:                   urls,
+		Username:               cfg.Username,
+		Password:               cfg.Password,
+		APIKey:                 cfg.APIKey,
+		ServiceToken:           cfg.ServiceToken,
+		CertificateFingerprint: cfg.CertificateFingerprint,
 
 		Header: cfg.Header,
 		CACert: cfg.CACert,

--- a/elasticsearch_internal_test.go
+++ b/elasticsearch_internal_test.go
@@ -495,7 +495,7 @@ func TestFingerprint(t *testing.T) {
 
 	// We add the fingerprint corresponding ton testcert.LocalhostCert
 	//
-	config.Fingerprint = "448F628A8A65AA18560E53A80C53ACB38C51B427DF0334082349141147DC9BF6"
+	config.CertificateFingerprint = "448F628A8A65AA18560E53A80C53ACB38C51B427DF0334082349141147DC9BF6"
 	client, _ = NewClient(config)
 	res, err = client.Info()
 	if err != nil {

--- a/estransport/estransport.go
+++ b/estransport/estransport.go
@@ -109,7 +109,7 @@ type Config struct {
 
 	ConnectionPoolFunc func([]*Connection, Selector) ConnectionPool
 
-	Fingerprint string
+	CertificateFingerprint string
 }
 
 // Client represents the HTTP client.
@@ -155,9 +155,9 @@ func New(cfg Config) (*Client, error) {
 	}
 
 	if transport, ok := cfg.Transport.(*http.Transport); ok {
-		if cfg.Fingerprint != "" {
+		if cfg.CertificateFingerprint != "" {
 			transport.DialTLS = func(network, addr string) (net.Conn, error) {
-				fingerprint, _ := hex.DecodeString(cfg.Fingerprint)
+				fingerprint, _ := hex.DecodeString(cfg.CertificateFingerprint)
 
 				c, err := tls.Dial(network, addr, &tls.Config{InsecureSkipVerify: true})
 				if err != nil {
@@ -175,7 +175,7 @@ func New(cfg Config) (*Client, error) {
 						return c, nil
 					}
 				}
-				return nil, fmt.Errorf("fingerprint mismatch, provided: %s", cfg.Fingerprint)
+				return nil, fmt.Errorf("fingerprint mismatch, provided: %s", cfg.CertificateFingerprint)
 			}
 		}
 	}


### PR DESCRIPTION
At first launch the Elasticsearch server will generate a certificate and provide in its logs the fingerprint.
This allows the client to verify the match of at least one certificate with the provided fingerprint upon TLS handshake.