### PR TITLE
[Backport 8.7] Bump transport version to 1a3c63d

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -2,4 +2,4 @@ module github.com/elastic/go-elasticsearch/v8
 
 go 1.13
 
-require github.com/elastic/elastic-transport-go/v8 v8.0.0-20230201152525-7be14259265a
+require github.com/elastic/elastic-transport-go/v8 v8.0.0-20230329154755-1a3c63de0db6

--- a/go.sum
+++ b/go.sum
@@ -1,2 +1,2 @@
-github.com/elastic/elastic-transport-go/v8 v8.0.0-20230201152525-7be14259265a h1:WoeSTB0D6DO+2nZyVmvSLZFTbKiB+ZUhjWZ9NkRjnXM=
-github.com/elastic/elastic-transport-go/v8 v8.0.0-20230201152525-7be14259265a/go.mod h1:87Tcz8IVNe6rVSLdBux1o/PEItLtyabHU3naC7IoqKI=
+github.com/elastic/elastic-transport-go/v8 v8.0.0-20230329154755-1a3c63de0db6 h1:1+44gxLdKRnR/Bx/iAtr+XqNcE4e0oODa63+FABNANI=
+github.com/elastic/elastic-transport-go/v8 v8.0.0-20230329154755-1a3c63de0db6/go.mod h1:87Tcz8IVNe6rVSLdBux1o/PEItLtyabHU3naC7IoqKI=


### PR DESCRIPTION
* Transport: Bump to version 1a3c63d