### PR TITLE
[Backport 8.7] Do not drop item after flush() failed

### DIFF
--- a/esutil/bulk_indexer.go
+++ b/esutil/bulk_indexer.go
@@ -441,7 +441,8 @@ func (w *worker) run() {
 					if w.bi.config.OnError != nil {
 						w.bi.config.OnError(ctx, err)
 					}
-					continue
+					w.mu.Lock()
+					// continue with 'item' even when flush failed
 				}
 			}
 


### PR DESCRIPTION
Backport of #623 