### PR TITLE
Use pkg.go.dev instead of godoc.org on overview page

### DIFF
--- a/.doc/overview.asciidoc
+++ b/.doc/overview.asciidoc
@@ -5,7 +5,7 @@ This is the official Go client for {es}.
 
 Full documentation is hosted at 
 https://github.com/elastic/go-elasticsearch[GitHub]
-and https://godoc.org/github.com/elastic/go-elasticsearch[GoDoc]. This 
+and https://pkg.go.dev/github.com/elastic/go-elasticsearch[PkgGoDev]. This 
 documentation provides only an overview of features.
 
 [discrete]


### PR DESCRIPTION
The [README.md](https://github.com/elastic/go-elasticsearch#readme) is already updated, but [Elastic Docs](https://www.elastic.co/guide/en/elasticsearch/client/go-api/master/overview.html) isn't.