### PR TITLE
Compatibility header should not set content-type when body is nil

### DIFF
--- a/elasticsearch.go
+++ b/elasticsearch.go
@@ -48,6 +48,8 @@ const (
 	// HeaderClientMeta Key for the HTTP Header related to telemetry data sent with
 	// each request to Elasticsearch.
 	HeaderClientMeta = "x-elastic-client-meta"
+
+	CompatibilityHeader = "application/vnd.elasticsearch+json;compatible-with=8"
 )
 
 var (
@@ -240,8 +242,10 @@ func NewClient(cfg Config) (*Client, error) {
 func (c *Client) Perform(req *http.Request) (*http.Response, error) {
 	// Compatibility Header
 	if c.compatibilityHeader {
-		req.Header.Set("Content-Type", "application/vnd.elasticsearch+json;compatible-with=8")
-		req.Header.Set("Accept", "application/vnd.elasticsearch+json;compatible-with=8")
+		if req.Body != nil {
+			req.Header.Set("Content-Type", CompatibilityHeader)
+		}
+		req.Header.Set("Accept", CompatibilityHeader)
 	}
 
 	if !c.disableMetaHeader {

--- a/elasticsearch.go
+++ b/elasticsearch.go
@@ -49,7 +49,7 @@ const (
 	// each request to Elasticsearch.
 	HeaderClientMeta = "x-elastic-client-meta"
 
-	CompatibilityHeader = "application/vnd.elasticsearch+json;compatible-with=8"
+	compatibilityHeader = "application/vnd.elasticsearch+json;compatible-with=8"
 )
 
 var (
@@ -243,9 +243,9 @@ func (c *Client) Perform(req *http.Request) (*http.Response, error) {
 	// Compatibility Header
 	if c.compatibilityHeader {
 		if req.Body != nil {
-			req.Header.Set("Content-Type", CompatibilityHeader)
+			req.Header.Set("Content-Type", compatibilityHeader)
 		}
-		req.Header.Set("Accept", CompatibilityHeader)
+		req.Header.Set("Accept", compatibilityHeader)
 	}
 
 	if !c.disableMetaHeader {

--- a/elasticsearch_internal_test.go
+++ b/elasticsearch_internal_test.go
@@ -630,6 +630,10 @@ func TestCompatibilityHeader(t *testing.T) {
 								if !reflect.DeepEqual(req.Header["Content-Type"], test.expectsHeader) {
 									t.Errorf("Compatibility header with Body enabled, not in request headers, got: %s, want: %s", req.Header["Content-Type"], test.expectsHeader)
 								}
+							} else {
+								if reflect.DeepEqual(req.Header["Content-Type"], test.expectsHeader) {
+									t.Errorf("Compatibility header if Content-Type shouldn't be set with an empty body")
+								}
 							}
 						}
 


### PR DESCRIPTION
This right the wrongs and adds a test case to reflect this and prevent mistakes in the future.