### PR TITLE
[DOCS] References source_branch in index and changes URLs

### DIFF
--- a/.doc/connecting.asciidoc
+++ b/.doc/connecting.asciidoc
@@ -219,8 +219,8 @@ You can also include the username and password in the endpoint URL:
 
 HTTP Bearer authentication uses the `ServiceToken` parameter by passing the token
 as a string. This authentication method is used by
-https://www.elastic.co/guide/en/elasticsearch/reference/master/security-api-create-service-token.html[Service Account Tokens]
-and https://www.elastic.co/guide/en/elasticsearch/reference/master/security-api-get-token.html[Bearer Tokens].
+https://www.elastic.co/guide/en/elasticsearch/reference/{branch}/security-api-create-service-token.html[Service Account Tokens]
+and https://www.elastic.co/guide/en/elasticsearch/reference/{branch}/security-api-get-token.html[Bearer Tokens].
 
 [source,go]
 ------------------------------------

--- a/.doc/index.asciidoc
+++ b/.doc/index.asciidoc
@@ -2,6 +2,8 @@
 
 :doctype:           book
 
+include::{docs-root}/shared/versions/stack/{source_branch}.asciidoc[]
+
 include::{asciidoc-dir}/../../shared/attributes.asciidoc[]
 
 include::overview.asciidoc[]

--- a/.doc/index.asciidoc
+++ b/.doc/index.asciidoc
@@ -2,7 +2,7 @@
 
 :doctype:           book
 
-include::{asciidoc-dir}/shared/versions/stack/{source_branch}.asciidoc[]
+include::{asciidoc-dir}/../../shared/versions/stack/{source_branch}.asciidoc[]
 
 include::{asciidoc-dir}/../../shared/attributes.asciidoc[]
 

--- a/.doc/index.asciidoc
+++ b/.doc/index.asciidoc
@@ -2,7 +2,7 @@
 
 :doctype:           book
 
-include::{docs-root}/shared/versions/stack/{source_branch}.asciidoc[]
+include::{asciidoc-dir}/shared/versions/stack/{source_branch}.asciidoc[]
 
 include::{asciidoc-dir}/../../shared/attributes.asciidoc[]
 


### PR DESCRIPTION
## Overview

Related to https://github.com/elastic/clients-team/issues/532.
This PR adds a reference of `source_branch` to the index file and changes two URLs to use `{branch}` instead of `master`.