### PR TITLE
Add security on by default documentation

### DIFF
--- a/.doc/connecting.asciidoc
+++ b/.doc/connecting.asciidoc
@@ -36,7 +36,7 @@ cfg := elasticsearch.Config{
 }
 es, err := elasticsearch.NewClient(cfg)
 ------------------------------------
-**IMPORTANT**: you need to copy and store the `API key` in a secure place, since you will not be able to view it again in Elastic Cloud.
+IMPORTANT: you need to copy and store the `API key` in a secure place since you will not be able to view it again in Elastic Cloud.
 
 [discrete]
 [[connecting-to-self-managed]]

--- a/.doc/connecting.asciidoc
+++ b/.doc/connecting.asciidoc
@@ -6,15 +6,193 @@ This page contains the information you need to connect and use the Client with
 
 **On this page**
 
-* <<auth-reference, Authentication options>>
+* <<connecting, Connecting>>
+** <<connecting-to-elastic-cloud, Connecting to Elastic Cloud>>
+** <<connecting-to-self-managed, Connecting to a self-managed cluster>>
+** <<verifying-with-ca, Verifying HTTPS with CA certificates>>
+** <<verifying-with-fingerprint, Verifying HTTPS with certificate fingerprint>>
+** <<connecting-without-security, Connecting without security enabled>>
+** <<connecting-multiple-nodes, Connecting to multiple nodes>>
+* <<auth-reference, Authentication>>
+** <<auth-basic, Basic Authentication>>
+** <<auth-token, HTTP Bearer authentication>>
+* <<compatibility-mode, Compatibility mode>>
 * <<client-usage, Using the client>>
