### PR TITLE
Faster JSON decoding of the bulk response

### DIFF
--- a/esutil/bulk_indexer.go
+++ b/esutil/bulk_indexer.go
@@ -20,7 +20,6 @@ package esutil
 import (
 	"bytes"
 	"context"
-	"encoding/json"
 	"errors"
 	"fmt"
 	"io"
@@ -33,6 +32,7 @@ import (
 
 	"github.com/elastic/go-elasticsearch/v8"
 	"github.com/elastic/go-elasticsearch/v8/esapi"
+	"github.com/goccy/go-json"
 )
 
 // BulkIndexer represents a parallel, asynchronous, efficient indexer for Elasticsearch.

--- a/go.mod
+++ b/go.mod
@@ -2,4 +2,7 @@ module github.com/elastic/go-elasticsearch/v8
 
 go 1.13
 
-require github.com/elastic/elastic-transport-go/v8 v8.0.0-20211216131617-bbee439d559c
+require (
+	github.com/elastic/elastic-transport-go/v8 v8.0.0-20211216131617-bbee439d559c
+	github.com/goccy/go-json v0.10.0 // indirect
+)

--- a/go.sum
+++ b/go.sum
@@ -1,2 +1,4 @@
 github.com/elastic/elastic-transport-go/v8 v8.0.0-20211216131617-bbee439d559c h1:onA2RpIyeCPvYAj1LFYiiMTrSpqVINWMfYFRS7lofJs=
 github.com/elastic/elastic-transport-go/v8 v8.0.0-20211216131617-bbee439d559c/go.mod h1:87Tcz8IVNe6rVSLdBux1o/PEItLtyabHU3naC7IoqKI=
+github.com/goccy/go-json v0.10.0 h1:mXKd9Qw4NuzShiRlOXKews24ufknHO7gx30lsDyokKA=
+github.com/goccy/go-json v0.10.0/go.mod h1:6MelG93GURQebXPDq3khkgXZkazVtN9CRI+MGFi0w8I=


### PR DESCRIPTION
Using the bulk indexer heavily shows that JSON decoding is one of the heaviest CPU consumers.

In my (real world) application a CPU profile shows these top 10:
```
Duration: 8.96s, Total samples = 2.44s (27.24%)
Showing nodes accounting for 1280ms, 52.46% of 2440ms total
Dropped 131 nodes (cum <= 12.20ms)
Showing top 10 nodes out of 183
      flat  flat%   sum%        cum   cum%
     360ms 14.75% 14.75%      360ms 14.75%  runtime.memmove
     360ms 14.75% 29.51%      360ms 14.75%  runtime/internal/syscall.Syscall6
     120ms  4.92% 34.43%      350ms 14.34%  encoding/json.(*Decoder).readValue
      90ms  3.69% 38.11%       90ms  3.69%  runtime.futex
      80ms  3.28% 41.39%       80ms  3.28%  crypto/aes.gcmAesEnc
      70ms  2.87% 44.26%       70ms  2.87%  runtime.nextFreeFast
      50ms  2.05% 46.31%       50ms  2.05%  encoding/json.stateInString
      50ms  2.05% 48.36%       50ms  2.05%  encoding/json.unquoteBytes
      50ms  2.05% 50.41%       70ms  2.87%  runtime.findObject
      50ms  2.05% 52.46%       50ms  2.05%  runtime.memclrNoHeapPointers
```
This made me wonder how the top N look like when sorted by CPU cumulated (`sort=cum`):
```
Showing top 10 nodes out of 183
      flat  flat%   sum%        cum   cum%
         0     0%     0%     1250ms 51.23%  main.runDelayed.func1
         0     0%     0%     1250ms 51.23%  main.startProcessingExecutables.func1
         0     0%     0%      680ms 27.87%  encoding/json.(*Decoder).Decode
         0     0%     0%      680ms 27.87%  github.com/elastic/go-elasticsearch/v8/esutil.(*bulkIndexer).Close
         0     0%     0%      680ms 27.87%  github.com/elastic/go-elasticsearch/v8/esutil.(*worker).flush
         0     0%     0%      680ms 27.87%  github.com/elastic/go-elasticsearch/v8/esutil.defaultJSONDecoder.UnmarshalFromRead
```
It was unexpected to see the `Decode()` so high ranked. After some digging, I found the bulk response decoding being responsible.

A fast drop in replacement for `encode/json` is `"github.com/goccy/go-json"`.
There is a good comparison of JSON Go libraries [here](https://medium.com/geekculture/my-golang-json-evaluation-20a9ca6ef79c).

For basically just changing a single line of code, the reduction of CPU is quite nice:
```
Duration: 7.95s, Total samples = 1.97s (24.79%)
Showing nodes accounting for 1020ms, 51.78% of 1970ms total
Showing top 10 nodes out of 300
      flat  flat%   sum%        cum   cum%
     250ms 12.69% 12.69%      250ms 12.69%  runtime.memmove
     240ms 12.18% 24.87%      240ms 12.18%  runtime/internal/syscall.Syscall6
     110ms  5.58% 30.46%      180ms  9.14%  github.com/goccy/go-json/internal/decoder.stringBytes
     100ms  5.08% 35.53%      220ms 11.17%  runtime.mallocgc
      90ms  4.57% 40.10%       90ms  4.57%  runtime.futex
      50ms  2.54% 42.64%      200ms 10.15%  github.com/goccy/go-json/internal/encoder/vm.Run
      50ms  2.54% 45.18%      100ms  5.08%  google.golang.org/protobuf/internal/impl.(*MessageInfo).unmarshalPointer
      50ms  2.54% 47.72%       50ms  2.54%  runtime.memclrNoHeapPointers
      40ms  2.03% 49.75%       40ms  2.03%  net.appendHex (inline)
      40ms  2.03% 51.78%       40ms  2.03%  runtime.(*randomEnum).next

```
So that is a drop by 19% for the overall application CPU usage.
The bulk indexer flush() CPU usage dropped by ~40% (from 680ms down to 390ms):
```
      flat  flat%   sum%        cum   cum%
     0.01s  0.51%  0.51%      0.39s 19.80%  github.com/elastic/go-elasticsearch/v8/esutil.(*worker).flush
```

[Warning]: The above numbers are from single/manual tests and have some variation between runs. So take them more as a indicator of an significant improvement.