### PR TITLE
Do not drop item after flush() failed

### DIFF
--- a/esutil/bulk_indexer.go
+++ b/esutil/bulk_indexer.go
@@ -441,7 +441,8 @@ func (w *worker) run() {
 					if w.bi.config.OnError != nil {
 						w.bi.config.OnError(ctx, err)
 					}
-					continue
+					w.mu.Lock()
+					// continue with 'item' even when flush failed
 				}
 			}
 


### PR DESCRIPTION
Bulk Indexer: In run() we drop the current item when the flush() failed.
This PR fixes it.