### PR TITLE
[Backport 6.x] Add per item routing for bulk requests

### DIFF
--- a/esutil/bulk_indexer.go
+++ b/esutil/bulk_indexer.go
@@ -427,7 +427,7 @@ func (w *worker) writeMeta(item BulkIndexerItem) error {
 		if item.DocumentID != "" {
 			w.buf.WriteRune(',')
 		}
-		w.buf.WriteString(`"_routing":`)
+		w.buf.WriteString(`"routing":`)
 		w.aux = strconv.AppendQuote(w.aux, item.Routing)
 		w.buf.Write(w.aux)
 		w.aux = w.aux[:0]

--- a/esutil/bulk_indexer.go
+++ b/esutil/bulk_indexer.go
@@ -93,6 +93,9 @@ type BulkIndexerItem struct {
 	Action          string
 	DocumentID      string
 	DocumentType    string
+	Routing         string
+	Version         *int64
+	VersionType     string
 	Body            io.Reader
 	RetryOnConflict *int
 
@@ -405,8 +408,32 @@ func (w *worker) writeMeta(item BulkIndexerItem) error {
 		w.buf.Write(w.aux)
 		w.aux = w.aux[:0]
 	}
-	if item.Index != "" {
+
+	if item.DocumentID != "" && item.Version != nil {
+		w.buf.WriteRune(',')
+		w.buf.WriteString(`"version":`)
+		w.buf.WriteString(strconv.FormatInt(*item.Version, 10))
+	}
+
+	if item.DocumentID != "" && item.VersionType != "" {
+		w.buf.WriteRune(',')
+		w.buf.WriteString(`"version_type":`)
+		w.aux = strconv.AppendQuote(w.aux, item.VersionType)
+		w.buf.Write(w.aux)
+		w.aux = w.aux[:0]
+	}
+
+	if item.Routing != "" {
 		if item.DocumentID != "" {
+			w.buf.WriteRune(',')
+		}
+		w.buf.WriteString(`"_routing":`)
+		w.aux = strconv.AppendQuote(w.aux, item.Routing)
+		w.buf.Write(w.aux)
+		w.aux = w.aux[:0]
+	}
+	if item.Index != "" {
+		if item.DocumentID != "" || item.Routing != "" {
 			w.buf.WriteRune(',')
 		}
 		w.buf.WriteString(`"_index":`)

--- a/esutil/bulk_indexer.go
+++ b/esutil/bulk_indexer.go
@@ -424,7 +424,7 @@ func (w *worker) writeMeta(item BulkIndexerItem) error {
 	}
 
 	if item.Routing != "" {
-		if item.DocumentID != "" {
+		if item.DocumentID != "" || item.DocumentType != "" {
 			w.buf.WriteRune(',')
 		}
 		w.buf.WriteString(`"routing":`)

--- a/esutil/bulk_indexer_integration_test.go
+++ b/esutil/bulk_indexer_integration_test.go
@@ -206,14 +206,16 @@ func TestBulkIndexerIntegration(t *testing.T) {
 		}
 
 		bi, _ := esutil.NewBulkIndexer(esutil.BulkIndexerConfig{
-			Index:  index,
-			Client: es,
+			Index:        index,
+			Client:       es,
+			DocumentType: "_doc",
 		})
 		bulkIndex(bi, 500)
 
 		bi, _ = esutil.NewBulkIndexer(esutil.BulkIndexerConfig{
-			Index:  index,
-			Client: es,
+			Index:        index,
+			Client:       es,
+			DocumentType: "_doc",
 		})
 		bulkIndex(bi, 900)
 	})

--- a/esutil/bulk_indexer_integration_test.go
+++ b/esutil/bulk_indexer_integration_test.go
@@ -2,6 +2,7 @@
 // Elasticsearch B.V. licenses this file to you under the Apache 2.0 License.
 // See the LICENSE file in the project root for more information.
 
+//go:build integration
 // +build integration
 
 package esutil_test
@@ -157,5 +158,63 @@ func TestBulkIndexerIntegration(t *testing.T) {
 		if res.StatusCode != 200 {
 			t.Errorf("Expected indices to exist, but got a [%s] response", res.Status())
 		}
+	})
+	t.Run("External version", func(t *testing.T) {
+		var index string = "test-index-a"
+
+		es, _ := elasticsearch.NewClient(elasticsearch.Config{
+			CompressRequestBody: tt.CompressRequestBodyEnabled,
+			Logger:              &estransport.ColorLogger{Output: os.Stdout},
+		})
+
+		es.Indices.Delete([]string{index}, es.Indices.Delete.WithIgnoreUnavailable(true))
+		es.Indices.Create(index, es.Indices.Create.WithWaitForActiveShards("1"))
+
+		bulkIndex := func(bulkIndexer esutil.BulkIndexer, baseVersion int) {
+			var countTotal int = 500
+			var countSuccessful uint64
+			for i := 0; i < countTotal; i++ {
+				version := int64(baseVersion + i)
+				item := esutil.BulkIndexerItem{
+					Action:      "index",
+					Index:       index,
+					DocumentID:  strconv.Itoa(i),
+					Body:        strings.NewReader(body),
+					Version:     &version,
+					VersionType: "external",
+					OnSuccess: func(ctx context.Context, item esutil.BulkIndexerItem, item2 esutil.BulkIndexerResponseItem) {
+						if version != item2.Version &&
+							version != *item.Version &&
+							item2.Result != "created" {
+							t.Fatalf("version mismatch, expected: %d, got: %d && %d", version, item.Version, item2.Version)
+						}
+						atomic.AddUint64(&countSuccessful, 1)
+					},
+				}
+				err := bulkIndexer.Add(context.Background(), item)
+				if err != nil {
+					t.Fatal(err)
+				}
+			}
+			if err := bulkIndexer.Close(context.Background()); err != nil {
+				t.Fatal(err)
+			}
+
+			if int(countSuccessful) != countTotal {
+				t.Fatalf("Unexpected countSuccessful, expected %d, got: %d", countTotal, countSuccessful)
+			}
+		}
+
+		bi, _ := esutil.NewBulkIndexer(esutil.BulkIndexerConfig{
+			Index:  index,
+			Client: es,
+		})
+		bulkIndex(bi, 500)
+
+		bi, _ = esutil.NewBulkIndexer(esutil.BulkIndexerConfig{
+			Index:  index,
+			Client: es,
+		})
+		bulkIndex(bi, 900)
 	})
 }

--- a/esutil/bulk_indexer_integration_test.go
+++ b/esutil/bulk_indexer_integration_test.go
@@ -181,6 +181,7 @@ func TestBulkIndexerIntegration(t *testing.T) {
 					Body:        strings.NewReader(body),
 					Version:     &version,
 					VersionType: "external",
+					Routing:     `"{required": true}`,
 					OnSuccess: func(ctx context.Context, item esutil.BulkIndexerItem, item2 esutil.BulkIndexerResponseItem) {
 						if version != item2.Version &&
 							version != *item.Version &&

--- a/esutil/bulk_indexer_integration_test.go
+++ b/esutil/bulk_indexer_integration_test.go
@@ -163,8 +163,7 @@ func TestBulkIndexerIntegration(t *testing.T) {
 		var index string = "test-index-a"
 
 		es, _ := elasticsearch.NewClient(elasticsearch.Config{
-			CompressRequestBody: tt.CompressRequestBodyEnabled,
-			Logger:              &estransport.ColorLogger{Output: os.Stdout},
+			Logger: &estransport.ColorLogger{Output: os.Stdout},
 		})
 
 		es.Indices.Delete([]string{index}, es.Indices.Delete.WithIgnoreUnavailable(true))

--- a/esutil/bulk_indexer_internal_test.go
+++ b/esutil/bulk_indexer_internal_test.go
@@ -621,6 +621,17 @@ func TestBulkIndexer(t *testing.T) {
 				}},
 				`{"index":{"_id":"42","version":23,"version_type":"external","_index":"test"}}` + "\n",
 			},
+			{
+				"with doc type and routing",
+				args{BulkIndexerItem{
+					Action:       "index",
+					DocumentID:   "42",
+					DocumentType: "type",
+					Index:        "test",
+					Routing:      "route",
+				}},
+				`{"index":{"_type":"type","_id":"42","routing":"route","_index":"test"}}` + "\n",
+			},
 		}
 		for _, tt := range tests {
 			tt := tt


### PR DESCRIPTION
Cherry-picked backports to ES6 client for item routing for bulk requests.
- https://github.com/elastic/go-elasticsearch/pull/265
- https://github.com/elastic/go-elasticsearch/pull/360
- https://github.com/elastic/go-elasticsearch/pull/426
