### PR TITLE
[Generator] Required arguments pointers shouldn't be nil

### DIFF
--- a/internal/build/cmd/generate/commands/gensource/generator.go
+++ b/internal/build/cmd/generate/commands/gensource/generator.go
@@ -569,8 +569,9 @@ func (r ` + g.Endpoint.MethodWithNamespace() + `Request) Do(ctx context.Context,
 		g.w(f(g.Endpoint))
 	} else {
 		var (
-			pathGrow    strings.Builder
-			pathContent strings.Builder
+			requiredArgsValidation strings.Builder
+			pathGrow               strings.Builder
+			pathContent            strings.Builder
 		)
 
 		pathGrow.WriteString(`	path.Grow(`)
@@ -623,15 +624,18 @@ func (r ` + g.Endpoint.MethodWithNamespace() + `Request) Do(ctx context.Context,
 						pathContent.WriteString(`	path.WriteString("/")` + "\n")
 						switch a.Type {
 						case "int":
+							requiredArgsValidation.WriteString(`if r.` + p + ` == nil { return nil, errors.New("` + a.Name + ` is required and cannot be nil") }` + "\n")
 							pathGrow.WriteString(`len(strconv.Itoa(*r.` + p + `)) + `)
 							pathContent.WriteString(`	path.WriteString(strconv.Itoa(*r.` + p + `))` + "\n")
 						case "string":
 							pathGrow.WriteString(`len(r.` + p + `) + `)
 							pathContent.WriteString(`	path.WriteString(r.` + p + `)` + "\n")
 						case "list":
+							requiredArgsValidation.WriteString(`if len(r.` + p + `) == 0 { return nil, errors.New("` + a.Name + ` is required and cannot be nil or empty") }` + "\n")
 							pathGrow.WriteString(`len(strings.Join(r.` + p + `, ",")) + `)
 							pathContent.WriteString(`	path.WriteString(strings.Join(r.` + p + `, ","))` + "\n")
 						case "long":
+							requiredArgsValidation.WriteString(`if r.` + p + ` == nil { return nil, errors.New("` + a.Name + ` is required and cannot be nil") }` + "\n")
 							pathGrow.WriteString(`len(strconv.Itoa(*r.` + p + `)) + `)
 							pathContent.WriteString(`	path.WriteString(strconv.Itoa(*r.` + p + `))` + "\n")
 						default:
@@ -710,6 +714,7 @@ func (r ` + g.Endpoint.MethodWithNamespace() + `Request) Do(ctx context.Context,
 
 		// Write out the content
 		pathGrow.WriteString(`)`)
+		g.w(requiredArgsValidation.String() + "\n")
 		g.w(strings.Replace(pathGrow.String(), " + )", ")", 1) + "\n")
 		g.w(pathContent.String() + "\n")
 	}

--- a/internal/build/cmd/generate/commands/gentests/skips.go
+++ b/internal/build/cmd/generate/commands/gentests/skips.go
@@ -136,6 +136,13 @@ cat.aliases/10_basic.yml:
   - "Column headers (pre 7.4.0)"
   - "Alias against closed index (pre 7.4.0)"
 
+# Checks for nil required arguments makes this test incompatible with the integration tests
+indices.delete_alias/all_path_options.yml:
+  - check delete with blank index and blank alias
+indices.put_alias/all_path_options.yml:
+  - put alias with blank index
+  - put alias with missing name
+
 indices.put_mapping/10_basic.yml:
   - "Put mappings with explicit _doc type bwc"
 


### PR DESCRIPTION
This PR addresses the fact that required arguments that can be pointers shouldn't be passed as nil.
It aligns with the behavior of other clients and partly addresses #201