### PR TITLE
Resolve a deadlock in go-elasticsearch

### DIFF
--- a/estransport/connection.go
+++ b/estransport/connection.go
@@ -152,6 +152,11 @@ func (cp *statusConnectionPool) OnSuccess(c *Connection) error {
 	cp.Lock()
 	defer cp.Unlock()
 	c.Lock()
+	// check again
+	if !c.IsDead {
+		c.Unlock()
+		return nil
+	}
 	defer c.Unlock()
 	return cp.resurrect(c, true)
 }

--- a/estransport/connection.go
+++ b/estransport/connection.go
@@ -139,17 +139,20 @@ func (cp *statusConnectionPool) Next() (*Connection, error) {
 //
 func (cp *statusConnectionPool) OnSuccess(c *Connection) error {
 	c.Lock()
-	defer c.Unlock()
 
 	// Short-circuit for live connection
 	if !c.IsDead {
+		c.Unlock()
 		return nil
 	}
 
 	c.markAsHealthy()
+        c.Unlock()
 
 	cp.Lock()
 	defer cp.Unlock()
+	c.Lock()
+	defer c.Unlock()
 	return cp.resurrect(c, true)
 }
 


### PR DESCRIPTION
Deadlock in go-elasticsearch/estransport/connection.go
In func (cp *statusConnectionPool) OnSuccess(c *Connection), the lock order ( c.lock->cp.clock)  is different from other functions.