### PR TITLE
Reformat existing Go code

### DIFF
--- a/_examples/cloudfunction/function_test.go
+++ b/_examples/cloudfunction/function_test.go
@@ -36,7 +36,7 @@ type MockTransport struct{}
 // RoundTrip returns a mock response.
 func (t *MockTransport) RoundTrip(req *http.Request) (*http.Response, error) {
 	return &http.Response{
-		Body: ioutil.NopCloser(strings.NewReader(`{"status":"mocked"}`)),
+		Body:   ioutil.NopCloser(strings.NewReader(`{"status":"mocked"}`)),
 		Header: http.Header{"X-Elastic-Product": []string{"Elasticsearch"}},
 	}, nil
 }

--- a/_examples/extension/main.go
+++ b/_examples/extension/main.go
@@ -15,6 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
+//go:build ignore
 // +build ignore
 
 // This examples demonstrates how extend the API of the client by embedding it inside a custom type.
@@ -30,9 +31,9 @@ import (
 	"net/url"
 	"os"
 
+	"github.com/elastic/elastic-transport-go/v8/elastictransport"
 	"github.com/elastic/go-elasticsearch/v8"
 	"github.com/elastic/go-elasticsearch/v8/esapi"
-	"github.com/elastic/elastic-transport-go/v8/elastictransport"
 )
 
 const port = "9209"

