### PR TITLE
replace readme string concat with json marshal

### DIFF
--- a/README.md
+++ b/README.md
@@ -196,6 +196,7 @@ import (
   "strconv"
   "strings"
   "sync"
+  "bytes"
 
   "github.com/elastic/go-elasticsearch/v8"
   "github.com/elastic/go-elasticsearch/v8/esapi"
@@ -246,17 +247,17 @@ func main() {
     go func(i int, title string) {
       defer wg.Done()
 
-      // Build the request body.
-      var b strings.Builder
-      b.WriteString(`{"title" : "`)
-      b.WriteString(title)
-      b.WriteString(`"}`)
+      // Build the request body.      
+      data, err := json.Marshal(struct{ Title string }{Title: title})
+      if err != nil {
+        log.Fatalf("Error marshaling document: %s", err)
+      }
 
       // Set up the request object.
       req := esapi.IndexRequest{
         Index:      "test",
         DocumentID: strconv.Itoa(i + 1),
-        Body:       strings.NewReader(b.String()),
+        Body:       bytes.NewReader(data),
         Refresh:    "true",
       }
 


### PR DESCRIPTION
Just took a look after being a long time user of oliver/elastic-go and noticed a quite jarring promotion of string concatenation in the example for indexing a document.

I don't think a database driver should be promoting usage of string concatenation. Someone is going to copy this into production and end up with an injection vulnerability or request smuggling issue.


https://github.com/elastic/go-elasticsearch#usage

<img width="398" alt="image" src="https://user-images.githubusercontent.com/5204642/167987969-ff1abe07-9f3b-499c-8a6c-1561a41ff5cf.png">