### PR TITLE
Fix "concurrent map iteration and map write" while read estransport.M…

### DIFF
--- a/estransport/metrics.go
+++ b/estransport/metrics.go
@@ -92,7 +92,11 @@ func (c *Client) Metrics() (Metrics, error) {
 	m := Metrics{
 		Requests:  c.metrics.requests,
 		Failures:  c.metrics.failures,
-		Responses: c.metrics.responses,
+		Responses: make(map[int]int, len(c.metrics.responses)),
+	}
+
+	for code, num := range c.metrics.responses {
+		m.Responses[code] = num
 	}
 
 	if pool, ok := c.pool.(connectionable); ok {


### PR DESCRIPTION
"fatal error: concurrent map iteration and map write" while other goroutine reads estransport.Metrics.Responses


```
func TestTransportPerformAndReadMetricsResponses(t *testing.T) {
	t.Run("Executes", func(t *testing.T) {
		u, _ := url.Parse("https://foo.com/bar")
		tp, _ := New(Config{
			EnableMetrics: true,
			URLs:          []*url.URL{u},
			Transport: &mockTransp{
				RoundTripFunc: func(req *http.Request) (*http.Response, error) { return &http.Response{Status: "MOCK"}, nil },
			}})

		go func() {
			for {
				metrics, _ := tp.Metrics()
				t.Logf("len(responses): %v", len(metrics.Responses))
				for code, num := range metrics.Responses {
					t.Logf("%v(%v)", code, num)
				}
			}
		}()

		for i := 0; i < 100000; i++ {
			req, _ := http.NewRequest("GET", "/abc", nil)
			res, err := tp.Perform(req)
			if err != nil {
				t.Fatalf("Unexpected error: %s", err)
			}

			if res.Status != "MOCK" {
				t.Errorf("Unexpected response: %+v", res)
			}
		}
	})
}
```