--- a/_examples/instrumentation/expvar.go
+++ b/_examples/instrumentation/expvar.go
@@ -36,8 +36,8 @@ import (
 
 	"golang.org/x/crypto/ssh/terminal"
 
-	"github.com/elastic/go-elasticsearch/v8"
 	"github.com/elastic/elastic-transport-go/v8/elastictransport"
+	"github.com/elastic/go-elasticsearch/v8"
 )
 
 var (

--- a/_examples/logging/custom.go
+++ b/_examples/logging/custom.go
@@ -15,6 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
+//go:build ignore
 // +build ignore
 
 // This examples demonstrates how to implement the "elastictransport.Logger" interface with a custom type,

--- a/_examples/logging/default.go
+++ b/_examples/logging/default.go
@@ -15,6 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
+//go:build ignore
 // +build ignore
 
 // This collection of examples demonstrates how to configure the default logger of the client.
@@ -31,8 +32,8 @@ import (
 	"os"
 	"strings"
 
-	"github.com/elastic/go-elasticsearch/v8"
 	"github.com/elastic/elastic-transport-go/v8/elastictransport"
+	"github.com/elastic/go-elasticsearch/v8"
 )
 
 func main() {

--- a/_examples/security/tls_configure_ca.go
+++ b/_examples/security/tls_configure_ca.go
@@ -15,6 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
+//go:build ignore
 // +build ignore
 
 package main

--- a/_examples/security/tls_with_ca.go
+++ b/_examples/security/tls_with_ca.go
@@ -15,6 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
+//go:build ignore
 // +build ignore
 
 package main

--- a/_examples/xkcdsearch/store_test.go
+++ b/_examples/xkcdsearch/store_test.go
@@ -81,7 +81,7 @@ func TestStore(t *testing.T) {
 		Response: &http.Response{
 			StatusCode: http.StatusOK,
 			Body:       ioutil.NopCloser(strings.NewReader(`{}`)),
-			Header: http.Header{"X-Elastic-Product": []string{"Elasticsearch"}},
+			Header:     http.Header{"X-Elastic-Product": []string{"Elasticsearch"}},
 		},
 	}
 	mocktrans.RoundTripFn = func(req *http.Request) (*http.Response, error) { return mocktrans.Response, nil }

--- a/elasticsearch_benchmark_test.go
+++ b/elasticsearch_benchmark_test.go
@@ -15,6 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
+//go:build !integration
 // +build !integration
 
 package elasticsearch_test

--- a/elasticsearch_example_test.go
+++ b/elasticsearch_example_test.go
@@ -15,6 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
+//go:build !integration
 // +build !integration
 
 package elasticsearch_test

--- a/elasticsearch_integration_test.go
+++ b/elasticsearch_integration_test.go
@@ -15,6 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
+//go:build integration && !multinode
 // +build integration,!multinode
 
 package elasticsearch_test
@@ -33,9 +34,9 @@ import (
 	"testing"
 	"time"
 
+	"github.com/elastic/elastic-transport-go/v8/elastictransport"
 	"github.com/elastic/go-elasticsearch/v8"
 	"github.com/elastic/go-elasticsearch/v8/esapi"
-	"github.com/elastic/elastic-transport-go/v8/elastictransport"
 )
 
 func TestClientTransport(t *testing.T) {

--- a/esapi/esapi_benchmark_test.go
+++ b/esapi/esapi_benchmark_test.go
@@ -32,10 +32,10 @@ import (
 // TODO(karmi): Refactor into a shared mock/testing package
 
 var (
-	defaultResponse    = &http.Response{
+	defaultResponse = &http.Response{
 		StatusCode: 200,
-		Body: ioutil.NopCloser(strings.NewReader("MOCK")),
-		Header: http.Header{"X-Elastic-Product": []string{"Elasticsearch"}},
+		Body:       ioutil.NopCloser(strings.NewReader("MOCK")),
+		Header:     http.Header{"X-Elastic-Product": []string{"Elasticsearch"}},
 	}
 	defaultRoundTripFn = func(*http.Request) (*http.Response, error) { return defaultResponse, nil }
 	errorRoundTripFn   = func(*http.Request) (*http.Response, error) {

--- a/esapi/esapi_integration_test.go
+++ b/esapi/esapi_integration_test.go
@@ -15,6 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
+//go:build integration
 // +build integration
 
 package esapi_test

--- a/esapi/esapi_internal_test.go
+++ b/esapi/esapi_internal_test.go
@@ -15,6 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
+//go:build !integration
 // +build !integration
 
 package esapi

--- a/esapi/esapi_response_internal_test.go
+++ b/esapi/esapi_response_internal_test.go
@@ -15,6 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
+//go:build !integration
 // +build !integration
 
 package esapi

--- a/esutil/bulk_indexer_benchmark_test.go
+++ b/esutil/bulk_indexer_benchmark_test.go
@@ -15,6 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
+//go:build !integration
 // +build !integration
 
 package esutil_test

--- a/esutil/bulk_indexer_example_test.go
+++ b/esutil/bulk_indexer_example_test.go
@@ -15,6 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
+//go:build !integration
 // +build !integration
 
 package esutil_test

--- a/esutil/bulk_indexer_integration_test.go
+++ b/esutil/bulk_indexer_integration_test.go
@@ -30,8 +30,8 @@ import (
 	"testing"
 	"time"
 
-	"github.com/elastic/go-elasticsearch/v8"
 	"github.com/elastic/elastic-transport-go/v8/elastictransport"
+	"github.com/elastic/go-elasticsearch/v8"
 	"github.com/elastic/go-elasticsearch/v8/esutil"
 )
 

--- a/esutil/bulk_indexer_internal_test.go
+++ b/esutil/bulk_indexer_internal_test.go
@@ -15,6 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
+//go:build !integration
 // +build !integration
 
 package esutil
@@ -80,7 +81,7 @@ func TestBulkIndexer(t *testing.T) {
 				}
 				bodyContent, _ := ioutil.ReadFile(testfile)
 				return &http.Response{
-					Body: ioutil.NopCloser(bytes.NewBuffer(bodyContent)),
+					Body:   ioutil.NopCloser(bytes.NewBuffer(bodyContent)),
 					Header: http.Header{"X-Elastic-Product": []string{"Elasticsearch"}},
 				}, nil
 			},
@@ -264,7 +265,7 @@ func TestBulkIndexer(t *testing.T) {
 		es, _ := elasticsearch.NewClient(elasticsearch.Config{Transport: &mockTransport{
 			RoundTripFunc: func(*http.Request) (*http.Response, error) {
 				return &http.Response{
-					Body: ioutil.NopCloser(bytes.NewBuffer(bodyContent)),
+					Body:   ioutil.NopCloser(bytes.NewBuffer(bodyContent)),
 					Header: http.Header{"X-Elastic-Product": []string{"Elasticsearch"}},
 				}, nil
 			},
@@ -434,7 +435,7 @@ func TestBulkIndexer(t *testing.T) {
 					StatusCode: http.StatusOK,
 					Status:     "200 OK",
 					Body:       ioutil.NopCloser(strings.NewReader(`{"items":[{"index": {}}]}`)),
-					Header: http.Header{"X-Elastic-Product": []string{"Elasticsearch"}},
+					Header:     http.Header{"X-Elastic-Product": []string{"Elasticsearch"}},
 				}, nil
 			},
 		}})
@@ -504,7 +505,7 @@ func TestBulkIndexer(t *testing.T) {
 						StatusCode: http.StatusOK,
 						Status:     "200 OK",
 						Body:       ioutil.NopCloser(bytes.NewBuffer(bodyContent)),
-						Header: http.Header{"X-Elastic-Product": []string{"Elasticsearch"}},
+						Header:     http.Header{"X-Elastic-Product": []string{"Elasticsearch"}},
 					}, nil
 				},
 			},
@@ -594,7 +595,7 @@ func TestBulkIndexer(t *testing.T) {
 		}
 	})
 	t.Run("Worker.writeMeta()", func(t *testing.T) {
-		v:=int64(23)
+		v := int64(23)
 		type args struct {
 			item BulkIndexerItem
 		}
@@ -636,9 +637,9 @@ func TestBulkIndexer(t *testing.T) {
 			{
 				"with version and no document",
 				args{BulkIndexerItem{
-					Action:     "index",
-					Index:      "test",
-					Version:    &v,
+					Action:  "index",
+					Index:   "test",
+					Version: &v,
 				}},
 				`{"index":{"_index":"test"}}` + "\n",
 			},
@@ -722,7 +723,7 @@ func TestBulkIndexer(t *testing.T) {
 				args: args{
 					disableMetaHeader: false,
 					header: http.Header{
-						"X-Test-User":                []string{"UserValue"},
+						"X-Test-User":                  []string{"UserValue"},
 						elasticsearch.HeaderClientMeta: []string{"h=shouldntbechanged"},
 					},
 				},

--- a/esutil/json_reader_benchmark_test.go
+++ b/esutil/json_reader_benchmark_test.go
@@ -15,6 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
+//go:build !integration
 // +build !integration
 
 package esutil_test

--- a/esutil/json_reader_integration_test.go
+++ b/esutil/json_reader_integration_test.go
@@ -15,6 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
+//go:build integration
 // +build integration
 
 package esutil_test

--- a/esutil/json_reader_internal_test.go
+++ b/esutil/json_reader_internal_test.go
@@ -15,6 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
+//go:build !integration
 // +build !integration
 
 package esutil

--- a/internal/build/cmd/generate/commands/gensource/model.go
+++ b/internal/build/cmd/generate/commands/gensource/model.go
@@ -396,7 +396,7 @@ func (e *Endpoint) RequiredArguments() []MethodArgument {
 	}
 
 	var keys []string
-	for k := range e.URL.Paths[0].Parts{
+	for k := range e.URL.Paths[0].Parts {
 		keys = append(keys, k)
 	}
 	sort.Strings(keys)

--- a/internal/build/cmd/generate/commands/genstruct/command.go
+++ b/internal/build/cmd/generate/commands/genstruct/command.go
@@ -272,7 +272,7 @@ type API struct {
 				// Some methods are equal to the namespace (like 'rollup.rollup')
 				// and we don't want to have an empty string here.
 				if len(methodName) == 0 {
-				    methodName = strings.Replace(name, n, "", 1)
+					methodName = strings.Replace(name, n, "", 1)
 				}
 				b.WriteString(fmt.Sprintf("\t%s %s\n", methodName, name))
 			}
@@ -309,7 +309,7 @@ func New(t Transport) *API {
 				// Some methods are equal to the namespace (like 'rollup.rollup')
 				// and we don't want to have an empty string here.
 				if len(methodName) == 0 {
-				    methodName = strings.Replace(name, n, "", 1)
+					methodName = strings.Replace(name, n, "", 1)
 				}
 				b.WriteString(fmt.Sprintf("\t\t\t%s: new%sFunc(t),\n", methodName, name))
 			}

--- a/internal/build/cmd/generate/commands/gentests/gen_api_registry.go
+++ b/internal/build/cmd/generate/commands/gentests/gen_api_registry.go
@@ -15,6 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
+//go:build ignore
 // +build ignore
 
 package main

--- a/internal/build/cmd/tools/commands/spec/command.go
+++ b/internal/build/cmd/tools/commands/spec/command.go
@@ -200,7 +200,7 @@ type Build struct {
 }
 
 func NewBuild() Build {
-	t := time.Date(1970, 0,0,0,0,0,0, time.UTC)
+	t := time.Date(1970, 0, 0, 0, 0, 0, 0, time.UTC)
 	startTime := BuildStartTime{Time: &t}
 	return Build{StartTime: startTime}
 }

--- a/internal/build/cmd/tools/commands/spec/command_test.go
+++ b/internal/build/cmd/tools/commands/spec/command_test.go
@@ -24,9 +24,9 @@ import (
 
 func TestBuild_zipfileUrl(t *testing.T) {
 	tests := []struct {
-		name   string
-		json   string
-		want   string
+		name string
+		json string
+		want string
 	}{
 		{
 			name: "Simple test with valid url",


### PR DESCRIPTION
Reformat the project with the standard `gofmt` tool
Add `go:build` tags.