### PR TITLE
Reduce CPU usage

### DIFF
--- a/esutil/bulk_indexer.go
+++ b/esutil/bulk_indexer.go
@@ -174,7 +174,6 @@ func (item *BulkIndexerItem) marshallMeta() {
 // computeLength calculate the size of the body and the metadata.
 func (item *BulkIndexerItem) computeLength() error {
 	if item.Body != nil {
-		// TODO propagate buf len to config to allow for performance gains.
 		n, err := item.Body.Seek(0, io.SeekEnd)
 		if err != nil {
 			return err

--- a/esutil/bulk_indexer.go
+++ b/esutil/bulk_indexer.go
@@ -114,18 +114,19 @@ type BulkIndexerItem struct {
 
 // marshallMeta format as JSON the item metadata.
 func (item *BulkIndexerItem) marshallMeta() {
-	var aux []byte
+	// Pre-allocate a buffer large enough for most use cases.
+	// 'aux = aux[:0]' resets the length without changing the capacity.
+	aux := make([]byte, 0, 256)
+
 	item.meta.WriteRune('{')
-	aux = strconv.AppendQuote(aux, item.Action)
-	item.meta.Write(aux)
-	aux = nil
+	item.meta.Write(strconv.AppendQuote(aux, item.Action))
+	aux = aux[:0]
 	item.meta.WriteRune(':')
 	item.meta.WriteRune('{')
 	if item.DocumentID != "" {
 		item.meta.WriteString(`"_id":`)
-		aux = strconv.AppendQuote(aux, item.DocumentID)
-		item.meta.Write(aux)
-		aux = nil
+		item.meta.Write(strconv.AppendQuote(aux, item.DocumentID))
+		aux = aux[:0]
 	}
 
 	if item.DocumentID != "" && item.Version != nil {
@@ -137,9 +138,8 @@ func (item *BulkIndexerItem) marshallMeta() {
 	if item.DocumentID != "" && item.VersionType != "" {
 		item.meta.WriteRune(',')
 		item.meta.WriteString(`"version_type":`)
-		aux = strconv.AppendQuote(aux, item.VersionType)
-		item.meta.Write(aux)
-		aux = nil
+		item.meta.Write(strconv.AppendQuote(aux, item.VersionType))
+		aux = aux[:0]
 	}
 
 	if item.Routing != "" {
@@ -147,27 +147,24 @@ func (item *BulkIndexerItem) marshallMeta() {
 			item.meta.WriteRune(',')
 		}
 		item.meta.WriteString(`"routing":`)
-		aux = strconv.AppendQuote(aux, item.Routing)
-		item.meta.Write(aux)
-		aux = nil
+		item.meta.Write(strconv.AppendQuote(aux, item.Routing))
+		aux = aux[:0]
 	}
 	if item.Index != "" {
 		if item.DocumentID != "" || item.Routing != "" {
 			item.meta.WriteRune(',')
 		}
 		item.meta.WriteString(`"_index":`)
-		aux = strconv.AppendQuote(aux, item.Index)
-		item.meta.Write(aux)
-		aux = nil
+		item.meta.Write(strconv.AppendQuote(aux, item.Index))
+		aux = aux[:0]
 	}
 	if item.RetryOnConflict != nil && item.Action == "update" {
 		if item.DocumentID != "" || item.Routing != "" || item.Index != "" {
 			item.meta.WriteString(",")
 		}
 		item.meta.WriteString(`"retry_on_conflict":`)
-		aux = strconv.AppendInt(aux, int64(*item.RetryOnConflict), 10)
-		item.meta.Write(aux)
-		aux = nil
+		item.meta.Write(strconv.AppendInt(aux, int64(*item.RetryOnConflict), 10))
+		aux = aux[:0]
 	}
 	item.meta.WriteRune('}')
 	item.meta.WriteRune('}')


### PR DESCRIPTION
My client application writes a lot of relatively small documents (few hundred bytes each) into ES. Without request compression, the bulk indexer is responsible for >90% of the CPU spent by the client. With request compression it is less, as ~20% of the CPU time is now spent inside the gzip compression. It still seemed worth improving the the bulk indexer code...

The application writes ~3 million documents to a remote ES cluster.

### Timing based on `main` (commit 30b59239b0863522ac7edf7cbb8372a6441e8439)
```
real    4m43.854s
user    5m41.925s
sys     0m23.021s
(pprof) Duration: 283.71s, Total samples = 360.56s (127.09%)
```

### Timing based on the first commit (Compute length using Seek())
```
real    4m44.704s
user    5m4.591s
sys     0m20.914s
(pprof) Duration: 284.55s, Total samples = 322.17s (113.22%)
```

### Timing based on both commits
```
real    4m41.193s
user    4m42.874s
sys     0m19.013s
(pprof) Duration: 281.10s, Total samples = 298.95s (106.35%)
```

Both commits reduce the number of heap allocations in the hot path.
The performance improvements are gained mostly by less (expensive) calls to gcmalloc()+memmove and consequently by a reduced GC pressure.

The real time stays relatively constant, mostly due to network throughput and latency plus ES response times being constant.
 