### PR TITLE
Add basic scheme to url building path to prevent mishaps in parsing

### DIFF
--- a/esapi/esapi_request_internal_test.go
+++ b/esapi/esapi_request_internal_test.go
@@ -15,6 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
+//go:build !integration
 // +build !integration
 
 package esapi
@@ -73,6 +74,17 @@ func TestAPIRequest(t *testing.T) {
 		}
 		if _, ok := req.Body.(io.ReadCloser); !ok {
 			t.Errorf("Unexpected type for req.Body: %T", req.Body)
+		}
+
+		req, err = newRequest("GET", "http:////_aliases/test", nil)
+		if err != nil {
+			t.Fatalf("Unexpected error: %s", err)
+		}
+		if req.URL.String() != "http:////_aliases/test" {
+			t.Errorf("Unexpected url for request: %s", req.URL.String())
+		}
+		if req.URL.Host != "" {
+			t.Errorf("Unexpected host, should be empty, got: %s", req.URL.Host)
 		}
 	})
 }

--- a/internal/build/cmd/generate/commands/gensource/generator.go
+++ b/internal/build/cmd/generate/commands/gensource/generator.go
@@ -576,6 +576,12 @@ func (r ` + g.Endpoint.MethodWithNamespace() + `Request) Do(ctx context.Context,
 
 		pathGrow.WriteString(`	path.Grow(`)
 
+		// Adds a scheme to the initial empty request.
+		// This allows the http.NewRequest to build a proper url
+		// even if some arguments are missing.
+		pathGrow.WriteString(`7 + `)
+		pathContent.WriteString(`path.WriteString("http://")` + "\n")
+
 		// FIXME: Select longest path based on number of template entries, not string length
 		longestPath := g.Endpoint.URL.Paths[0]
 		for _, p := range g.Endpoint.URL.Paths {
@@ -806,6 +812,7 @@ func (r ` + g.Endpoint.MethodWithNamespace() + `Request) Do(ctx context.Context,
 	}
 
 	g.w(`req, err := newRequest(method, path.String(), ` + httpBody + `)` + "\n")
+
 	g.w(`if err != nil {
 		return nil, err
 	}` + "\n\n")


### PR DESCRIPTION
This PR fixes #201 by adding a scheme to build a viable url.
It prevents the `url.Parse` to trip up during the `http.NewRequest` call.

The then created `req.Scheme` and `req.Host` will be overridden by the `elastictransport.Do` via the `setReqUrl` method upon request execution.