+* <<connecting-faas, Using the Client in a Function-as-a-Service Environment>>
+
+[discrete]
+[[connecting]]
+=== Connecting
+
+This section contains code snippets to show you how to connect to various {es}
+providers.
+
+[discrete]
+[[connecting-to-elastic-cloud]]
+==== Connecting to Elastic Cloud
+
+If you are using https://www.elastic.co/cloud[Elastic Cloud], the client offers
+an easy way to connect to it. You must pass the Cloud ID that you can find in
+the cloud console and the corresponding API key.
+
+[source,go]
+------------------------------------
+cfg := elasticsearch.Config{
+        CloudID: "CLOUD_ID",
+        APIKey: "API_KEY"
+}
+es, err := elasticsearch.NewClient(cfg)
+------------------------------------
+**IMPORTANT**: you need to copy and store the `API key` in a secure place, since you will not be able to view it again in Elastic Cloud.
+
+[discrete]
+[[connecting-to-self-managed]]
+==== Connecting to a self-managed cluster
+
+Starting from version 8.0, {es} offers security by default with authentication and TLS enabled.
+
+To connect to the {es} cluster you need to configure the client to use the generated CA certificate. If you’re just getting started with {es} we recommend reading the documentation on configuring and starting {es} to ensure your cluster is running as expected.
+
+When you start Elasticsearch for the first time you’ll see a distinct block like the one below in the output from Elasticsearch (you may have to scroll up if it’s been a while):
+
+```sh
+----------------------------------------------------------------
+-> Elasticsearch security features have been automatically configured!
+-> Authentication is enabled and cluster connections are encrypted.
+->  Password for the elastic user (reset with `bin/elasticsearch-reset-password -u elastic`):
+  lhQpLELkjkrawaBoaz0Q
+->  HTTP CA certificate SHA-256 fingerprint:
+  a52dd93511e8c6045e21f16654b77c9ee0f34aea26d9f40320b531c474676228
+...
+----------------------------------------------------------------
+```
+
+Note down the `elastic` user password and HTTP CA fingerprint for the next sections. In the examples below they will be stored in the variables `ELASTIC_PASSWORD` and `CERT_FINGERPRINT` respectively.
+
+Depending on the circumstances there are two options for verifying the HTTPS connection, either verifying with the CA certificate itself or via the HTTP CA certificate fingerprint.
+
+[discrete]
+[[verifying-with-ca]]
+==== Verifying HTTPS with CA certificates
+
+The generated root CA certificate can be found in the `certs` directory in your {es} config location (`$ES_CONF_PATH/certs/http_ca.crt`). If you're running {es} in Docker there is https://www.elastic.co/guide/en/elasticsearch/reference/current/docker.html[additional documentation for retrieving the CA certificate].
+
+Once you have the `http_ca.crt` file somewhere accessible pass the content of the file to the client via `CACert`:
+
+[source,go]
+------------------------------------
+cert, _ := ioutil.ReadFile("/path/to/http_ca.crt")
+
+cfg := elasticsearch.Config{
+        Addresses: []string{
+            "https://localhost:9200",
+        },
+        Username: "elastic",
+        Password: ELASTIC_PASSWORD
+        CACert:   cert
+}
+es, err := elasticsearch.NewClient(cfg)
+------------------------------------
+
+[discrete]
+[[verifying-with-fingerprint]]
+==== Verifying HTTPS with certificate fingerprint
+
+This method of verifying the HTTPS connection takes advantage of the certificate fingerprint value noted down earlier. Take this SHA256 fingerprint value and pass it to the Go {es} client via `ca_fingerprint`:
+
+[source,go]
+------------------------------------
+cfg := elasticsearch.Config{
+        Addresses: []string{
+            "https://localhost:9200",
+        },
+        Username: "elastic",
+        Password: ELASTIC_PASSWORD
+        CertificateFingerprint: CERT_FINGERPRINT
+}
+es, err := elasticsearch.NewClient(cfg)
+------------------------------------
+
+The certificate fingerprint can be calculated using openssl x509 with the certificate file:
+
+[source,sh]
+----
+openssl x509 -fingerprint -sha256 -noout -in /path/to/http_ca.crt
+----
+
+If you don't have access to the generated CA file from {es} you can use the following script to output the root CA fingerprint of the {es} instance with `openssl s_client`:
+
+[source,sh]
+----
+# Replace the values of 'localhost' and '9200' to the
+# corresponding host and port values for the cluster.
+openssl s_client -connect localhost:9200 -servername localhost -showcerts </dev/null 2>/dev/null \
+  | openssl x509 -fingerprint -sha256 -noout -in /dev/stdin
+----
+
+The output of `openssl x509` will look something like this:
+
+[source,sh]
+----
+SHA256 Fingerprint=A5:2D:D9:35:11:E8:C6:04:5E:21:F1:66:54:B7:7C:9E:E0:F3:4A:EA:26:D9:F4:03:20:B5:31:C4:74:67:62:28
+----
+
+[discrete]
+[[connecting-without-security]]
+==== Connecting without security enabled
+
+WARNING: Running {es} without security enabled is not recommended.
+
+If your cluster is configured with
+https://www.elastic.co/guide/en/elasticsearch/reference/current/security-settings.html[security explicitly disabled]
+then you can connect via HTTP:
+
+[source,go]
+----
+cfg := elasticsearch.Config{
+        Addresses: []string{
+            "http://localhost:9200",
+        },
+}
+es, err := elasticsearch.NewClient(cfg)
+----
+
+[discrete]
+[[connecting-multiple-nodes]]
+==== Connecting to multiple nodes
+
+The Go {es} client supports sending API requests to multiple nodes in the
+cluster. This means that work will be more evenly spread across the cluster
+instead of hammering the same node over and over with requests. To configure the
+client with multiple nodes you can pass a list of URLs, each URL will be used as
+a separate node in the pool.
+
+[source,go]
+----
+cfg := elasticsearch.Config{
+  Addresses: []string{
+    "https://localhost:9200",
+    "https://localhost:9201",
+  },
+  CACert:   caCert,
+  Username: "elastic",
+  Password: ELASTIC_PASSWORD,
+}
+es, err := elasticsearch.NewClient(cfg)
+----
+
+By default nodes are selected using round-robin, but alternate node selection
+strategies can be implemented via the `elastictransport.Selector` interface and provided to the client configuration.
+
+NOTE: If your {es} cluster is behind a load balancer like when using Elastic
+Cloud you won't need to configure multiple nodes. Instead use the load balancer
+host and port.
 
 [discrete]
 [[auth-reference]]
 === Authentication
 
-This document contains code snippets to show you how to connect to various {es} 
-providers.
+This section contains code snippets to show you how to authenticate with {es}.
 
 
 [discrete]
