### PR TITLE
[DOCS] Changes hero image on the landing page and adds a line about license

### DIFF
--- a/.doc/index-custom-title-page.html
+++ b/.doc/index-custom-title-page.html
@@ -69,7 +69,7 @@
       </p>
     </div>
     <div class="col-md-6 col-12">
-      <img class="w-100" src="https://images.contentstack.io/v3/assets/bltefdd0b53724fa2ce/blt0238da6059720d24/641dc21613a86c544af672ee/go-es-lp-hero.png" />
+      <img class="w-100" src="https://images.contentstack.io/v3/assets/bltefdd0b53724fa2ce/blt309b983fa254e216/642563bba793f910de28b9d1/ES_Go_landing_page.png" />
     </div>
   </div>
 
@@ -171,3 +171,4 @@
   </div>
 
   <p class="my-4"><a href="https://www.elastic.co/guide/index.html">View all Elastic docs</a></p>
+  <p class="my-4"><small>The Go gopher available <a href="https://go.dev/blog/gopher">here</a> is created by Renee French and released under the Creative Commons <a href="https://creativecommons.org/licenses/by-sa/4.0/deed.en"> Attribution-Share Alike 4.0 International license</a>.</small></p>


### PR DESCRIPTION
## Overview

This PR:
* changes the hero image of the Go landing page to include the Go gopher,
* adds a licensing line about the mascot to the bottom of the page.

### Preview

[Go landing page](https://go-elasticsearch_642.docs-preview.app.elstc.co/guide/en/elasticsearch/client/go-api/master/index.html)