### PR TITLE
[Backport 8.2] use struct in readme instead of string buffer

### DIFF
--- a/README.md
+++ b/README.md
@@ -187,6 +187,7 @@ import (
   "strconv"
   "strings"
   "sync"
+  "bytes"
 
   "github.com/elastic/go-elasticsearch/v8"
   "github.com/elastic/go-elasticsearch/v8/esapi"
@@ -237,17 +238,17 @@ func main() {
     go func(i int, title string) {
       defer wg.Done()
 
-      // Build the request body.
-      var b strings.Builder
-      b.WriteString(`{"title" : "`)
-      b.WriteString(title)
-      b.WriteString(`"}`)
+      // Build the request body.      
+      data, err := json.Marshal(struct{ Title string }{Title: title})
+      if err != nil {
+        log.Fatalf("Error marshaling document: %s", err)
+      }
 
       // Set up the request object.
       req := esapi.IndexRequest{
         Index:      "test",
         DocumentID: strconv.Itoa(i + 1),
-        Body:       strings.NewReader(b.String()),
+        Body:       bytes.NewReader(data),
         Refresh:    "true",
       }
 


### PR DESCRIPTION
Backport of #493 