### PR TITLE
support retry in bulk update

### DIFF
--- a/esutil/bulk_indexer.go
+++ b/esutil/bulk_indexer.go
@@ -442,6 +442,13 @@ func (w *worker) writeMeta(item BulkIndexerItem) error {
 		w.buf.Write(w.aux)
 		w.aux = w.aux[:0]
 	}
+	// support update retry_on_conflict
+	if item.RetryOnConflict != nil && item.Action == "update" {
+		w.buf.WriteString(",")
+		w.aux = strconv.AppendInt(w.aux, int64(*item.RetryOnConflict), 10)
+		w.buf.Write(w.aux)
+		w.aux = w.aux[:0]
+	}
 	w.buf.WriteRune('}')
 	w.buf.WriteRune('}')
 	w.buf.WriteRune('\n')


### PR DESCRIPTION
Relate Issue: https://github.com/elastic/go-elasticsearch/issues/461

On bulk update action, support retryonconflict field in 5.x, 6.x, 7.x.