### PR TITLE
go bump to 1.17, add docker-compose

### DIFF
--- a/_examples/xkcdsearch/Dockerfile
+++ b/_examples/xkcdsearch/Dockerfile
@@ -3,7 +3,7 @@
 #
 # $ docker run -it --network elasticsearch --name xkcdsearch-demo --publish 8000:8000 --rm elastic/go-elasticsearch-demo-xkcdsearch
 #
-FROM golang:1.11-alpine AS Builder
+FROM golang:1.17-alpine AS Builder
 
 WORKDIR /go-elasticsearch-demo-xkcdsearch
 COPY . .

--- a/_examples/xkcdsearch/docker-compose.yaml
+++ b/_examples/xkcdsearch/docker-compose.yaml
@@ -1,0 +1,15 @@
+version: '3.5'
+services:
+  search_api:
+    container_name: 'xkcd-search'
+    build: .
+    restart: 'on-failure'
+    ports:
+      - '8000:8000'
+    depends_on:
+      - elasticsearch
+  elasticsearch:
+    container_name: 'es01'
+    image: 'bitnami/elasticsearch:7'
+    ports:
+      - '9200:9200'

--- a/_examples/xkcdsearch/go.mod
+++ b/_examples/xkcdsearch/go.mod
@@ -1,16 +1,19 @@
 module github.com/elastic/go-elasticsearch/v8/_examples/xkcdsearch
 
-go 1.11
+go 1.17
 
 replace github.com/elastic/go-elasticsearch/v8 => ../..
 
 require (
-	github.com/elastic/elastic-transport-go/v8 v8.0.0-20211202110751-50105067ef27 // indirect
 	github.com/elastic/go-elasticsearch/v8 v8.0.0-20210817150010-57d659deaca7
-	github.com/inconshreveable/mousetrap v1.0.0 // indirect
 	github.com/rs/zerolog v1.11.0
 	github.com/spf13/cobra v0.0.3
-	github.com/spf13/pflag v1.0.3 // indirect
 	golang.org/x/crypto v0.0.0-20181127143415-eb0de9b17e85
+)
+
+require (
+	github.com/elastic/elastic-transport-go/v8 v8.0.0-20211216131617-bbee439d559c // indirect
+	github.com/inconshreveable/mousetrap v1.0.0 // indirect
+	github.com/spf13/pflag v1.0.3 // indirect
 	golang.org/x/sys v0.0.0-20181128092732-4ed8d59d0b35 // indirect
 )

--- a/_examples/xkcdsearch/go.sum
+++ b/_examples/xkcdsearch/go.sum
@@ -1,5 +1,7 @@
 github.com/elastic/elastic-transport-go/v8 v8.0.0-20211202110751-50105067ef27 h1:O58SwZ7pdt7Lzy8JqpJubJlgDbr9jVV7ro4HFPvaZDw=
 github.com/elastic/elastic-transport-go/v8 v8.0.0-20211202110751-50105067ef27/go.mod h1:87Tcz8IVNe6rVSLdBux1o/PEItLtyabHU3naC7IoqKI=
+github.com/elastic/elastic-transport-go/v8 v8.0.0-20211216131617-bbee439d559c h1:onA2RpIyeCPvYAj1LFYiiMTrSpqVINWMfYFRS7lofJs=
+github.com/elastic/elastic-transport-go/v8 v8.0.0-20211216131617-bbee439d559c/go.mod h1:87Tcz8IVNe6rVSLdBux1o/PEItLtyabHU3naC7IoqKI=
 github.com/inconshreveable/mousetrap v1.0.0 h1:Z8tu5sraLXCXIcARxBp/8cbvlwVa7Z1NHg9XEKhtSvM=
 github.com/inconshreveable/mousetrap v1.0.0/go.mod h1:PxqpIevigyE2G7u3NXJIT2ANytuPF1OarO4DADm73n8=
 github.com/rs/zerolog v1.11.0 h1:DRuq/S+4k52uJzBQciUcofXx45GrMC6yrEbb/CoK6+M=


### PR DESCRIPTION
Thanks for the wonderful example on xkcd search. I have made the following two changes to keep it up-to-date and easy for beginners
1. Bumped go version to 1.17
2. Added docker-compose which includes elastic server setup

