### PR TITLE
Mention `Response.IsError()` also handles 3xx in example

### DIFF
--- a/esapi/esapi.response_example_test.go
+++ b/esapi/esapi.response_example_test.go
@@ -35,7 +35,7 @@ func ExampleResponse_IsError() {
 	}
 	defer res.Body.Close()
 
-	// Handle error response (4xx, 5xx)
+	// Handle error response (3xx, 4xx, 5xx)
 	//
 	if res.IsError() {
 		log.Fatalf("ERROR: %s", res.Status())


### PR DESCRIPTION
This adds `3xx` to the `Response.IsError()` example comment as  [it catches `>299` status codes](https://github.com/elastic/go-elasticsearch/blob/11608f98966a036fb555a51e7a08955f4d042c28/esapi/esapi.response.go#L89-L93).