@@ -27,8 +205,8 @@ To set the cluster endpoints, the username, and the password programatically, pa
 ------------------------------------
 cfg := elasticsearch.Config{
   Addresses: []string{
-    "http://localhost:9200",
-    "http://localhost:9201",
+    "https://localhost:9200",
+    "https://localhost:9201",
   },
   Username: "foo",
   Password: "bar",
@@ -42,20 +220,21 @@ You can also include the username and password in the endpoint URL:
 'https://username:password@localhost:9200'
 ```
 
-
 [discrete]
-[[auth-ec]]
-==== Elastic Cloud
-
-If you are using https://www.elastic.co/cloud[Elastic Cloud], the client offers 
-an easy way to connect to it. You must pass the Cloud ID that you can find in 
-the cloud console and the corresponding API key.
+[[auth-token]]
+==== HTTP Bearer authentication
+HTTP Bearer authentication uses the `ServiceToken` parameter by passing the token
+as a string. This authentication method is used by
+https://www.elastic.co/guide/en/elasticsearch/reference/master/security-api-create-service-token.html[Service Account Tokens]
+and https://www.elastic.co/guide/en/elasticsearch/reference/master/security-api-get-token.html[Bearer Tokens].
 
 [source,go]
 ------------------------------------
 cfg := elasticsearch.Config{
-		CloudID: "CLOUD_ID",
-		APIKey: "API_KEY"
+    Addresses: []string{
+        "https://localhost:9200",
+    },
+    ServiceToken: "token-value",
 }
 es, err := elasticsearch.NewClient(cfg)
 ------------------------------------

--- a/.doc/connecting.asciidoc
+++ b/.doc/connecting.asciidoc
@@ -216,6 +216,7 @@ You can also include the username and password in the endpoint URL:
 [discrete]
 [[auth-token]]
 ==== HTTP Bearer authentication
+
 HTTP Bearer authentication uses the `ServiceToken` parameter by passing the token
 as a string. This authentication method is used by
 https://www.elastic.co/guide/en/elasticsearch/reference/master/security-api-create-service-token.html[Service Account Tokens]

--- a/.doc/connecting.asciidoc
+++ b/.doc/connecting.asciidoc
@@ -6,7 +6,7 @@ This page contains the information you need to connect and use the Client with
 
 **On this page**
 
-* <<connecting, Connecting>>
+* Connecting
 ** <<connecting-to-elastic-cloud, Connecting to Elastic Cloud>>
 ** <<connecting-to-self-managed, Connecting to a self-managed cluster>>
 ** <<verifying-with-ca, Verifying HTTPS with CA certificates>>
@@ -19,13 +19,6 @@ This page contains the information you need to connect and use the Client with
 * <<compatibility-mode, Compatibility mode>>
 * <<client-usage, Using the client>>
 * <<connecting-faas, Using the Client in a Function-as-a-Service Environment>>
-
-[discrete]
-[[connecting]]
-=== Connecting
-
-This section contains code snippets to show you how to connect to various {es}
-providers.
 
 [discrete]
 [[connecting-to-elastic-cloud]]

--- a/.doc/connecting.asciidoc
+++ b/.doc/connecting.asciidoc
@@ -46,7 +46,7 @@ Starting from version 8.0, {es} offers security by default with authentication a
 
 To connect to the {es} cluster you need to configure the client to use the generated CA certificate. If you’re just getting started with {es} we recommend reading the documentation on configuring and starting {es} to ensure your cluster is running as expected.
 
-When you start Elasticsearch for the first time you’ll see a distinct block like the one below in the output from Elasticsearch (you may have to scroll up if it’s been a while):
+When you start {es} for the first time you’ll see a distinct block like the one below in the output from {es} (you may have to scroll up if it’s been a while):
 
 ```sh
 ----------------------------------------------------------------

--- a/README.md
+++ b/README.md
@@ -119,8 +119,8 @@ to the `elasticsearch.NewClient()` function.
 ```golang
 cfg := elasticsearch.Config{
   Addresses: []string{
-    "http://localhost:9200",
-    "http://localhost:9201",
+    "https://localhost:9200",
+    "https://localhost:9201",
   },
   // ...
 }
@@ -147,6 +147,15 @@ cert, _ := ioutil.ReadFile(*cacert)
 cfg := elasticsearch.Config{
   // ...
   CACert: cert,
+}
+```
+
+To set a fingerprint to validate the HTTPS connectionm use the `CertificateFingerprint` configuration option.
+
+```golang
+cfg := elasticsearch.Config{
+	// ...
+    CertificateFingerprint: fingerPrint,
 }
 ```
 


### PR DESCRIPTION
This PR revamps the connecting section of the documentation and adds relevant examples on how to connect, use TLS and authenticate a client on different cluster layouts.