### PR TITLE
[Transport]Update transport with resilient retry

### DIFF
--- a/_benchmarks/benchmarks/cmd/main.go
+++ b/_benchmarks/benchmarks/cmd/main.go
@@ -31,8 +31,8 @@ import (
 	"github.com/fatih/color"
 	"github.com/montanaflynn/stats"
 
-	"github.com/elastic/go-elasticsearch/v8"
 	"github.com/elastic/elastic-transport-go/v8/elastictransport"
+	"github.com/elastic/go-elasticsearch/v8"
 
 	"github.com/elastic/go-elasticsearch/v8/benchmarks"
 	"github.com/elastic/go-elasticsearch/v8/benchmarks/runner"
@@ -76,7 +76,7 @@ func main() {
 	log.Printf(boldUnderline("Running benchmarks for go-elasticsearch@%s; %s/go%s"), elasticsearch.Version, runner.RuntimeOS, runner.RuntimeVersion)
 
 	var missingConfigs []string
-	for k, _ := range benchmarks.Config {
+	for k := range benchmarks.Config {
 		v := os.Getenv(k)
 		if v == "" {
 			missingConfigs = append(missingConfigs, k)
@@ -120,9 +120,8 @@ func main() {
 	}
 
 	reportClientConfig := elasticsearch.Config{
-		Addresses:            []string{benchmarks.Config["ELASTICSEARCH_REPORT_URL"]},
-		MaxRetries:           10,
-		EnableRetryOnTimeout: true,
+		Addresses:  []string{benchmarks.Config["ELASTICSEARCH_REPORT_URL"]},
+		MaxRetries: 10,
 	}
 	if os.Getenv("DEBUG") != "" {
 		runnerClientConfig.Logger = &elastictransport.ColorLogger{Output: os.Stdout}

--- a/_benchmarks/benchmarks/go.mod
+++ b/_benchmarks/benchmarks/go.mod
@@ -5,6 +5,7 @@ go 1.14
 replace github.com/elastic/go-elasticsearch/v8 => ../../
 
 require (
+	github.com/elastic/elastic-transport-go/v8 v8.0.0-20211216131617-bbee439d559c
 	github.com/elastic/go-elasticsearch/v8 v8.0.0-20200408073057-6f36a473b19f
 	github.com/fatih/color v1.7.0
 	github.com/mattn/go-colorable v0.1.6 // indirect

--- a/elasticsearch.go
+++ b/elasticsearch.go
@@ -74,10 +74,10 @@ type Config struct {
 	// The option is only valid when the transport is not specified, or when it's http.Transport.
 	CACert []byte
 
-	RetryOnStatus        []int // List of status codes for retry. Default: 502, 503, 504.
-	DisableRetry         bool  // Default: false.
-	EnableRetryOnTimeout bool  // Default: false.
-	MaxRetries           int   // Default: 3.
+	RetryOnStatus []int                           // List of status codes for retry. Default: 502, 503, 504.
+	DisableRetry  bool                            // Default: false.
+	MaxRetries    int                             // Default: 3.
+	RetryOnError  func(*http.Request, error) bool // Optional function allowing to indicate which error should be retried. Default: nil.
 
 	CompressRequestBody bool // Default: false.
 
@@ -188,11 +188,11 @@ func NewClient(cfg Config) (*Client, error) {
 		Header: cfg.Header,
 		CACert: cfg.CACert,
 
-		RetryOnStatus:        cfg.RetryOnStatus,
-		DisableRetry:         cfg.DisableRetry,
-		EnableRetryOnTimeout: cfg.EnableRetryOnTimeout,
-		MaxRetries:           cfg.MaxRetries,
-		RetryBackoff:         cfg.RetryBackoff,
+		RetryOnStatus: cfg.RetryOnStatus,
+		DisableRetry:  cfg.DisableRetry,
+		RetryOnError:  cfg.RetryOnError,
+		MaxRetries:    cfg.MaxRetries,
+		RetryBackoff:  cfg.RetryBackoff,
 
 		CompressRequestBody: cfg.CompressRequestBody,
 

--- a/go.mod
+++ b/go.mod
@@ -2,4 +2,4 @@ module github.com/elastic/go-elasticsearch/v8
 
 go 1.13
 
-require github.com/elastic/elastic-transport-go/v8 v8.0.0-20211202110751-50105067ef27
+require github.com/elastic/elastic-transport-go/v8 v8.0.0-20211216131617-bbee439d559c

--- a/go.sum
+++ b/go.sum
@@ -1,2 +1,2 @@
-github.com/elastic/elastic-transport-go/v8 v8.0.0-20211202110751-50105067ef27 h1:O58SwZ7pdt7Lzy8JqpJubJlgDbr9jVV7ro4HFPvaZDw=
-github.com/elastic/elastic-transport-go/v8 v8.0.0-20211202110751-50105067ef27/go.mod h1:87Tcz8IVNe6rVSLdBux1o/PEItLtyabHU3naC7IoqKI=
+github.com/elastic/elastic-transport-go/v8 v8.0.0-20211216131617-bbee439d559c h1:onA2RpIyeCPvYAj1LFYiiMTrSpqVINWMfYFRS7lofJs=
+github.com/elastic/elastic-transport-go/v8 v8.0.0-20211216131617-bbee439d559c/go.mod h1:87Tcz8IVNe6rVSLdBux1o/PEItLtyabHU3naC7IoqKI=


### PR DESCRIPTION
This pull request integrates the latest version of the `elastic-transport-go` package.
It introduces a new callback `RetryOnError` which allows the user to decide which errors should be retried and replaces the old `RetryOnTimeout`.
For context this function gets the `*http.Request` as well as the matching `error`.