### PR TITLE
[TypedClient] Fix Unmarshall of Bucket Aggregations

### DIFF
--- a/typedapi/types/adjacencymatrixbucket.go
+++ b/typedapi/types/adjacencymatrixbucket.go
@@ -53,449 +53,11 @@ func (s *AdjacencyMatrixBucket) UnmarshalJSON(data []byte) error {
 			return err
 		}
 
-		switch t {
+		if _, ok := t.(json.Delim); ok {
+			continue
+		}
 
-		case "aggregations":
-			for dec.More() {
-				tt, err := dec.Token()
-				if err != nil {
-					if errors.Is(err, io.EOF) {
-						break
-					}
-					return err
-				}
-				if value, ok := tt.(string); ok {
-					if strings.Contains(value, "#") {
-						elems := strings.Split(value, "#")
-						if len(elems) == 2 {
-							switch elems[0] {
-							case "cardinality":
-								o := NewCardinalityAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "hdr_percentiles":
-								o := NewHdrPercentilesAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "hdr_percentile_ranks":
-								o := NewHdrPercentileRanksAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "tdigest_percentiles":
-								o := NewTDigestPercentilesAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "tdigest_percentile_ranks":
-								o := NewTDigestPercentileRanksAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "percentiles_bucket":
-								o := NewPercentilesBucketAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "median_absolute_deviation":
-								o := NewMedianAbsoluteDeviationAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "min":
-								o := NewMinAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "max":
-								o := NewMaxAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "sum":
-								o := NewSumAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "avg":
-								o := NewAvgAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "weighted_avg":
-								o := NewWeightedAvgAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "value_count":
-								o := NewValueCountAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "simple_value":
-								o := NewSimpleValueAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "derivative":
-								o := NewDerivativeAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "bucket_metric_value":
-								o := NewBucketMetricValueAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "stats":
-								o := NewStatsAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "stats_bucket":
-								o := NewStatsBucketAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "extended_stats":
-								o := NewExtendedStatsAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "extended_stats_bucket":
-								o := NewExtendedStatsBucketAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "geo_bounds":
-								o := NewGeoBoundsAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "geo_centroid":
-								o := NewGeoCentroidAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "histogram":
-								o := NewHistogramAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "date_histogram":
-								o := NewDateHistogramAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "auto_date_histogram":
-								o := NewAutoDateHistogramAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "variable_width_histogram":
-								o := NewVariableWidthHistogramAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "sterms":
-								o := NewStringTermsAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "lterms":
-								o := NewLongTermsAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "dterms":
-								o := NewDoubleTermsAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "umterms":
-								o := NewUnmappedTermsAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "lrareterms":
-								o := NewLongRareTermsAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "srareterms":
-								o := NewStringRareTermsAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "umrareterms":
-								o := NewUnmappedRareTermsAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "multi_terms":
-								o := NewMultiTermsAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "missing":
-								o := NewMissingAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "nested":
-								o := NewNestedAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "reverse_nested":
-								o := NewReverseNestedAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "global":
-								o := NewGlobalAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "filter":
-								o := NewFilterAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "children":
-								o := NewChildrenAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "parent":
-								o := NewParentAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "sampler":
-								o := NewSamplerAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "unmapped_sampler":
-								o := NewUnmappedSamplerAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "geohash_grid":
-								o := NewGeoHashGridAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "geotile_grid":
-								o := NewGeoTileGridAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "geohex_grid":
-								o := NewGeoHexGridAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "range":
-								o := NewRangeAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "date_range":
-								o := NewDateRangeAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "geo_distance":
-								o := NewGeoDistanceAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "ip_range":
-								o := NewIpRangeAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "ip_prefix":
-								o := NewIpPrefixAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "filters":
-								o := NewFiltersAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "adjacency_matrix":
-								o := NewAdjacencyMatrixAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "siglterms":
-								o := NewSignificantLongTermsAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "sigsterms":
-								o := NewSignificantStringTermsAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "umsigterms":
-								o := NewUnmappedSignificantTermsAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "composite":
-								o := NewCompositeAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "scripted_metric":
-								o := NewScriptedMetricAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "top_hits":
-								o := NewTopHitsAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "inference":
-								o := NewInferenceAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "string_stats":
-								o := NewStringStatsAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "box_plot":
-								o := NewBoxPlotAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "top_metrics":
-								o := NewTopMetricsAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "t_test":
-								o := NewTTestAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "rate":
-								o := NewRateAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "simple_long_value":
-								o := NewCumulativeCardinalityAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "matrix_stats":
-								o := NewMatrixStatsAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "geo_line":
-								o := NewGeoLineAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							default:
-								o := make(map[string]interface{}, 0)
-								if err := dec.Decode(&o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							}
-						} else {
-							return errors.New("cannot decode JSON for field Aggregations")
-						}
-					} else {
-						o := make(map[string]interface{}, 0)
-						if err := dec.Decode(&o); err != nil {
-							return err
-						}
-						s.Aggregations[value] = o
-					}
-				}
-			}
+		switch t {
 
 		case "doc_count":
 			if err := dec.Decode(&s.DocCount); err != nil {
@@ -507,6 +69,442 @@ func (s *AdjacencyMatrixBucket) UnmarshalJSON(data []byte) error {
 				return err
 			}
 
+		default:
+			if value, ok := t.(string); ok {
+				if s.Aggregations == nil {
+					s.Aggregations = make(map[string]Aggregate, 0)
+				}
+
+				if strings.Contains(value, "#") {
+					elems := strings.Split(value, "#")
+					if len(elems) == 2 {
+						switch elems[0] {
+						case "cardinality":
+							o := NewCardinalityAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "hdr_percentiles":
+							o := NewHdrPercentilesAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "hdr_percentile_ranks":
+							o := NewHdrPercentileRanksAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "tdigest_percentiles":
+							o := NewTDigestPercentilesAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "tdigest_percentile_ranks":
+							o := NewTDigestPercentileRanksAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "percentiles_bucket":
+							o := NewPercentilesBucketAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "median_absolute_deviation":
+							o := NewMedianAbsoluteDeviationAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "min":
+							o := NewMinAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "max":
+							o := NewMaxAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "sum":
+							o := NewSumAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "avg":
+							o := NewAvgAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "weighted_avg":
+							o := NewWeightedAvgAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "value_count":
+							o := NewValueCountAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "simple_value":
+							o := NewSimpleValueAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "derivative":
+							o := NewDerivativeAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "bucket_metric_value":
+							o := NewBucketMetricValueAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "stats":
+							o := NewStatsAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "stats_bucket":
+							o := NewStatsBucketAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "extended_stats":
+							o := NewExtendedStatsAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "extended_stats_bucket":
+							o := NewExtendedStatsBucketAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "geo_bounds":
+							o := NewGeoBoundsAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "geo_centroid":
+							o := NewGeoCentroidAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "histogram":
+							o := NewHistogramAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "date_histogram":
+							o := NewDateHistogramAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "auto_date_histogram":
+							o := NewAutoDateHistogramAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "variable_width_histogram":
+							o := NewVariableWidthHistogramAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "sterms":
+							o := NewStringTermsAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "lterms":
+							o := NewLongTermsAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "dterms":
+							o := NewDoubleTermsAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "umterms":
+							o := NewUnmappedTermsAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "lrareterms":
+							o := NewLongRareTermsAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "srareterms":
+							o := NewStringRareTermsAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "umrareterms":
+							o := NewUnmappedRareTermsAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "multi_terms":
+							o := NewMultiTermsAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "missing":
+							o := NewMissingAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "nested":
+							o := NewNestedAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "reverse_nested":
+							o := NewReverseNestedAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "global":
+							o := NewGlobalAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "filter":
+							o := NewFilterAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "children":
+							o := NewChildrenAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "parent":
+							o := NewParentAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "sampler":
+							o := NewSamplerAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "unmapped_sampler":
+							o := NewUnmappedSamplerAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "geohash_grid":
+							o := NewGeoHashGridAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "geotile_grid":
+							o := NewGeoTileGridAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "geohex_grid":
+							o := NewGeoHexGridAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "range":
+							o := NewRangeAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "date_range":
+							o := NewDateRangeAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "geo_distance":
+							o := NewGeoDistanceAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "ip_range":
+							o := NewIpRangeAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "ip_prefix":
+							o := NewIpPrefixAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "filters":
+							o := NewFiltersAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "adjacency_matrix":
+							o := NewAdjacencyMatrixAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "siglterms":
+							o := NewSignificantLongTermsAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "sigsterms":
+							o := NewSignificantStringTermsAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "umsigterms":
+							o := NewUnmappedSignificantTermsAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "composite":
+							o := NewCompositeAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "scripted_metric":
+							o := NewScriptedMetricAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "top_hits":
+							o := NewTopHitsAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "inference":
+							o := NewInferenceAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "string_stats":
+							o := NewStringStatsAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "box_plot":
+							o := NewBoxPlotAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "top_metrics":
+							o := NewTopMetricsAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "t_test":
+							o := NewTTestAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "rate":
+							o := NewRateAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "simple_long_value":
+							o := NewCumulativeCardinalityAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "matrix_stats":
+							o := NewMatrixStatsAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "geo_line":
+							o := NewGeoLineAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						default:
+							o := make(map[string]interface{}, 0)
+							if err := dec.Decode(&o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						}
+					} else {
+						return errors.New("cannot decode JSON for field Aggregations")
+					}
+				} else {
+					o := make(map[string]interface{}, 0)
+					if err := dec.Decode(&o); err != nil {
+						return err
+					}
+					s.Aggregations[value] = o
+				}
+			}
 		}
 	}
 	return nil

--- a/typedapi/types/compositebucket.go
+++ b/typedapi/types/compositebucket.go
@@ -53,449 +53,11 @@ func (s *CompositeBucket) UnmarshalJSON(data []byte) error {
 			return err
 		}
 
-		switch t {
+		if _, ok := t.(json.Delim); ok {
+			continue
+		}
 
-		case "aggregations":
-			for dec.More() {
-				tt, err := dec.Token()
-				if err != nil {
-					if errors.Is(err, io.EOF) {
-						break
-					}
-					return err
-				}
-				if value, ok := tt.(string); ok {
-					if strings.Contains(value, "#") {
-						elems := strings.Split(value, "#")
-						if len(elems) == 2 {
-							switch elems[0] {
-							case "cardinality":
-								o := NewCardinalityAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "hdr_percentiles":
-								o := NewHdrPercentilesAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "hdr_percentile_ranks":
-								o := NewHdrPercentileRanksAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "tdigest_percentiles":
-								o := NewTDigestPercentilesAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "tdigest_percentile_ranks":
-								o := NewTDigestPercentileRanksAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "percentiles_bucket":
-								o := NewPercentilesBucketAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "median_absolute_deviation":
-								o := NewMedianAbsoluteDeviationAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "min":
-								o := NewMinAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "max":
-								o := NewMaxAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "sum":
-								o := NewSumAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "avg":
-								o := NewAvgAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "weighted_avg":
-								o := NewWeightedAvgAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "value_count":
-								o := NewValueCountAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "simple_value":
-								o := NewSimpleValueAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "derivative":
-								o := NewDerivativeAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "bucket_metric_value":
-								o := NewBucketMetricValueAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "stats":
-								o := NewStatsAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "stats_bucket":
-								o := NewStatsBucketAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "extended_stats":
-								o := NewExtendedStatsAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "extended_stats_bucket":
-								o := NewExtendedStatsBucketAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "geo_bounds":
-								o := NewGeoBoundsAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "geo_centroid":
-								o := NewGeoCentroidAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "histogram":
-								o := NewHistogramAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "date_histogram":
-								o := NewDateHistogramAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "auto_date_histogram":
-								o := NewAutoDateHistogramAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "variable_width_histogram":
-								o := NewVariableWidthHistogramAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "sterms":
-								o := NewStringTermsAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "lterms":
-								o := NewLongTermsAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "dterms":
-								o := NewDoubleTermsAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "umterms":
-								o := NewUnmappedTermsAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "lrareterms":
-								o := NewLongRareTermsAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "srareterms":
-								o := NewStringRareTermsAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "umrareterms":
-								o := NewUnmappedRareTermsAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "multi_terms":
-								o := NewMultiTermsAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "missing":
-								o := NewMissingAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "nested":
-								o := NewNestedAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "reverse_nested":
-								o := NewReverseNestedAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "global":
-								o := NewGlobalAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "filter":
-								o := NewFilterAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "children":
-								o := NewChildrenAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "parent":
-								o := NewParentAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "sampler":
-								o := NewSamplerAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "unmapped_sampler":
-								o := NewUnmappedSamplerAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "geohash_grid":
-								o := NewGeoHashGridAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "geotile_grid":
-								o := NewGeoTileGridAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "geohex_grid":
-								o := NewGeoHexGridAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "range":
-								o := NewRangeAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "date_range":
-								o := NewDateRangeAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "geo_distance":
-								o := NewGeoDistanceAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "ip_range":
-								o := NewIpRangeAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "ip_prefix":
-								o := NewIpPrefixAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "filters":
-								o := NewFiltersAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "adjacency_matrix":
-								o := NewAdjacencyMatrixAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "siglterms":
-								o := NewSignificantLongTermsAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "sigsterms":
-								o := NewSignificantStringTermsAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "umsigterms":
-								o := NewUnmappedSignificantTermsAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "composite":
-								o := NewCompositeAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "scripted_metric":
-								o := NewScriptedMetricAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "top_hits":
-								o := NewTopHitsAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "inference":
-								o := NewInferenceAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "string_stats":
-								o := NewStringStatsAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "box_plot":
-								o := NewBoxPlotAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "top_metrics":
-								o := NewTopMetricsAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "t_test":
-								o := NewTTestAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "rate":
-								o := NewRateAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "simple_long_value":
-								o := NewCumulativeCardinalityAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "matrix_stats":
-								o := NewMatrixStatsAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "geo_line":
-								o := NewGeoLineAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							default:
-								o := make(map[string]interface{}, 0)
-								if err := dec.Decode(&o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							}
-						} else {
-							return errors.New("cannot decode JSON for field Aggregations")
-						}
-					} else {
-						o := make(map[string]interface{}, 0)
-						if err := dec.Decode(&o); err != nil {
-							return err
-						}
-						s.Aggregations[value] = o
-					}
-				}
-			}
+		switch t {
 
 		case "doc_count":
 			if err := dec.Decode(&s.DocCount); err != nil {
@@ -507,6 +69,442 @@ func (s *CompositeBucket) UnmarshalJSON(data []byte) error {
 				return err
 			}
 
+		default:
+			if value, ok := t.(string); ok {
+				if s.Aggregations == nil {
+					s.Aggregations = make(map[string]Aggregate, 0)
+				}
+
+				if strings.Contains(value, "#") {
+					elems := strings.Split(value, "#")
+					if len(elems) == 2 {
+						switch elems[0] {
+						case "cardinality":
+							o := NewCardinalityAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "hdr_percentiles":
+							o := NewHdrPercentilesAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "hdr_percentile_ranks":
+							o := NewHdrPercentileRanksAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "tdigest_percentiles":
+							o := NewTDigestPercentilesAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "tdigest_percentile_ranks":
+							o := NewTDigestPercentileRanksAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "percentiles_bucket":
+							o := NewPercentilesBucketAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "median_absolute_deviation":
+							o := NewMedianAbsoluteDeviationAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "min":
+							o := NewMinAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "max":
+							o := NewMaxAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "sum":
+							o := NewSumAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "avg":
+							o := NewAvgAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "weighted_avg":
+							o := NewWeightedAvgAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "value_count":
+							o := NewValueCountAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "simple_value":
+							o := NewSimpleValueAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "derivative":
+							o := NewDerivativeAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "bucket_metric_value":
+							o := NewBucketMetricValueAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "stats":
+							o := NewStatsAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "stats_bucket":
+							o := NewStatsBucketAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "extended_stats":
+							o := NewExtendedStatsAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "extended_stats_bucket":
+							o := NewExtendedStatsBucketAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "geo_bounds":
+							o := NewGeoBoundsAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "geo_centroid":
+							o := NewGeoCentroidAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "histogram":
+							o := NewHistogramAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "date_histogram":
+							o := NewDateHistogramAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "auto_date_histogram":
+							o := NewAutoDateHistogramAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "variable_width_histogram":
+							o := NewVariableWidthHistogramAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "sterms":
+							o := NewStringTermsAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "lterms":
+							o := NewLongTermsAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "dterms":
+							o := NewDoubleTermsAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "umterms":
+							o := NewUnmappedTermsAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "lrareterms":
+							o := NewLongRareTermsAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "srareterms":
+							o := NewStringRareTermsAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "umrareterms":
+							o := NewUnmappedRareTermsAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "multi_terms":
+							o := NewMultiTermsAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "missing":
+							o := NewMissingAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "nested":
+							o := NewNestedAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "reverse_nested":
+							o := NewReverseNestedAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "global":
+							o := NewGlobalAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "filter":
+							o := NewFilterAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "children":
+							o := NewChildrenAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "parent":
+							o := NewParentAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "sampler":
+							o := NewSamplerAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "unmapped_sampler":
+							o := NewUnmappedSamplerAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "geohash_grid":
+							o := NewGeoHashGridAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "geotile_grid":
+							o := NewGeoTileGridAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "geohex_grid":
+							o := NewGeoHexGridAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "range":
+							o := NewRangeAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "date_range":
+							o := NewDateRangeAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "geo_distance":
+							o := NewGeoDistanceAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "ip_range":
+							o := NewIpRangeAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "ip_prefix":
+							o := NewIpPrefixAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "filters":
+							o := NewFiltersAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "adjacency_matrix":
+							o := NewAdjacencyMatrixAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "siglterms":
+							o := NewSignificantLongTermsAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "sigsterms":
+							o := NewSignificantStringTermsAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "umsigterms":
+							o := NewUnmappedSignificantTermsAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "composite":
+							o := NewCompositeAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "scripted_metric":
+							o := NewScriptedMetricAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "top_hits":
+							o := NewTopHitsAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "inference":
+							o := NewInferenceAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "string_stats":
+							o := NewStringStatsAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "box_plot":
+							o := NewBoxPlotAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "top_metrics":
+							o := NewTopMetricsAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "t_test":
+							o := NewTTestAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "rate":
+							o := NewRateAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "simple_long_value":
+							o := NewCumulativeCardinalityAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "matrix_stats":
+							o := NewMatrixStatsAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "geo_line":
+							o := NewGeoLineAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						default:
+							o := make(map[string]interface{}, 0)
+							if err := dec.Decode(&o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						}
+					} else {
+						return errors.New("cannot decode JSON for field Aggregations")
+					}
+				} else {
+					o := make(map[string]interface{}, 0)
+					if err := dec.Decode(&o); err != nil {
+						return err
+					}
+					s.Aggregations[value] = o
+				}
+			}
 		}
 	}
 	return nil

--- a/typedapi/types/datehistogrambucket.go
+++ b/typedapi/types/datehistogrambucket.go
@@ -54,449 +54,11 @@ func (s *DateHistogramBucket) UnmarshalJSON(data []byte) error {
 			return err
 		}
 
-		switch t {
+		if _, ok := t.(json.Delim); ok {
+			continue
+		}
 
-		case "aggregations":
-			for dec.More() {
-				tt, err := dec.Token()
-				if err != nil {
-					if errors.Is(err, io.EOF) {
-						break
-					}
-					return err
-				}
-				if value, ok := tt.(string); ok {
-					if strings.Contains(value, "#") {
-						elems := strings.Split(value, "#")
-						if len(elems) == 2 {
-							switch elems[0] {
-							case "cardinality":
-								o := NewCardinalityAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "hdr_percentiles":
-								o := NewHdrPercentilesAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "hdr_percentile_ranks":
-								o := NewHdrPercentileRanksAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "tdigest_percentiles":
-								o := NewTDigestPercentilesAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "tdigest_percentile_ranks":
-								o := NewTDigestPercentileRanksAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "percentiles_bucket":
-								o := NewPercentilesBucketAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "median_absolute_deviation":
-								o := NewMedianAbsoluteDeviationAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "min":
-								o := NewMinAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "max":
-								o := NewMaxAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "sum":
-								o := NewSumAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "avg":
-								o := NewAvgAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "weighted_avg":
-								o := NewWeightedAvgAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "value_count":
-								o := NewValueCountAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "simple_value":
-								o := NewSimpleValueAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "derivative":
-								o := NewDerivativeAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "bucket_metric_value":
-								o := NewBucketMetricValueAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "stats":
-								o := NewStatsAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "stats_bucket":
-								o := NewStatsBucketAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "extended_stats":
-								o := NewExtendedStatsAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "extended_stats_bucket":
-								o := NewExtendedStatsBucketAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "geo_bounds":
-								o := NewGeoBoundsAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "geo_centroid":
-								o := NewGeoCentroidAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "histogram":
-								o := NewHistogramAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "date_histogram":
-								o := NewDateHistogramAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "auto_date_histogram":
-								o := NewAutoDateHistogramAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "variable_width_histogram":
-								o := NewVariableWidthHistogramAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "sterms":
-								o := NewStringTermsAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "lterms":
-								o := NewLongTermsAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "dterms":
-								o := NewDoubleTermsAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "umterms":
-								o := NewUnmappedTermsAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "lrareterms":
-								o := NewLongRareTermsAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "srareterms":
-								o := NewStringRareTermsAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "umrareterms":
-								o := NewUnmappedRareTermsAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "multi_terms":
-								o := NewMultiTermsAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "missing":
-								o := NewMissingAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "nested":
-								o := NewNestedAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "reverse_nested":
-								o := NewReverseNestedAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "global":
-								o := NewGlobalAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "filter":
-								o := NewFilterAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "children":
-								o := NewChildrenAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "parent":
-								o := NewParentAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "sampler":
-								o := NewSamplerAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "unmapped_sampler":
-								o := NewUnmappedSamplerAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "geohash_grid":
-								o := NewGeoHashGridAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "geotile_grid":
-								o := NewGeoTileGridAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "geohex_grid":
-								o := NewGeoHexGridAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "range":
-								o := NewRangeAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "date_range":
-								o := NewDateRangeAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "geo_distance":
-								o := NewGeoDistanceAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "ip_range":
-								o := NewIpRangeAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "ip_prefix":
-								o := NewIpPrefixAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "filters":
-								o := NewFiltersAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "adjacency_matrix":
-								o := NewAdjacencyMatrixAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "siglterms":
-								o := NewSignificantLongTermsAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "sigsterms":
-								o := NewSignificantStringTermsAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "umsigterms":
-								o := NewUnmappedSignificantTermsAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "composite":
-								o := NewCompositeAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "scripted_metric":
-								o := NewScriptedMetricAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "top_hits":
-								o := NewTopHitsAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "inference":
-								o := NewInferenceAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "string_stats":
-								o := NewStringStatsAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "box_plot":
-								o := NewBoxPlotAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "top_metrics":
-								o := NewTopMetricsAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "t_test":
-								o := NewTTestAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "rate":
-								o := NewRateAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "simple_long_value":
-								o := NewCumulativeCardinalityAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "matrix_stats":
-								o := NewMatrixStatsAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "geo_line":
-								o := NewGeoLineAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							default:
-								o := make(map[string]interface{}, 0)
-								if err := dec.Decode(&o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							}
-						} else {
-							return errors.New("cannot decode JSON for field Aggregations")
-						}
-					} else {
-						o := make(map[string]interface{}, 0)
-						if err := dec.Decode(&o); err != nil {
-							return err
-						}
-						s.Aggregations[value] = o
-					}
-				}
-			}
+		switch t {
 
 		case "doc_count":
 			if err := dec.Decode(&s.DocCount); err != nil {
@@ -513,6 +75,442 @@ func (s *DateHistogramBucket) UnmarshalJSON(data []byte) error {
 				return err
 			}
 
+		default:
+			if value, ok := t.(string); ok {
+				if s.Aggregations == nil {
+					s.Aggregations = make(map[string]Aggregate, 0)
+				}
+
+				if strings.Contains(value, "#") {
+					elems := strings.Split(value, "#")
+					if len(elems) == 2 {
+						switch elems[0] {
+						case "cardinality":
+							o := NewCardinalityAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "hdr_percentiles":
+							o := NewHdrPercentilesAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "hdr_percentile_ranks":
+							o := NewHdrPercentileRanksAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "tdigest_percentiles":
+							o := NewTDigestPercentilesAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "tdigest_percentile_ranks":
+							o := NewTDigestPercentileRanksAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "percentiles_bucket":
+							o := NewPercentilesBucketAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "median_absolute_deviation":
+							o := NewMedianAbsoluteDeviationAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "min":
+							o := NewMinAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "max":
+							o := NewMaxAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "sum":
+							o := NewSumAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "avg":
+							o := NewAvgAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "weighted_avg":
+							o := NewWeightedAvgAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "value_count":
+							o := NewValueCountAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "simple_value":
+							o := NewSimpleValueAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "derivative":
+							o := NewDerivativeAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "bucket_metric_value":
+							o := NewBucketMetricValueAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "stats":
+							o := NewStatsAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "stats_bucket":
+							o := NewStatsBucketAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "extended_stats":
+							o := NewExtendedStatsAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "extended_stats_bucket":
+							o := NewExtendedStatsBucketAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "geo_bounds":
+							o := NewGeoBoundsAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "geo_centroid":
+							o := NewGeoCentroidAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "histogram":
+							o := NewHistogramAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "date_histogram":
+							o := NewDateHistogramAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "auto_date_histogram":
+							o := NewAutoDateHistogramAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "variable_width_histogram":
+							o := NewVariableWidthHistogramAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "sterms":
+							o := NewStringTermsAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "lterms":
+							o := NewLongTermsAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "dterms":
+							o := NewDoubleTermsAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "umterms":
+							o := NewUnmappedTermsAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "lrareterms":
+							o := NewLongRareTermsAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "srareterms":
+							o := NewStringRareTermsAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "umrareterms":
+							o := NewUnmappedRareTermsAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "multi_terms":
+							o := NewMultiTermsAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "missing":
+							o := NewMissingAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "nested":
+							o := NewNestedAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "reverse_nested":
+							o := NewReverseNestedAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "global":
+							o := NewGlobalAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "filter":
+							o := NewFilterAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "children":
+							o := NewChildrenAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "parent":
+							o := NewParentAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "sampler":
+							o := NewSamplerAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "unmapped_sampler":
+							o := NewUnmappedSamplerAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "geohash_grid":
+							o := NewGeoHashGridAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "geotile_grid":
+							o := NewGeoTileGridAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "geohex_grid":
+							o := NewGeoHexGridAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "range":
+							o := NewRangeAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "date_range":
+							o := NewDateRangeAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "geo_distance":
+							o := NewGeoDistanceAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "ip_range":
+							o := NewIpRangeAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "ip_prefix":
+							o := NewIpPrefixAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "filters":
+							o := NewFiltersAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "adjacency_matrix":
+							o := NewAdjacencyMatrixAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "siglterms":
+							o := NewSignificantLongTermsAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "sigsterms":
+							o := NewSignificantStringTermsAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "umsigterms":
+							o := NewUnmappedSignificantTermsAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "composite":
+							o := NewCompositeAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "scripted_metric":
+							o := NewScriptedMetricAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "top_hits":
+							o := NewTopHitsAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "inference":
+							o := NewInferenceAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "string_stats":
+							o := NewStringStatsAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "box_plot":
+							o := NewBoxPlotAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "top_metrics":
+							o := NewTopMetricsAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "t_test":
+							o := NewTTestAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "rate":
+							o := NewRateAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "simple_long_value":
+							o := NewCumulativeCardinalityAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "matrix_stats":
+							o := NewMatrixStatsAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "geo_line":
+							o := NewGeoLineAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						default:
+							o := make(map[string]interface{}, 0)
+							if err := dec.Decode(&o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						}
+					} else {
+						return errors.New("cannot decode JSON for field Aggregations")
+					}
+				} else {
+					o := make(map[string]interface{}, 0)
+					if err := dec.Decode(&o); err != nil {
+						return err
+					}
+					s.Aggregations[value] = o
+				}
+			}
 		}
 	}
 	return nil

--- a/typedapi/types/doubletermsbucket.go
+++ b/typedapi/types/doubletermsbucket.go
@@ -55,449 +55,11 @@ func (s *DoubleTermsBucket) UnmarshalJSON(data []byte) error {
 			return err
 		}
 
-		switch t {
+		if _, ok := t.(json.Delim); ok {
+			continue
+		}
 
-		case "aggregations":
-			for dec.More() {
-				tt, err := dec.Token()
-				if err != nil {
-					if errors.Is(err, io.EOF) {
-						break
-					}
-					return err
-				}
-				if value, ok := tt.(string); ok {
-					if strings.Contains(value, "#") {
-						elems := strings.Split(value, "#")
-						if len(elems) == 2 {
-							switch elems[0] {
-							case "cardinality":
-								o := NewCardinalityAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "hdr_percentiles":
-								o := NewHdrPercentilesAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "hdr_percentile_ranks":
-								o := NewHdrPercentileRanksAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "tdigest_percentiles":
-								o := NewTDigestPercentilesAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "tdigest_percentile_ranks":
-								o := NewTDigestPercentileRanksAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "percentiles_bucket":
-								o := NewPercentilesBucketAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "median_absolute_deviation":
-								o := NewMedianAbsoluteDeviationAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "min":
-								o := NewMinAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "max":
-								o := NewMaxAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "sum":
-								o := NewSumAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "avg":
-								o := NewAvgAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "weighted_avg":
-								o := NewWeightedAvgAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "value_count":
-								o := NewValueCountAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "simple_value":
-								o := NewSimpleValueAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "derivative":
-								o := NewDerivativeAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "bucket_metric_value":
-								o := NewBucketMetricValueAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "stats":
-								o := NewStatsAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "stats_bucket":
-								o := NewStatsBucketAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "extended_stats":
-								o := NewExtendedStatsAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "extended_stats_bucket":
-								o := NewExtendedStatsBucketAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "geo_bounds":
-								o := NewGeoBoundsAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "geo_centroid":
-								o := NewGeoCentroidAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "histogram":
-								o := NewHistogramAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "date_histogram":
-								o := NewDateHistogramAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "auto_date_histogram":
-								o := NewAutoDateHistogramAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "variable_width_histogram":
-								o := NewVariableWidthHistogramAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "sterms":
-								o := NewStringTermsAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "lterms":
-								o := NewLongTermsAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "dterms":
-								o := NewDoubleTermsAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "umterms":
-								o := NewUnmappedTermsAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "lrareterms":
-								o := NewLongRareTermsAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "srareterms":
-								o := NewStringRareTermsAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "umrareterms":
-								o := NewUnmappedRareTermsAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "multi_terms":
-								o := NewMultiTermsAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "missing":
-								o := NewMissingAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "nested":
-								o := NewNestedAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "reverse_nested":
-								o := NewReverseNestedAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "global":
-								o := NewGlobalAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "filter":
-								o := NewFilterAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "children":
-								o := NewChildrenAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "parent":
-								o := NewParentAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "sampler":
-								o := NewSamplerAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "unmapped_sampler":
-								o := NewUnmappedSamplerAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "geohash_grid":
-								o := NewGeoHashGridAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "geotile_grid":
-								o := NewGeoTileGridAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "geohex_grid":
-								o := NewGeoHexGridAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "range":
-								o := NewRangeAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "date_range":
-								o := NewDateRangeAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "geo_distance":
-								o := NewGeoDistanceAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "ip_range":
-								o := NewIpRangeAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "ip_prefix":
-								o := NewIpPrefixAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "filters":
-								o := NewFiltersAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "adjacency_matrix":
-								o := NewAdjacencyMatrixAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "siglterms":
-								o := NewSignificantLongTermsAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "sigsterms":
-								o := NewSignificantStringTermsAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "umsigterms":
-								o := NewUnmappedSignificantTermsAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "composite":
-								o := NewCompositeAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "scripted_metric":
-								o := NewScriptedMetricAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "top_hits":
-								o := NewTopHitsAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "inference":
-								o := NewInferenceAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "string_stats":
-								o := NewStringStatsAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "box_plot":
-								o := NewBoxPlotAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "top_metrics":
-								o := NewTopMetricsAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "t_test":
-								o := NewTTestAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "rate":
-								o := NewRateAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "simple_long_value":
-								o := NewCumulativeCardinalityAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "matrix_stats":
-								o := NewMatrixStatsAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "geo_line":
-								o := NewGeoLineAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							default:
-								o := make(map[string]interface{}, 0)
-								if err := dec.Decode(&o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							}
-						} else {
-							return errors.New("cannot decode JSON for field Aggregations")
-						}
-					} else {
-						o := make(map[string]interface{}, 0)
-						if err := dec.Decode(&o); err != nil {
-							return err
-						}
-						s.Aggregations[value] = o
-					}
-				}
-			}
+		switch t {
 
 		case "doc_count":
 			if err := dec.Decode(&s.DocCount); err != nil {
@@ -519,6 +81,442 @@ func (s *DoubleTermsBucket) UnmarshalJSON(data []byte) error {
 				return err
 			}
 
+		default:
+			if value, ok := t.(string); ok {
+				if s.Aggregations == nil {
+					s.Aggregations = make(map[string]Aggregate, 0)
+				}
+
+				if strings.Contains(value, "#") {
+					elems := strings.Split(value, "#")
+					if len(elems) == 2 {
+						switch elems[0] {
+						case "cardinality":
+							o := NewCardinalityAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "hdr_percentiles":
+							o := NewHdrPercentilesAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "hdr_percentile_ranks":
+							o := NewHdrPercentileRanksAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "tdigest_percentiles":
+							o := NewTDigestPercentilesAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "tdigest_percentile_ranks":
+							o := NewTDigestPercentileRanksAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "percentiles_bucket":
+							o := NewPercentilesBucketAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "median_absolute_deviation":
+							o := NewMedianAbsoluteDeviationAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "min":
+							o := NewMinAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "max":
+							o := NewMaxAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "sum":
+							o := NewSumAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "avg":
+							o := NewAvgAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "weighted_avg":
+							o := NewWeightedAvgAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "value_count":
+							o := NewValueCountAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "simple_value":
+							o := NewSimpleValueAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "derivative":
+							o := NewDerivativeAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "bucket_metric_value":
+							o := NewBucketMetricValueAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "stats":
+							o := NewStatsAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "stats_bucket":
+							o := NewStatsBucketAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "extended_stats":
+							o := NewExtendedStatsAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "extended_stats_bucket":
+							o := NewExtendedStatsBucketAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "geo_bounds":
+							o := NewGeoBoundsAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "geo_centroid":
+							o := NewGeoCentroidAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "histogram":
+							o := NewHistogramAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "date_histogram":
+							o := NewDateHistogramAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "auto_date_histogram":
+							o := NewAutoDateHistogramAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "variable_width_histogram":
+							o := NewVariableWidthHistogramAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "sterms":
+							o := NewStringTermsAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "lterms":
+							o := NewLongTermsAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "dterms":
+							o := NewDoubleTermsAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "umterms":
+							o := NewUnmappedTermsAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "lrareterms":
+							o := NewLongRareTermsAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "srareterms":
+							o := NewStringRareTermsAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "umrareterms":
+							o := NewUnmappedRareTermsAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "multi_terms":
+							o := NewMultiTermsAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "missing":
+							o := NewMissingAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "nested":
+							o := NewNestedAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "reverse_nested":
+							o := NewReverseNestedAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "global":
+							o := NewGlobalAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "filter":
+							o := NewFilterAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "children":
+							o := NewChildrenAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "parent":
+							o := NewParentAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "sampler":
+							o := NewSamplerAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "unmapped_sampler":
+							o := NewUnmappedSamplerAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "geohash_grid":
+							o := NewGeoHashGridAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "geotile_grid":
+							o := NewGeoTileGridAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "geohex_grid":
+							o := NewGeoHexGridAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "range":
+							o := NewRangeAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "date_range":
+							o := NewDateRangeAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "geo_distance":
+							o := NewGeoDistanceAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "ip_range":
+							o := NewIpRangeAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "ip_prefix":
+							o := NewIpPrefixAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "filters":
+							o := NewFiltersAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "adjacency_matrix":
+							o := NewAdjacencyMatrixAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "siglterms":
+							o := NewSignificantLongTermsAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "sigsterms":
+							o := NewSignificantStringTermsAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "umsigterms":
+							o := NewUnmappedSignificantTermsAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "composite":
+							o := NewCompositeAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "scripted_metric":
+							o := NewScriptedMetricAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "top_hits":
+							o := NewTopHitsAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "inference":
+							o := NewInferenceAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "string_stats":
+							o := NewStringStatsAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "box_plot":
+							o := NewBoxPlotAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "top_metrics":
+							o := NewTopMetricsAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "t_test":
+							o := NewTTestAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "rate":
+							o := NewRateAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "simple_long_value":
+							o := NewCumulativeCardinalityAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "matrix_stats":
+							o := NewMatrixStatsAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "geo_line":
+							o := NewGeoLineAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						default:
+							o := make(map[string]interface{}, 0)
+							if err := dec.Decode(&o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						}
+					} else {
+						return errors.New("cannot decode JSON for field Aggregations")
+					}
+				} else {
+					o := make(map[string]interface{}, 0)
+					if err := dec.Decode(&o); err != nil {
+						return err
+					}
+					s.Aggregations[value] = o
+				}
+			}
 		}
 	}
 	return nil

--- a/typedapi/types/filtersbucket.go
+++ b/typedapi/types/filtersbucket.go
@@ -52,455 +52,453 @@ func (s *FiltersBucket) UnmarshalJSON(data []byte) error {
 			return err
 		}
 
-		switch t {
+		if _, ok := t.(json.Delim); ok {
+			continue
+		}
 
-		case "aggregations":
-			for dec.More() {
-				tt, err := dec.Token()
-				if err != nil {
-					if errors.Is(err, io.EOF) {
-						break
-					}
-					return err
-				}
-				if value, ok := tt.(string); ok {
-					if strings.Contains(value, "#") {
-						elems := strings.Split(value, "#")
-						if len(elems) == 2 {
-							switch elems[0] {
-							case "cardinality":
-								o := NewCardinalityAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "hdr_percentiles":
-								o := NewHdrPercentilesAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "hdr_percentile_ranks":
-								o := NewHdrPercentileRanksAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "tdigest_percentiles":
-								o := NewTDigestPercentilesAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "tdigest_percentile_ranks":
-								o := NewTDigestPercentileRanksAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "percentiles_bucket":
-								o := NewPercentilesBucketAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "median_absolute_deviation":
-								o := NewMedianAbsoluteDeviationAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "min":
-								o := NewMinAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "max":
-								o := NewMaxAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "sum":
-								o := NewSumAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "avg":
-								o := NewAvgAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "weighted_avg":
-								o := NewWeightedAvgAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "value_count":
-								o := NewValueCountAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "simple_value":
-								o := NewSimpleValueAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "derivative":
-								o := NewDerivativeAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "bucket_metric_value":
-								o := NewBucketMetricValueAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "stats":
-								o := NewStatsAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "stats_bucket":
-								o := NewStatsBucketAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "extended_stats":
-								o := NewExtendedStatsAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "extended_stats_bucket":
-								o := NewExtendedStatsBucketAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "geo_bounds":
-								o := NewGeoBoundsAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "geo_centroid":
-								o := NewGeoCentroidAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "histogram":
-								o := NewHistogramAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "date_histogram":
-								o := NewDateHistogramAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "auto_date_histogram":
-								o := NewAutoDateHistogramAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "variable_width_histogram":
-								o := NewVariableWidthHistogramAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "sterms":
-								o := NewStringTermsAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "lterms":
-								o := NewLongTermsAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "dterms":
-								o := NewDoubleTermsAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "umterms":
-								o := NewUnmappedTermsAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "lrareterms":
-								o := NewLongRareTermsAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "srareterms":
-								o := NewStringRareTermsAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "umrareterms":
-								o := NewUnmappedRareTermsAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "multi_terms":
-								o := NewMultiTermsAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "missing":
-								o := NewMissingAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "nested":
-								o := NewNestedAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "reverse_nested":
-								o := NewReverseNestedAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "global":
-								o := NewGlobalAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "filter":
-								o := NewFilterAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "children":
-								o := NewChildrenAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "parent":
-								o := NewParentAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "sampler":
-								o := NewSamplerAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "unmapped_sampler":
-								o := NewUnmappedSamplerAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "geohash_grid":
-								o := NewGeoHashGridAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "geotile_grid":
-								o := NewGeoTileGridAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "geohex_grid":
-								o := NewGeoHexGridAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "range":
-								o := NewRangeAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "date_range":
-								o := NewDateRangeAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "geo_distance":
-								o := NewGeoDistanceAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "ip_range":
-								o := NewIpRangeAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "ip_prefix":
-								o := NewIpPrefixAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "filters":
-								o := NewFiltersAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "adjacency_matrix":
-								o := NewAdjacencyMatrixAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "siglterms":
-								o := NewSignificantLongTermsAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "sigsterms":
-								o := NewSignificantStringTermsAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "umsigterms":
-								o := NewUnmappedSignificantTermsAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "composite":
-								o := NewCompositeAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "scripted_metric":
-								o := NewScriptedMetricAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "top_hits":
-								o := NewTopHitsAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "inference":
-								o := NewInferenceAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "string_stats":
-								o := NewStringStatsAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "box_plot":
-								o := NewBoxPlotAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "top_metrics":
-								o := NewTopMetricsAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "t_test":
-								o := NewTTestAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "rate":
-								o := NewRateAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "simple_long_value":
-								o := NewCumulativeCardinalityAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "matrix_stats":
-								o := NewMatrixStatsAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "geo_line":
-								o := NewGeoLineAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							default:
-								o := make(map[string]interface{}, 0)
-								if err := dec.Decode(&o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							}
-						} else {
-							return errors.New("cannot decode JSON for field Aggregations")
-						}
-					} else {
-						o := make(map[string]interface{}, 0)
-						if err := dec.Decode(&o); err != nil {
-							return err
-						}
-						s.Aggregations[value] = o
-					}
-				}
-			}
+		switch t {
 
 		case "doc_count":
 			if err := dec.Decode(&s.DocCount); err != nil {
 				return err
 			}
 
+		default:
+			if value, ok := t.(string); ok {
+				if s.Aggregations == nil {
+					s.Aggregations = make(map[string]Aggregate, 0)
+				}
+
+				if strings.Contains(value, "#") {
+					elems := strings.Split(value, "#")
+					if len(elems) == 2 {
+						switch elems[0] {
+						case "cardinality":
+							o := NewCardinalityAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "hdr_percentiles":
+							o := NewHdrPercentilesAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "hdr_percentile_ranks":
+							o := NewHdrPercentileRanksAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "tdigest_percentiles":
+							o := NewTDigestPercentilesAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "tdigest_percentile_ranks":
+							o := NewTDigestPercentileRanksAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "percentiles_bucket":
+							o := NewPercentilesBucketAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "median_absolute_deviation":
+							o := NewMedianAbsoluteDeviationAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "min":
+							o := NewMinAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "max":
+							o := NewMaxAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "sum":
+							o := NewSumAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "avg":
+							o := NewAvgAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "weighted_avg":
+							o := NewWeightedAvgAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "value_count":
+							o := NewValueCountAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "simple_value":
+							o := NewSimpleValueAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "derivative":
+							o := NewDerivativeAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "bucket_metric_value":
+							o := NewBucketMetricValueAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "stats":
+							o := NewStatsAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "stats_bucket":
+							o := NewStatsBucketAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "extended_stats":
+							o := NewExtendedStatsAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "extended_stats_bucket":
+							o := NewExtendedStatsBucketAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "geo_bounds":
+							o := NewGeoBoundsAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "geo_centroid":
+							o := NewGeoCentroidAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "histogram":
+							o := NewHistogramAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "date_histogram":
+							o := NewDateHistogramAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "auto_date_histogram":
+							o := NewAutoDateHistogramAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "variable_width_histogram":
+							o := NewVariableWidthHistogramAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "sterms":
+							o := NewStringTermsAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "lterms":
+							o := NewLongTermsAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "dterms":
+							o := NewDoubleTermsAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "umterms":
+							o := NewUnmappedTermsAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "lrareterms":
+							o := NewLongRareTermsAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "srareterms":
+							o := NewStringRareTermsAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "umrareterms":
+							o := NewUnmappedRareTermsAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "multi_terms":
+							o := NewMultiTermsAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "missing":
+							o := NewMissingAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "nested":
+							o := NewNestedAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "reverse_nested":
+							o := NewReverseNestedAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "global":
+							o := NewGlobalAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "filter":
+							o := NewFilterAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "children":
+							o := NewChildrenAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "parent":
+							o := NewParentAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "sampler":
+							o := NewSamplerAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "unmapped_sampler":
+							o := NewUnmappedSamplerAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "geohash_grid":
+							o := NewGeoHashGridAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "geotile_grid":
+							o := NewGeoTileGridAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "geohex_grid":
+							o := NewGeoHexGridAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "range":
+							o := NewRangeAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "date_range":
+							o := NewDateRangeAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "geo_distance":
+							o := NewGeoDistanceAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "ip_range":
+							o := NewIpRangeAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "ip_prefix":
+							o := NewIpPrefixAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "filters":
+							o := NewFiltersAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "adjacency_matrix":
+							o := NewAdjacencyMatrixAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "siglterms":
+							o := NewSignificantLongTermsAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "sigsterms":
+							o := NewSignificantStringTermsAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "umsigterms":
+							o := NewUnmappedSignificantTermsAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "composite":
+							o := NewCompositeAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "scripted_metric":
+							o := NewScriptedMetricAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "top_hits":
+							o := NewTopHitsAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "inference":
+							o := NewInferenceAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "string_stats":
+							o := NewStringStatsAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "box_plot":
+							o := NewBoxPlotAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "top_metrics":
+							o := NewTopMetricsAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "t_test":
+							o := NewTTestAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "rate":
+							o := NewRateAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "simple_long_value":
+							o := NewCumulativeCardinalityAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "matrix_stats":
+							o := NewMatrixStatsAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "geo_line":
+							o := NewGeoLineAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						default:
+							o := make(map[string]interface{}, 0)
+							if err := dec.Decode(&o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						}
+					} else {
+						return errors.New("cannot decode JSON for field Aggregations")
+					}
+				} else {
+					o := make(map[string]interface{}, 0)
+					if err := dec.Decode(&o); err != nil {
+						return err
+					}
+					s.Aggregations[value] = o
+				}
+			}
 		}
 	}
 	return nil

--- a/typedapi/types/geohashgridbucket.go
+++ b/typedapi/types/geohashgridbucket.go
@@ -53,449 +53,11 @@ func (s *GeoHashGridBucket) UnmarshalJSON(data []byte) error {
 			return err
 		}
 
-		switch t {
+		if _, ok := t.(json.Delim); ok {
+			continue
+		}
 
-		case "aggregations":
-			for dec.More() {
-				tt, err := dec.Token()
-				if err != nil {
-					if errors.Is(err, io.EOF) {
-						break
-					}
-					return err
-				}
-				if value, ok := tt.(string); ok {
-					if strings.Contains(value, "#") {
-						elems := strings.Split(value, "#")
-						if len(elems) == 2 {
-							switch elems[0] {
-							case "cardinality":
-								o := NewCardinalityAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "hdr_percentiles":
-								o := NewHdrPercentilesAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "hdr_percentile_ranks":
-								o := NewHdrPercentileRanksAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "tdigest_percentiles":
-								o := NewTDigestPercentilesAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "tdigest_percentile_ranks":
-								o := NewTDigestPercentileRanksAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "percentiles_bucket":
-								o := NewPercentilesBucketAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "median_absolute_deviation":
-								o := NewMedianAbsoluteDeviationAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "min":
-								o := NewMinAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "max":
-								o := NewMaxAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "sum":
-								o := NewSumAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "avg":
-								o := NewAvgAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "weighted_avg":
-								o := NewWeightedAvgAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "value_count":
-								o := NewValueCountAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "simple_value":
-								o := NewSimpleValueAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "derivative":
-								o := NewDerivativeAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "bucket_metric_value":
-								o := NewBucketMetricValueAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "stats":
-								o := NewStatsAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "stats_bucket":
-								o := NewStatsBucketAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "extended_stats":
-								o := NewExtendedStatsAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "extended_stats_bucket":
-								o := NewExtendedStatsBucketAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "geo_bounds":
-								o := NewGeoBoundsAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "geo_centroid":
-								o := NewGeoCentroidAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "histogram":
-								o := NewHistogramAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "date_histogram":
-								o := NewDateHistogramAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "auto_date_histogram":
-								o := NewAutoDateHistogramAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "variable_width_histogram":
-								o := NewVariableWidthHistogramAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "sterms":
-								o := NewStringTermsAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "lterms":
-								o := NewLongTermsAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "dterms":
-								o := NewDoubleTermsAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "umterms":
-								o := NewUnmappedTermsAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "lrareterms":
-								o := NewLongRareTermsAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "srareterms":
-								o := NewStringRareTermsAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "umrareterms":
-								o := NewUnmappedRareTermsAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "multi_terms":
-								o := NewMultiTermsAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "missing":
-								o := NewMissingAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "nested":
-								o := NewNestedAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "reverse_nested":
-								o := NewReverseNestedAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "global":
-								o := NewGlobalAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "filter":
-								o := NewFilterAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "children":
-								o := NewChildrenAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "parent":
-								o := NewParentAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "sampler":
-								o := NewSamplerAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "unmapped_sampler":
-								o := NewUnmappedSamplerAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "geohash_grid":
-								o := NewGeoHashGridAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "geotile_grid":
-								o := NewGeoTileGridAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "geohex_grid":
-								o := NewGeoHexGridAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "range":
-								o := NewRangeAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "date_range":
-								o := NewDateRangeAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "geo_distance":
-								o := NewGeoDistanceAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "ip_range":
-								o := NewIpRangeAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "ip_prefix":
-								o := NewIpPrefixAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "filters":
-								o := NewFiltersAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "adjacency_matrix":
-								o := NewAdjacencyMatrixAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "siglterms":
-								o := NewSignificantLongTermsAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "sigsterms":
-								o := NewSignificantStringTermsAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "umsigterms":
-								o := NewUnmappedSignificantTermsAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "composite":
-								o := NewCompositeAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "scripted_metric":
-								o := NewScriptedMetricAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "top_hits":
-								o := NewTopHitsAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "inference":
-								o := NewInferenceAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "string_stats":
-								o := NewStringStatsAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "box_plot":
-								o := NewBoxPlotAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "top_metrics":
-								o := NewTopMetricsAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "t_test":
-								o := NewTTestAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "rate":
-								o := NewRateAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "simple_long_value":
-								o := NewCumulativeCardinalityAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "matrix_stats":
-								o := NewMatrixStatsAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "geo_line":
-								o := NewGeoLineAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							default:
-								o := make(map[string]interface{}, 0)
-								if err := dec.Decode(&o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							}
-						} else {
-							return errors.New("cannot decode JSON for field Aggregations")
-						}
-					} else {
-						o := make(map[string]interface{}, 0)
-						if err := dec.Decode(&o); err != nil {
-							return err
-						}
-						s.Aggregations[value] = o
-					}
-				}
-			}
+		switch t {
 
 		case "doc_count":
 			if err := dec.Decode(&s.DocCount); err != nil {
@@ -507,6 +69,442 @@ func (s *GeoHashGridBucket) UnmarshalJSON(data []byte) error {
 				return err
 			}
 
+		default:
+			if value, ok := t.(string); ok {
+				if s.Aggregations == nil {
+					s.Aggregations = make(map[string]Aggregate, 0)
+				}
+
+				if strings.Contains(value, "#") {
+					elems := strings.Split(value, "#")
+					if len(elems) == 2 {
+						switch elems[0] {
+						case "cardinality":
+							o := NewCardinalityAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "hdr_percentiles":
+							o := NewHdrPercentilesAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "hdr_percentile_ranks":
+							o := NewHdrPercentileRanksAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "tdigest_percentiles":
+							o := NewTDigestPercentilesAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "tdigest_percentile_ranks":
+							o := NewTDigestPercentileRanksAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "percentiles_bucket":
+							o := NewPercentilesBucketAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "median_absolute_deviation":
+							o := NewMedianAbsoluteDeviationAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "min":
+							o := NewMinAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "max":
+							o := NewMaxAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "sum":
+							o := NewSumAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "avg":
+							o := NewAvgAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "weighted_avg":
+							o := NewWeightedAvgAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "value_count":
+							o := NewValueCountAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "simple_value":
+							o := NewSimpleValueAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "derivative":
+							o := NewDerivativeAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "bucket_metric_value":
+							o := NewBucketMetricValueAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "stats":
+							o := NewStatsAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "stats_bucket":
+							o := NewStatsBucketAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "extended_stats":
+							o := NewExtendedStatsAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "extended_stats_bucket":
+							o := NewExtendedStatsBucketAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "geo_bounds":
+							o := NewGeoBoundsAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "geo_centroid":
+							o := NewGeoCentroidAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "histogram":
+							o := NewHistogramAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "date_histogram":
+							o := NewDateHistogramAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "auto_date_histogram":
+							o := NewAutoDateHistogramAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "variable_width_histogram":
+							o := NewVariableWidthHistogramAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "sterms":
+							o := NewStringTermsAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "lterms":
+							o := NewLongTermsAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "dterms":
+							o := NewDoubleTermsAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "umterms":
+							o := NewUnmappedTermsAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "lrareterms":
+							o := NewLongRareTermsAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "srareterms":
+							o := NewStringRareTermsAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "umrareterms":
+							o := NewUnmappedRareTermsAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "multi_terms":
+							o := NewMultiTermsAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "missing":
+							o := NewMissingAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "nested":
+							o := NewNestedAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "reverse_nested":
+							o := NewReverseNestedAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "global":
+							o := NewGlobalAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "filter":
+							o := NewFilterAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "children":
+							o := NewChildrenAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "parent":
+							o := NewParentAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "sampler":
+							o := NewSamplerAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "unmapped_sampler":
+							o := NewUnmappedSamplerAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "geohash_grid":
+							o := NewGeoHashGridAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "geotile_grid":
+							o := NewGeoTileGridAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "geohex_grid":
+							o := NewGeoHexGridAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "range":
+							o := NewRangeAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "date_range":
+							o := NewDateRangeAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "geo_distance":
+							o := NewGeoDistanceAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "ip_range":
+							o := NewIpRangeAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "ip_prefix":
+							o := NewIpPrefixAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "filters":
+							o := NewFiltersAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "adjacency_matrix":
+							o := NewAdjacencyMatrixAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "siglterms":
+							o := NewSignificantLongTermsAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "sigsterms":
+							o := NewSignificantStringTermsAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "umsigterms":
+							o := NewUnmappedSignificantTermsAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "composite":
+							o := NewCompositeAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "scripted_metric":
+							o := NewScriptedMetricAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "top_hits":
+							o := NewTopHitsAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "inference":
+							o := NewInferenceAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "string_stats":
+							o := NewStringStatsAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "box_plot":
+							o := NewBoxPlotAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "top_metrics":
+							o := NewTopMetricsAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "t_test":
+							o := NewTTestAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "rate":
+							o := NewRateAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "simple_long_value":
+							o := NewCumulativeCardinalityAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "matrix_stats":
+							o := NewMatrixStatsAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "geo_line":
+							o := NewGeoLineAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						default:
+							o := make(map[string]interface{}, 0)
+							if err := dec.Decode(&o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						}
+					} else {
+						return errors.New("cannot decode JSON for field Aggregations")
+					}
+				} else {
+					o := make(map[string]interface{}, 0)
+					if err := dec.Decode(&o); err != nil {
+						return err
+					}
+					s.Aggregations[value] = o
+				}
+			}
 		}
 	}
 	return nil

--- a/typedapi/types/geohexgridbucket.go
+++ b/typedapi/types/geohexgridbucket.go
@@ -53,449 +53,11 @@ func (s *GeoHexGridBucket) UnmarshalJSON(data []byte) error {
 			return err
 		}
 
-		switch t {
+		if _, ok := t.(json.Delim); ok {
+			continue
+		}
 
-		case "aggregations":
-			for dec.More() {
-				tt, err := dec.Token()
-				if err != nil {
-					if errors.Is(err, io.EOF) {
-						break
-					}
-					return err
-				}
-				if value, ok := tt.(string); ok {
-					if strings.Contains(value, "#") {
-						elems := strings.Split(value, "#")
-						if len(elems) == 2 {
-							switch elems[0] {
-							case "cardinality":
-								o := NewCardinalityAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "hdr_percentiles":
-								o := NewHdrPercentilesAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "hdr_percentile_ranks":
-								o := NewHdrPercentileRanksAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "tdigest_percentiles":
-								o := NewTDigestPercentilesAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "tdigest_percentile_ranks":
-								o := NewTDigestPercentileRanksAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "percentiles_bucket":
-								o := NewPercentilesBucketAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "median_absolute_deviation":
-								o := NewMedianAbsoluteDeviationAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "min":
-								o := NewMinAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "max":
-								o := NewMaxAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "sum":
-								o := NewSumAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "avg":
-								o := NewAvgAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "weighted_avg":
-								o := NewWeightedAvgAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "value_count":
-								o := NewValueCountAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "simple_value":
-								o := NewSimpleValueAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "derivative":
-								o := NewDerivativeAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "bucket_metric_value":
-								o := NewBucketMetricValueAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "stats":
-								o := NewStatsAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "stats_bucket":
-								o := NewStatsBucketAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "extended_stats":
-								o := NewExtendedStatsAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "extended_stats_bucket":
-								o := NewExtendedStatsBucketAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "geo_bounds":
-								o := NewGeoBoundsAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "geo_centroid":
-								o := NewGeoCentroidAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "histogram":
-								o := NewHistogramAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "date_histogram":
-								o := NewDateHistogramAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "auto_date_histogram":
-								o := NewAutoDateHistogramAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "variable_width_histogram":
-								o := NewVariableWidthHistogramAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "sterms":
-								o := NewStringTermsAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "lterms":
-								o := NewLongTermsAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "dterms":
-								o := NewDoubleTermsAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "umterms":
-								o := NewUnmappedTermsAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "lrareterms":
-								o := NewLongRareTermsAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "srareterms":
-								o := NewStringRareTermsAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "umrareterms":
-								o := NewUnmappedRareTermsAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "multi_terms":
-								o := NewMultiTermsAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "missing":
-								o := NewMissingAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "nested":
-								o := NewNestedAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "reverse_nested":
-								o := NewReverseNestedAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "global":
-								o := NewGlobalAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "filter":
-								o := NewFilterAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "children":
-								o := NewChildrenAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "parent":
-								o := NewParentAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "sampler":
-								o := NewSamplerAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "unmapped_sampler":
-								o := NewUnmappedSamplerAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "geohash_grid":
-								o := NewGeoHashGridAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "geotile_grid":
-								o := NewGeoTileGridAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "geohex_grid":
-								o := NewGeoHexGridAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "range":
-								o := NewRangeAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "date_range":
-								o := NewDateRangeAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "geo_distance":
-								o := NewGeoDistanceAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "ip_range":
-								o := NewIpRangeAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "ip_prefix":
-								o := NewIpPrefixAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "filters":
-								o := NewFiltersAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "adjacency_matrix":
-								o := NewAdjacencyMatrixAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "siglterms":
-								o := NewSignificantLongTermsAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "sigsterms":
-								o := NewSignificantStringTermsAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "umsigterms":
-								o := NewUnmappedSignificantTermsAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "composite":
-								o := NewCompositeAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "scripted_metric":
-								o := NewScriptedMetricAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "top_hits":
-								o := NewTopHitsAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "inference":
-								o := NewInferenceAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "string_stats":
-								o := NewStringStatsAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "box_plot":
-								o := NewBoxPlotAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "top_metrics":
-								o := NewTopMetricsAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "t_test":
-								o := NewTTestAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "rate":
-								o := NewRateAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "simple_long_value":
-								o := NewCumulativeCardinalityAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "matrix_stats":
-								o := NewMatrixStatsAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "geo_line":
-								o := NewGeoLineAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							default:
-								o := make(map[string]interface{}, 0)
-								if err := dec.Decode(&o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							}
-						} else {
-							return errors.New("cannot decode JSON for field Aggregations")
-						}
-					} else {
-						o := make(map[string]interface{}, 0)
-						if err := dec.Decode(&o); err != nil {
-							return err
-						}
-						s.Aggregations[value] = o
-					}
-				}
-			}
+		switch t {
 
 		case "doc_count":
 			if err := dec.Decode(&s.DocCount); err != nil {
@@ -507,6 +69,442 @@ func (s *GeoHexGridBucket) UnmarshalJSON(data []byte) error {
 				return err
 			}
 
+		default:
+			if value, ok := t.(string); ok {
+				if s.Aggregations == nil {
+					s.Aggregations = make(map[string]Aggregate, 0)
+				}
+
+				if strings.Contains(value, "#") {
+					elems := strings.Split(value, "#")
+					if len(elems) == 2 {
+						switch elems[0] {
+						case "cardinality":
+							o := NewCardinalityAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "hdr_percentiles":
+							o := NewHdrPercentilesAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "hdr_percentile_ranks":
+							o := NewHdrPercentileRanksAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "tdigest_percentiles":
+							o := NewTDigestPercentilesAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "tdigest_percentile_ranks":
+							o := NewTDigestPercentileRanksAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "percentiles_bucket":
+							o := NewPercentilesBucketAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "median_absolute_deviation":
+							o := NewMedianAbsoluteDeviationAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "min":
+							o := NewMinAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "max":
+							o := NewMaxAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "sum":
+							o := NewSumAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "avg":
+							o := NewAvgAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "weighted_avg":
+							o := NewWeightedAvgAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "value_count":
+							o := NewValueCountAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "simple_value":
+							o := NewSimpleValueAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "derivative":
+							o := NewDerivativeAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "bucket_metric_value":
+							o := NewBucketMetricValueAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "stats":
+							o := NewStatsAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "stats_bucket":
+							o := NewStatsBucketAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "extended_stats":
+							o := NewExtendedStatsAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "extended_stats_bucket":
+							o := NewExtendedStatsBucketAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "geo_bounds":
+							o := NewGeoBoundsAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "geo_centroid":
+							o := NewGeoCentroidAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "histogram":
+							o := NewHistogramAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "date_histogram":
+							o := NewDateHistogramAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "auto_date_histogram":
+							o := NewAutoDateHistogramAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "variable_width_histogram":
+							o := NewVariableWidthHistogramAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "sterms":
+							o := NewStringTermsAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "lterms":
+							o := NewLongTermsAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "dterms":
+							o := NewDoubleTermsAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "umterms":
+							o := NewUnmappedTermsAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "lrareterms":
+							o := NewLongRareTermsAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "srareterms":
+							o := NewStringRareTermsAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "umrareterms":
+							o := NewUnmappedRareTermsAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "multi_terms":
+							o := NewMultiTermsAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "missing":
+							o := NewMissingAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "nested":
+							o := NewNestedAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "reverse_nested":
+							o := NewReverseNestedAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "global":
+							o := NewGlobalAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "filter":
+							o := NewFilterAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "children":
+							o := NewChildrenAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "parent":
+							o := NewParentAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "sampler":
+							o := NewSamplerAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "unmapped_sampler":
+							o := NewUnmappedSamplerAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "geohash_grid":
+							o := NewGeoHashGridAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "geotile_grid":
+							o := NewGeoTileGridAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "geohex_grid":
+							o := NewGeoHexGridAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "range":
+							o := NewRangeAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "date_range":
+							o := NewDateRangeAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "geo_distance":
+							o := NewGeoDistanceAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "ip_range":
+							o := NewIpRangeAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "ip_prefix":
+							o := NewIpPrefixAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "filters":
+							o := NewFiltersAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "adjacency_matrix":
+							o := NewAdjacencyMatrixAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "siglterms":
+							o := NewSignificantLongTermsAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "sigsterms":
+							o := NewSignificantStringTermsAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "umsigterms":
+							o := NewUnmappedSignificantTermsAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "composite":
+							o := NewCompositeAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "scripted_metric":
+							o := NewScriptedMetricAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "top_hits":
+							o := NewTopHitsAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "inference":
+							o := NewInferenceAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "string_stats":
+							o := NewStringStatsAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "box_plot":
+							o := NewBoxPlotAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "top_metrics":
+							o := NewTopMetricsAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "t_test":
+							o := NewTTestAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "rate":
+							o := NewRateAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "simple_long_value":
+							o := NewCumulativeCardinalityAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "matrix_stats":
+							o := NewMatrixStatsAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "geo_line":
+							o := NewGeoLineAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						default:
+							o := make(map[string]interface{}, 0)
+							if err := dec.Decode(&o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						}
+					} else {
+						return errors.New("cannot decode JSON for field Aggregations")
+					}
+				} else {
+					o := make(map[string]interface{}, 0)
+					if err := dec.Decode(&o); err != nil {
+						return err
+					}
+					s.Aggregations[value] = o
+				}
+			}
 		}
 	}
 	return nil

--- a/typedapi/types/geotilegridbucket.go
+++ b/typedapi/types/geotilegridbucket.go
@@ -53,449 +53,11 @@ func (s *GeoTileGridBucket) UnmarshalJSON(data []byte) error {
 			return err
 		}
 
-		switch t {
+		if _, ok := t.(json.Delim); ok {
+			continue
+		}
 
-		case "aggregations":
-			for dec.More() {
-				tt, err := dec.Token()
-				if err != nil {
-					if errors.Is(err, io.EOF) {
-						break
-					}
-					return err
-				}
-				if value, ok := tt.(string); ok {
-					if strings.Contains(value, "#") {
-						elems := strings.Split(value, "#")
-						if len(elems) == 2 {
-							switch elems[0] {
-							case "cardinality":
-								o := NewCardinalityAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "hdr_percentiles":
-								o := NewHdrPercentilesAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "hdr_percentile_ranks":
-								o := NewHdrPercentileRanksAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "tdigest_percentiles":
-								o := NewTDigestPercentilesAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "tdigest_percentile_ranks":
-								o := NewTDigestPercentileRanksAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "percentiles_bucket":
-								o := NewPercentilesBucketAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "median_absolute_deviation":
-								o := NewMedianAbsoluteDeviationAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "min":
-								o := NewMinAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "max":
-								o := NewMaxAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "sum":
-								o := NewSumAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "avg":
-								o := NewAvgAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "weighted_avg":
-								o := NewWeightedAvgAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "value_count":
-								o := NewValueCountAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "simple_value":
-								o := NewSimpleValueAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "derivative":
-								o := NewDerivativeAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "bucket_metric_value":
-								o := NewBucketMetricValueAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "stats":
-								o := NewStatsAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "stats_bucket":
-								o := NewStatsBucketAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "extended_stats":
-								o := NewExtendedStatsAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "extended_stats_bucket":
-								o := NewExtendedStatsBucketAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "geo_bounds":
-								o := NewGeoBoundsAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "geo_centroid":
-								o := NewGeoCentroidAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "histogram":
-								o := NewHistogramAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "date_histogram":
-								o := NewDateHistogramAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "auto_date_histogram":
-								o := NewAutoDateHistogramAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "variable_width_histogram":
-								o := NewVariableWidthHistogramAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "sterms":
-								o := NewStringTermsAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "lterms":
-								o := NewLongTermsAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "dterms":
-								o := NewDoubleTermsAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "umterms":
-								o := NewUnmappedTermsAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "lrareterms":
-								o := NewLongRareTermsAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "srareterms":
-								o := NewStringRareTermsAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "umrareterms":
-								o := NewUnmappedRareTermsAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "multi_terms":
-								o := NewMultiTermsAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "missing":
-								o := NewMissingAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "nested":
-								o := NewNestedAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "reverse_nested":
-								o := NewReverseNestedAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "global":
-								o := NewGlobalAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "filter":
-								o := NewFilterAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "children":
-								o := NewChildrenAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "parent":
-								o := NewParentAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "sampler":
-								o := NewSamplerAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "unmapped_sampler":
-								o := NewUnmappedSamplerAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "geohash_grid":
-								o := NewGeoHashGridAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "geotile_grid":
-								o := NewGeoTileGridAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "geohex_grid":
-								o := NewGeoHexGridAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "range":
-								o := NewRangeAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "date_range":
-								o := NewDateRangeAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "geo_distance":
-								o := NewGeoDistanceAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "ip_range":
-								o := NewIpRangeAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "ip_prefix":
-								o := NewIpPrefixAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "filters":
-								o := NewFiltersAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "adjacency_matrix":
-								o := NewAdjacencyMatrixAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "siglterms":
-								o := NewSignificantLongTermsAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "sigsterms":
-								o := NewSignificantStringTermsAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "umsigterms":
-								o := NewUnmappedSignificantTermsAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "composite":
-								o := NewCompositeAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "scripted_metric":
-								o := NewScriptedMetricAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "top_hits":
-								o := NewTopHitsAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "inference":
-								o := NewInferenceAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "string_stats":
-								o := NewStringStatsAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "box_plot":
-								o := NewBoxPlotAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "top_metrics":
-								o := NewTopMetricsAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "t_test":
-								o := NewTTestAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "rate":
-								o := NewRateAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "simple_long_value":
-								o := NewCumulativeCardinalityAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "matrix_stats":
-								o := NewMatrixStatsAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "geo_line":
-								o := NewGeoLineAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							default:
-								o := make(map[string]interface{}, 0)
-								if err := dec.Decode(&o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							}
-						} else {
-							return errors.New("cannot decode JSON for field Aggregations")
-						}
-					} else {
-						o := make(map[string]interface{}, 0)
-						if err := dec.Decode(&o); err != nil {
-							return err
-						}
-						s.Aggregations[value] = o
-					}
-				}
-			}
+		switch t {
 
 		case "doc_count":
 			if err := dec.Decode(&s.DocCount); err != nil {
@@ -507,6 +69,442 @@ func (s *GeoTileGridBucket) UnmarshalJSON(data []byte) error {
 				return err
 			}
 
+		default:
+			if value, ok := t.(string); ok {
+				if s.Aggregations == nil {
+					s.Aggregations = make(map[string]Aggregate, 0)
+				}
+
+				if strings.Contains(value, "#") {
+					elems := strings.Split(value, "#")
+					if len(elems) == 2 {
+						switch elems[0] {
+						case "cardinality":
+							o := NewCardinalityAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "hdr_percentiles":
+							o := NewHdrPercentilesAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "hdr_percentile_ranks":
+							o := NewHdrPercentileRanksAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "tdigest_percentiles":
+							o := NewTDigestPercentilesAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "tdigest_percentile_ranks":
+							o := NewTDigestPercentileRanksAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "percentiles_bucket":
+							o := NewPercentilesBucketAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "median_absolute_deviation":
+							o := NewMedianAbsoluteDeviationAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "min":
+							o := NewMinAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "max":
+							o := NewMaxAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "sum":
+							o := NewSumAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "avg":
+							o := NewAvgAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "weighted_avg":
+							o := NewWeightedAvgAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "value_count":
+							o := NewValueCountAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "simple_value":
+							o := NewSimpleValueAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "derivative":
+							o := NewDerivativeAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "bucket_metric_value":
+							o := NewBucketMetricValueAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "stats":
+							o := NewStatsAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "stats_bucket":
+							o := NewStatsBucketAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "extended_stats":
+							o := NewExtendedStatsAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "extended_stats_bucket":
+							o := NewExtendedStatsBucketAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "geo_bounds":
+							o := NewGeoBoundsAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "geo_centroid":
+							o := NewGeoCentroidAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "histogram":
+							o := NewHistogramAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "date_histogram":
+							o := NewDateHistogramAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "auto_date_histogram":
+							o := NewAutoDateHistogramAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "variable_width_histogram":
+							o := NewVariableWidthHistogramAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "sterms":
+							o := NewStringTermsAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "lterms":
+							o := NewLongTermsAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "dterms":
+							o := NewDoubleTermsAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "umterms":
+							o := NewUnmappedTermsAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "lrareterms":
+							o := NewLongRareTermsAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "srareterms":
+							o := NewStringRareTermsAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "umrareterms":
+							o := NewUnmappedRareTermsAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "multi_terms":
+							o := NewMultiTermsAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "missing":
+							o := NewMissingAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "nested":
+							o := NewNestedAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "reverse_nested":
+							o := NewReverseNestedAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "global":
+							o := NewGlobalAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "filter":
+							o := NewFilterAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "children":
+							o := NewChildrenAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "parent":
+							o := NewParentAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "sampler":
+							o := NewSamplerAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "unmapped_sampler":
+							o := NewUnmappedSamplerAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "geohash_grid":
+							o := NewGeoHashGridAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "geotile_grid":
+							o := NewGeoTileGridAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "geohex_grid":
+							o := NewGeoHexGridAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "range":
+							o := NewRangeAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "date_range":
+							o := NewDateRangeAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "geo_distance":
+							o := NewGeoDistanceAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "ip_range":
+							o := NewIpRangeAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "ip_prefix":
+							o := NewIpPrefixAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "filters":
+							o := NewFiltersAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "adjacency_matrix":
+							o := NewAdjacencyMatrixAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "siglterms":
+							o := NewSignificantLongTermsAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "sigsterms":
+							o := NewSignificantStringTermsAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "umsigterms":
+							o := NewUnmappedSignificantTermsAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "composite":
+							o := NewCompositeAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "scripted_metric":
+							o := NewScriptedMetricAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "top_hits":
+							o := NewTopHitsAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "inference":
+							o := NewInferenceAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "string_stats":
+							o := NewStringStatsAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "box_plot":
+							o := NewBoxPlotAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "top_metrics":
+							o := NewTopMetricsAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "t_test":
+							o := NewTTestAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "rate":
+							o := NewRateAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "simple_long_value":
+							o := NewCumulativeCardinalityAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "matrix_stats":
+							o := NewMatrixStatsAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "geo_line":
+							o := NewGeoLineAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						default:
+							o := make(map[string]interface{}, 0)
+							if err := dec.Decode(&o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						}
+					} else {
+						return errors.New("cannot decode JSON for field Aggregations")
+					}
+				} else {
+					o := make(map[string]interface{}, 0)
+					if err := dec.Decode(&o); err != nil {
+						return err
+					}
+					s.Aggregations[value] = o
+				}
+			}
 		}
 	}
 	return nil

--- a/typedapi/types/histogrambucket.go
+++ b/typedapi/types/histogrambucket.go
@@ -54,449 +54,11 @@ func (s *HistogramBucket) UnmarshalJSON(data []byte) error {
 			return err
 		}
 
-		switch t {
+		if _, ok := t.(json.Delim); ok {
+			continue
+		}
 
-		case "aggregations":
-			for dec.More() {
-				tt, err := dec.Token()
-				if err != nil {
-					if errors.Is(err, io.EOF) {
-						break
-					}
-					return err
-				}
-				if value, ok := tt.(string); ok {
-					if strings.Contains(value, "#") {
-						elems := strings.Split(value, "#")
-						if len(elems) == 2 {
-							switch elems[0] {
-							case "cardinality":
-								o := NewCardinalityAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "hdr_percentiles":
-								o := NewHdrPercentilesAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "hdr_percentile_ranks":
-								o := NewHdrPercentileRanksAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "tdigest_percentiles":
-								o := NewTDigestPercentilesAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "tdigest_percentile_ranks":
-								o := NewTDigestPercentileRanksAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "percentiles_bucket":
-								o := NewPercentilesBucketAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "median_absolute_deviation":
-								o := NewMedianAbsoluteDeviationAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "min":
-								o := NewMinAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "max":
-								o := NewMaxAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "sum":
-								o := NewSumAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "avg":
-								o := NewAvgAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "weighted_avg":
-								o := NewWeightedAvgAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "value_count":
-								o := NewValueCountAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "simple_value":
-								o := NewSimpleValueAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "derivative":
-								o := NewDerivativeAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "bucket_metric_value":
-								o := NewBucketMetricValueAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "stats":
-								o := NewStatsAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "stats_bucket":
-								o := NewStatsBucketAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "extended_stats":
-								o := NewExtendedStatsAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "extended_stats_bucket":
-								o := NewExtendedStatsBucketAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "geo_bounds":
-								o := NewGeoBoundsAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "geo_centroid":
-								o := NewGeoCentroidAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "histogram":
-								o := NewHistogramAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "date_histogram":
-								o := NewDateHistogramAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "auto_date_histogram":
-								o := NewAutoDateHistogramAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "variable_width_histogram":
-								o := NewVariableWidthHistogramAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "sterms":
-								o := NewStringTermsAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "lterms":
-								o := NewLongTermsAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "dterms":
-								o := NewDoubleTermsAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "umterms":
-								o := NewUnmappedTermsAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "lrareterms":
-								o := NewLongRareTermsAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "srareterms":
-								o := NewStringRareTermsAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "umrareterms":
-								o := NewUnmappedRareTermsAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "multi_terms":
-								o := NewMultiTermsAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "missing":
-								o := NewMissingAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "nested":
-								o := NewNestedAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "reverse_nested":
-								o := NewReverseNestedAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "global":
-								o := NewGlobalAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "filter":
-								o := NewFilterAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "children":
-								o := NewChildrenAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "parent":
-								o := NewParentAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "sampler":
-								o := NewSamplerAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "unmapped_sampler":
-								o := NewUnmappedSamplerAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "geohash_grid":
-								o := NewGeoHashGridAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "geotile_grid":
-								o := NewGeoTileGridAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "geohex_grid":
-								o := NewGeoHexGridAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "range":
-								o := NewRangeAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "date_range":
-								o := NewDateRangeAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "geo_distance":
-								o := NewGeoDistanceAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "ip_range":
-								o := NewIpRangeAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "ip_prefix":
-								o := NewIpPrefixAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "filters":
-								o := NewFiltersAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "adjacency_matrix":
-								o := NewAdjacencyMatrixAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "siglterms":
-								o := NewSignificantLongTermsAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "sigsterms":
-								o := NewSignificantStringTermsAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "umsigterms":
-								o := NewUnmappedSignificantTermsAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "composite":
-								o := NewCompositeAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "scripted_metric":
-								o := NewScriptedMetricAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "top_hits":
-								o := NewTopHitsAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "inference":
-								o := NewInferenceAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "string_stats":
-								o := NewStringStatsAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "box_plot":
-								o := NewBoxPlotAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "top_metrics":
-								o := NewTopMetricsAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "t_test":
-								o := NewTTestAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "rate":
-								o := NewRateAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "simple_long_value":
-								o := NewCumulativeCardinalityAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "matrix_stats":
-								o := NewMatrixStatsAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "geo_line":
-								o := NewGeoLineAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							default:
-								o := make(map[string]interface{}, 0)
-								if err := dec.Decode(&o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							}
-						} else {
-							return errors.New("cannot decode JSON for field Aggregations")
-						}
-					} else {
-						o := make(map[string]interface{}, 0)
-						if err := dec.Decode(&o); err != nil {
-							return err
-						}
-						s.Aggregations[value] = o
-					}
-				}
-			}
+		switch t {
 
 		case "doc_count":
 			if err := dec.Decode(&s.DocCount); err != nil {
@@ -513,6 +75,442 @@ func (s *HistogramBucket) UnmarshalJSON(data []byte) error {
 				return err
 			}
 
+		default:
+			if value, ok := t.(string); ok {
+				if s.Aggregations == nil {
+					s.Aggregations = make(map[string]Aggregate, 0)
+				}
+
+				if strings.Contains(value, "#") {
+					elems := strings.Split(value, "#")
+					if len(elems) == 2 {
+						switch elems[0] {
+						case "cardinality":
+							o := NewCardinalityAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "hdr_percentiles":
+							o := NewHdrPercentilesAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "hdr_percentile_ranks":
+							o := NewHdrPercentileRanksAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "tdigest_percentiles":
+							o := NewTDigestPercentilesAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "tdigest_percentile_ranks":
+							o := NewTDigestPercentileRanksAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "percentiles_bucket":
+							o := NewPercentilesBucketAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "median_absolute_deviation":
+							o := NewMedianAbsoluteDeviationAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "min":
+							o := NewMinAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "max":
+							o := NewMaxAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "sum":
+							o := NewSumAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "avg":
+							o := NewAvgAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "weighted_avg":
+							o := NewWeightedAvgAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "value_count":
+							o := NewValueCountAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "simple_value":
+							o := NewSimpleValueAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "derivative":
+							o := NewDerivativeAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "bucket_metric_value":
+							o := NewBucketMetricValueAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "stats":
+							o := NewStatsAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "stats_bucket":
+							o := NewStatsBucketAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "extended_stats":
+							o := NewExtendedStatsAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "extended_stats_bucket":
+							o := NewExtendedStatsBucketAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "geo_bounds":
+							o := NewGeoBoundsAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "geo_centroid":
+							o := NewGeoCentroidAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "histogram":
+							o := NewHistogramAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "date_histogram":
+							o := NewDateHistogramAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "auto_date_histogram":
+							o := NewAutoDateHistogramAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "variable_width_histogram":
+							o := NewVariableWidthHistogramAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "sterms":
+							o := NewStringTermsAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "lterms":
+							o := NewLongTermsAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "dterms":
+							o := NewDoubleTermsAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "umterms":
+							o := NewUnmappedTermsAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "lrareterms":
+							o := NewLongRareTermsAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "srareterms":
+							o := NewStringRareTermsAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "umrareterms":
+							o := NewUnmappedRareTermsAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "multi_terms":
+							o := NewMultiTermsAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "missing":
+							o := NewMissingAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "nested":
+							o := NewNestedAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "reverse_nested":
+							o := NewReverseNestedAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "global":
+							o := NewGlobalAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "filter":
+							o := NewFilterAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "children":
+							o := NewChildrenAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "parent":
+							o := NewParentAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "sampler":
+							o := NewSamplerAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "unmapped_sampler":
+							o := NewUnmappedSamplerAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "geohash_grid":
+							o := NewGeoHashGridAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "geotile_grid":
+							o := NewGeoTileGridAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "geohex_grid":
+							o := NewGeoHexGridAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "range":
+							o := NewRangeAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "date_range":
+							o := NewDateRangeAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "geo_distance":
+							o := NewGeoDistanceAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "ip_range":
+							o := NewIpRangeAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "ip_prefix":
+							o := NewIpPrefixAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "filters":
+							o := NewFiltersAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "adjacency_matrix":
+							o := NewAdjacencyMatrixAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "siglterms":
+							o := NewSignificantLongTermsAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "sigsterms":
+							o := NewSignificantStringTermsAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "umsigterms":
+							o := NewUnmappedSignificantTermsAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "composite":
+							o := NewCompositeAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "scripted_metric":
+							o := NewScriptedMetricAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "top_hits":
+							o := NewTopHitsAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "inference":
+							o := NewInferenceAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "string_stats":
+							o := NewStringStatsAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "box_plot":
+							o := NewBoxPlotAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "top_metrics":
+							o := NewTopMetricsAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "t_test":
+							o := NewTTestAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "rate":
+							o := NewRateAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "simple_long_value":
+							o := NewCumulativeCardinalityAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "matrix_stats":
+							o := NewMatrixStatsAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "geo_line":
+							o := NewGeoLineAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						default:
+							o := make(map[string]interface{}, 0)
+							if err := dec.Decode(&o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						}
+					} else {
+						return errors.New("cannot decode JSON for field Aggregations")
+					}
+				} else {
+					o := make(map[string]interface{}, 0)
+					if err := dec.Decode(&o); err != nil {
+						return err
+					}
+					s.Aggregations[value] = o
+				}
+			}
 		}
 	}
 	return nil

--- a/typedapi/types/ipprefixbucket.go
+++ b/typedapi/types/ipprefixbucket.go
@@ -56,449 +56,11 @@ func (s *IpPrefixBucket) UnmarshalJSON(data []byte) error {
 			return err
 		}
 
-		switch t {
+		if _, ok := t.(json.Delim); ok {
+			continue
+		}
 
-		case "aggregations":
-			for dec.More() {
-				tt, err := dec.Token()
-				if err != nil {
-					if errors.Is(err, io.EOF) {
-						break
-					}
-					return err
-				}
-				if value, ok := tt.(string); ok {
-					if strings.Contains(value, "#") {
-						elems := strings.Split(value, "#")
-						if len(elems) == 2 {
-							switch elems[0] {
-							case "cardinality":
-								o := NewCardinalityAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "hdr_percentiles":
-								o := NewHdrPercentilesAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "hdr_percentile_ranks":
-								o := NewHdrPercentileRanksAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "tdigest_percentiles":
-								o := NewTDigestPercentilesAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "tdigest_percentile_ranks":
-								o := NewTDigestPercentileRanksAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "percentiles_bucket":
-								o := NewPercentilesBucketAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "median_absolute_deviation":
-								o := NewMedianAbsoluteDeviationAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "min":
-								o := NewMinAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "max":
-								o := NewMaxAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "sum":
-								o := NewSumAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "avg":
-								o := NewAvgAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "weighted_avg":
-								o := NewWeightedAvgAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "value_count":
-								o := NewValueCountAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "simple_value":
-								o := NewSimpleValueAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "derivative":
-								o := NewDerivativeAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "bucket_metric_value":
-								o := NewBucketMetricValueAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "stats":
-								o := NewStatsAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "stats_bucket":
-								o := NewStatsBucketAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "extended_stats":
-								o := NewExtendedStatsAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "extended_stats_bucket":
-								o := NewExtendedStatsBucketAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "geo_bounds":
-								o := NewGeoBoundsAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "geo_centroid":
-								o := NewGeoCentroidAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "histogram":
-								o := NewHistogramAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "date_histogram":
-								o := NewDateHistogramAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "auto_date_histogram":
-								o := NewAutoDateHistogramAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "variable_width_histogram":
-								o := NewVariableWidthHistogramAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "sterms":
-								o := NewStringTermsAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "lterms":
-								o := NewLongTermsAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "dterms":
-								o := NewDoubleTermsAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "umterms":
-								o := NewUnmappedTermsAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "lrareterms":
-								o := NewLongRareTermsAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "srareterms":
-								o := NewStringRareTermsAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "umrareterms":
-								o := NewUnmappedRareTermsAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "multi_terms":
-								o := NewMultiTermsAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "missing":
-								o := NewMissingAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "nested":
-								o := NewNestedAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "reverse_nested":
-								o := NewReverseNestedAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "global":
-								o := NewGlobalAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "filter":
-								o := NewFilterAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "children":
-								o := NewChildrenAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "parent":
-								o := NewParentAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "sampler":
-								o := NewSamplerAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "unmapped_sampler":
-								o := NewUnmappedSamplerAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "geohash_grid":
-								o := NewGeoHashGridAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "geotile_grid":
-								o := NewGeoTileGridAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "geohex_grid":
-								o := NewGeoHexGridAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "range":
-								o := NewRangeAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "date_range":
-								o := NewDateRangeAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "geo_distance":
-								o := NewGeoDistanceAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "ip_range":
-								o := NewIpRangeAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "ip_prefix":
-								o := NewIpPrefixAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "filters":
-								o := NewFiltersAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "adjacency_matrix":
-								o := NewAdjacencyMatrixAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "siglterms":
-								o := NewSignificantLongTermsAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "sigsterms":
-								o := NewSignificantStringTermsAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "umsigterms":
-								o := NewUnmappedSignificantTermsAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "composite":
-								o := NewCompositeAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "scripted_metric":
-								o := NewScriptedMetricAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "top_hits":
-								o := NewTopHitsAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "inference":
-								o := NewInferenceAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "string_stats":
-								o := NewStringStatsAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "box_plot":
-								o := NewBoxPlotAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "top_metrics":
-								o := NewTopMetricsAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "t_test":
-								o := NewTTestAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "rate":
-								o := NewRateAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "simple_long_value":
-								o := NewCumulativeCardinalityAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "matrix_stats":
-								o := NewMatrixStatsAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "geo_line":
-								o := NewGeoLineAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							default:
-								o := make(map[string]interface{}, 0)
-								if err := dec.Decode(&o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							}
-						} else {
-							return errors.New("cannot decode JSON for field Aggregations")
-						}
-					} else {
-						o := make(map[string]interface{}, 0)
-						if err := dec.Decode(&o); err != nil {
-							return err
-						}
-						s.Aggregations[value] = o
-					}
-				}
-			}
+		switch t {
 
 		case "doc_count":
 			if err := dec.Decode(&s.DocCount); err != nil {
@@ -525,6 +87,442 @@ func (s *IpPrefixBucket) UnmarshalJSON(data []byte) error {
 				return err
 			}
 
+		default:
+			if value, ok := t.(string); ok {
+				if s.Aggregations == nil {
+					s.Aggregations = make(map[string]Aggregate, 0)
+				}
+
+				if strings.Contains(value, "#") {
+					elems := strings.Split(value, "#")
+					if len(elems) == 2 {
+						switch elems[0] {
+						case "cardinality":
+							o := NewCardinalityAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "hdr_percentiles":
+							o := NewHdrPercentilesAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "hdr_percentile_ranks":
+							o := NewHdrPercentileRanksAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "tdigest_percentiles":
+							o := NewTDigestPercentilesAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "tdigest_percentile_ranks":
+							o := NewTDigestPercentileRanksAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "percentiles_bucket":
+							o := NewPercentilesBucketAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "median_absolute_deviation":
+							o := NewMedianAbsoluteDeviationAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "min":
+							o := NewMinAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "max":
+							o := NewMaxAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "sum":
+							o := NewSumAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "avg":
+							o := NewAvgAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "weighted_avg":
+							o := NewWeightedAvgAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "value_count":
+							o := NewValueCountAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "simple_value":
+							o := NewSimpleValueAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "derivative":
+							o := NewDerivativeAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "bucket_metric_value":
+							o := NewBucketMetricValueAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "stats":
+							o := NewStatsAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "stats_bucket":
+							o := NewStatsBucketAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "extended_stats":
+							o := NewExtendedStatsAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "extended_stats_bucket":
+							o := NewExtendedStatsBucketAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "geo_bounds":
+							o := NewGeoBoundsAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "geo_centroid":
+							o := NewGeoCentroidAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "histogram":
+							o := NewHistogramAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "date_histogram":
+							o := NewDateHistogramAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "auto_date_histogram":
+							o := NewAutoDateHistogramAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "variable_width_histogram":
+							o := NewVariableWidthHistogramAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "sterms":
+							o := NewStringTermsAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "lterms":
+							o := NewLongTermsAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "dterms":
+							o := NewDoubleTermsAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "umterms":
+							o := NewUnmappedTermsAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "lrareterms":
+							o := NewLongRareTermsAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "srareterms":
+							o := NewStringRareTermsAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "umrareterms":
+							o := NewUnmappedRareTermsAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "multi_terms":
+							o := NewMultiTermsAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "missing":
+							o := NewMissingAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "nested":
+							o := NewNestedAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "reverse_nested":
+							o := NewReverseNestedAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "global":
+							o := NewGlobalAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "filter":
+							o := NewFilterAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "children":
+							o := NewChildrenAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "parent":
+							o := NewParentAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "sampler":
+							o := NewSamplerAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "unmapped_sampler":
+							o := NewUnmappedSamplerAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "geohash_grid":
+							o := NewGeoHashGridAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "geotile_grid":
+							o := NewGeoTileGridAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "geohex_grid":
+							o := NewGeoHexGridAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "range":
+							o := NewRangeAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "date_range":
+							o := NewDateRangeAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "geo_distance":
+							o := NewGeoDistanceAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "ip_range":
+							o := NewIpRangeAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "ip_prefix":
+							o := NewIpPrefixAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "filters":
+							o := NewFiltersAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "adjacency_matrix":
+							o := NewAdjacencyMatrixAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "siglterms":
+							o := NewSignificantLongTermsAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "sigsterms":
+							o := NewSignificantStringTermsAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "umsigterms":
+							o := NewUnmappedSignificantTermsAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "composite":
+							o := NewCompositeAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "scripted_metric":
+							o := NewScriptedMetricAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "top_hits":
+							o := NewTopHitsAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "inference":
+							o := NewInferenceAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "string_stats":
+							o := NewStringStatsAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "box_plot":
+							o := NewBoxPlotAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "top_metrics":
+							o := NewTopMetricsAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "t_test":
+							o := NewTTestAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "rate":
+							o := NewRateAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "simple_long_value":
+							o := NewCumulativeCardinalityAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "matrix_stats":
+							o := NewMatrixStatsAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "geo_line":
+							o := NewGeoLineAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						default:
+							o := make(map[string]interface{}, 0)
+							if err := dec.Decode(&o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						}
+					} else {
+						return errors.New("cannot decode JSON for field Aggregations")
+					}
+				} else {
+					o := make(map[string]interface{}, 0)
+					if err := dec.Decode(&o); err != nil {
+						return err
+					}
+					s.Aggregations[value] = o
+				}
+			}
 		}
 	}
 	return nil

--- a/typedapi/types/iprangebucket.go
+++ b/typedapi/types/iprangebucket.go
@@ -55,449 +55,11 @@ func (s *IpRangeBucket) UnmarshalJSON(data []byte) error {
 			return err
 		}
 
-		switch t {
+		if _, ok := t.(json.Delim); ok {
+			continue
+		}
 
-		case "aggregations":
-			for dec.More() {
-				tt, err := dec.Token()
-				if err != nil {
-					if errors.Is(err, io.EOF) {
-						break
-					}
-					return err
-				}
-				if value, ok := tt.(string); ok {
-					if strings.Contains(value, "#") {
-						elems := strings.Split(value, "#")
-						if len(elems) == 2 {
-							switch elems[0] {
-							case "cardinality":
-								o := NewCardinalityAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "hdr_percentiles":
-								o := NewHdrPercentilesAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "hdr_percentile_ranks":
-								o := NewHdrPercentileRanksAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "tdigest_percentiles":
-								o := NewTDigestPercentilesAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "tdigest_percentile_ranks":
-								o := NewTDigestPercentileRanksAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "percentiles_bucket":
-								o := NewPercentilesBucketAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "median_absolute_deviation":
-								o := NewMedianAbsoluteDeviationAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "min":
-								o := NewMinAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "max":
-								o := NewMaxAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "sum":
-								o := NewSumAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "avg":
-								o := NewAvgAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "weighted_avg":
-								o := NewWeightedAvgAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "value_count":
-								o := NewValueCountAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "simple_value":
-								o := NewSimpleValueAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "derivative":
-								o := NewDerivativeAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "bucket_metric_value":
-								o := NewBucketMetricValueAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "stats":
-								o := NewStatsAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "stats_bucket":
-								o := NewStatsBucketAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "extended_stats":
-								o := NewExtendedStatsAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "extended_stats_bucket":
-								o := NewExtendedStatsBucketAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "geo_bounds":
-								o := NewGeoBoundsAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "geo_centroid":
-								o := NewGeoCentroidAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "histogram":
-								o := NewHistogramAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "date_histogram":
-								o := NewDateHistogramAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "auto_date_histogram":
-								o := NewAutoDateHistogramAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "variable_width_histogram":
-								o := NewVariableWidthHistogramAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "sterms":
-								o := NewStringTermsAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "lterms":
-								o := NewLongTermsAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "dterms":
-								o := NewDoubleTermsAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "umterms":
-								o := NewUnmappedTermsAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "lrareterms":
-								o := NewLongRareTermsAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "srareterms":
-								o := NewStringRareTermsAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "umrareterms":
-								o := NewUnmappedRareTermsAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "multi_terms":
-								o := NewMultiTermsAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "missing":
-								o := NewMissingAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "nested":
-								o := NewNestedAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "reverse_nested":
-								o := NewReverseNestedAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "global":
-								o := NewGlobalAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "filter":
-								o := NewFilterAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "children":
-								o := NewChildrenAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "parent":
-								o := NewParentAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "sampler":
-								o := NewSamplerAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "unmapped_sampler":
-								o := NewUnmappedSamplerAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "geohash_grid":
-								o := NewGeoHashGridAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "geotile_grid":
-								o := NewGeoTileGridAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "geohex_grid":
-								o := NewGeoHexGridAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "range":
-								o := NewRangeAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "date_range":
-								o := NewDateRangeAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "geo_distance":
-								o := NewGeoDistanceAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "ip_range":
-								o := NewIpRangeAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "ip_prefix":
-								o := NewIpPrefixAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "filters":
-								o := NewFiltersAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "adjacency_matrix":
-								o := NewAdjacencyMatrixAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "siglterms":
-								o := NewSignificantLongTermsAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "sigsterms":
-								o := NewSignificantStringTermsAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "umsigterms":
-								o := NewUnmappedSignificantTermsAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "composite":
-								o := NewCompositeAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "scripted_metric":
-								o := NewScriptedMetricAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "top_hits":
-								o := NewTopHitsAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "inference":
-								o := NewInferenceAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "string_stats":
-								o := NewStringStatsAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "box_plot":
-								o := NewBoxPlotAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "top_metrics":
-								o := NewTopMetricsAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "t_test":
-								o := NewTTestAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "rate":
-								o := NewRateAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "simple_long_value":
-								o := NewCumulativeCardinalityAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "matrix_stats":
-								o := NewMatrixStatsAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "geo_line":
-								o := NewGeoLineAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							default:
-								o := make(map[string]interface{}, 0)
-								if err := dec.Decode(&o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							}
-						} else {
-							return errors.New("cannot decode JSON for field Aggregations")
-						}
-					} else {
-						o := make(map[string]interface{}, 0)
-						if err := dec.Decode(&o); err != nil {
-							return err
-						}
-						s.Aggregations[value] = o
-					}
-				}
-			}
+		switch t {
 
 		case "doc_count":
 			if err := dec.Decode(&s.DocCount); err != nil {
@@ -519,6 +81,442 @@ func (s *IpRangeBucket) UnmarshalJSON(data []byte) error {
 				return err
 			}
 
+		default:
+			if value, ok := t.(string); ok {
+				if s.Aggregations == nil {
+					s.Aggregations = make(map[string]Aggregate, 0)
+				}
+
+				if strings.Contains(value, "#") {
+					elems := strings.Split(value, "#")
+					if len(elems) == 2 {
+						switch elems[0] {
+						case "cardinality":
+							o := NewCardinalityAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "hdr_percentiles":
+							o := NewHdrPercentilesAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "hdr_percentile_ranks":
+							o := NewHdrPercentileRanksAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "tdigest_percentiles":
+							o := NewTDigestPercentilesAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "tdigest_percentile_ranks":
+							o := NewTDigestPercentileRanksAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "percentiles_bucket":
+							o := NewPercentilesBucketAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "median_absolute_deviation":
+							o := NewMedianAbsoluteDeviationAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "min":
+							o := NewMinAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "max":
+							o := NewMaxAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "sum":
+							o := NewSumAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "avg":
+							o := NewAvgAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "weighted_avg":
+							o := NewWeightedAvgAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "value_count":
+							o := NewValueCountAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "simple_value":
+							o := NewSimpleValueAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "derivative":
+							o := NewDerivativeAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "bucket_metric_value":
+							o := NewBucketMetricValueAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "stats":
+							o := NewStatsAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "stats_bucket":
+							o := NewStatsBucketAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "extended_stats":
+							o := NewExtendedStatsAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "extended_stats_bucket":
+							o := NewExtendedStatsBucketAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "geo_bounds":
+							o := NewGeoBoundsAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "geo_centroid":
+							o := NewGeoCentroidAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "histogram":
+							o := NewHistogramAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "date_histogram":
+							o := NewDateHistogramAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "auto_date_histogram":
+							o := NewAutoDateHistogramAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "variable_width_histogram":
+							o := NewVariableWidthHistogramAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "sterms":
+							o := NewStringTermsAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "lterms":
+							o := NewLongTermsAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "dterms":
+							o := NewDoubleTermsAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "umterms":
+							o := NewUnmappedTermsAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "lrareterms":
+							o := NewLongRareTermsAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "srareterms":
+							o := NewStringRareTermsAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "umrareterms":
+							o := NewUnmappedRareTermsAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "multi_terms":
+							o := NewMultiTermsAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "missing":
+							o := NewMissingAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "nested":
+							o := NewNestedAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "reverse_nested":
+							o := NewReverseNestedAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "global":
+							o := NewGlobalAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "filter":
+							o := NewFilterAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "children":
+							o := NewChildrenAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "parent":
+							o := NewParentAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "sampler":
+							o := NewSamplerAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "unmapped_sampler":
+							o := NewUnmappedSamplerAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "geohash_grid":
+							o := NewGeoHashGridAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "geotile_grid":
+							o := NewGeoTileGridAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "geohex_grid":
+							o := NewGeoHexGridAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "range":
+							o := NewRangeAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "date_range":
+							o := NewDateRangeAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "geo_distance":
+							o := NewGeoDistanceAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "ip_range":
+							o := NewIpRangeAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "ip_prefix":
+							o := NewIpPrefixAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "filters":
+							o := NewFiltersAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "adjacency_matrix":
+							o := NewAdjacencyMatrixAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "siglterms":
+							o := NewSignificantLongTermsAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "sigsterms":
+							o := NewSignificantStringTermsAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "umsigterms":
+							o := NewUnmappedSignificantTermsAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "composite":
+							o := NewCompositeAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "scripted_metric":
+							o := NewScriptedMetricAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "top_hits":
+							o := NewTopHitsAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "inference":
+							o := NewInferenceAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "string_stats":
+							o := NewStringStatsAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "box_plot":
+							o := NewBoxPlotAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "top_metrics":
+							o := NewTopMetricsAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "t_test":
+							o := NewTTestAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "rate":
+							o := NewRateAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "simple_long_value":
+							o := NewCumulativeCardinalityAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "matrix_stats":
+							o := NewMatrixStatsAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "geo_line":
+							o := NewGeoLineAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						default:
+							o := make(map[string]interface{}, 0)
+							if err := dec.Decode(&o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						}
+					} else {
+						return errors.New("cannot decode JSON for field Aggregations")
+					}
+				} else {
+					o := make(map[string]interface{}, 0)
+					if err := dec.Decode(&o); err != nil {
+						return err
+					}
+					s.Aggregations[value] = o
+				}
+			}
 		}
 	}
 	return nil

--- a/typedapi/types/longraretermsbucket.go
+++ b/typedapi/types/longraretermsbucket.go
@@ -54,449 +54,11 @@ func (s *LongRareTermsBucket) UnmarshalJSON(data []byte) error {
 			return err
 		}
 
-		switch t {
+		if _, ok := t.(json.Delim); ok {
+			continue
+		}
 
-		case "aggregations":
-			for dec.More() {
-				tt, err := dec.Token()
-				if err != nil {
-					if errors.Is(err, io.EOF) {
-						break
-					}
-					return err
-				}
-				if value, ok := tt.(string); ok {
-					if strings.Contains(value, "#") {
-						elems := strings.Split(value, "#")
-						if len(elems) == 2 {
-							switch elems[0] {
-							case "cardinality":
-								o := NewCardinalityAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "hdr_percentiles":
-								o := NewHdrPercentilesAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "hdr_percentile_ranks":
-								o := NewHdrPercentileRanksAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "tdigest_percentiles":
-								o := NewTDigestPercentilesAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "tdigest_percentile_ranks":
-								o := NewTDigestPercentileRanksAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "percentiles_bucket":
-								o := NewPercentilesBucketAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "median_absolute_deviation":
-								o := NewMedianAbsoluteDeviationAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "min":
-								o := NewMinAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "max":
-								o := NewMaxAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "sum":
-								o := NewSumAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "avg":
-								o := NewAvgAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "weighted_avg":
-								o := NewWeightedAvgAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "value_count":
-								o := NewValueCountAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "simple_value":
-								o := NewSimpleValueAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "derivative":
-								o := NewDerivativeAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "bucket_metric_value":
-								o := NewBucketMetricValueAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "stats":
-								o := NewStatsAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "stats_bucket":
-								o := NewStatsBucketAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "extended_stats":
-								o := NewExtendedStatsAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "extended_stats_bucket":
-								o := NewExtendedStatsBucketAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "geo_bounds":
-								o := NewGeoBoundsAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "geo_centroid":
-								o := NewGeoCentroidAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "histogram":
-								o := NewHistogramAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "date_histogram":
-								o := NewDateHistogramAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "auto_date_histogram":
-								o := NewAutoDateHistogramAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "variable_width_histogram":
-								o := NewVariableWidthHistogramAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "sterms":
-								o := NewStringTermsAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "lterms":
-								o := NewLongTermsAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "dterms":
-								o := NewDoubleTermsAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "umterms":
-								o := NewUnmappedTermsAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "lrareterms":
-								o := NewLongRareTermsAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "srareterms":
-								o := NewStringRareTermsAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "umrareterms":
-								o := NewUnmappedRareTermsAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "multi_terms":
-								o := NewMultiTermsAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "missing":
-								o := NewMissingAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "nested":
-								o := NewNestedAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "reverse_nested":
-								o := NewReverseNestedAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "global":
-								o := NewGlobalAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "filter":
-								o := NewFilterAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "children":
-								o := NewChildrenAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "parent":
-								o := NewParentAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "sampler":
-								o := NewSamplerAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "unmapped_sampler":
-								o := NewUnmappedSamplerAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "geohash_grid":
-								o := NewGeoHashGridAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "geotile_grid":
-								o := NewGeoTileGridAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "geohex_grid":
-								o := NewGeoHexGridAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "range":
-								o := NewRangeAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "date_range":
-								o := NewDateRangeAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "geo_distance":
-								o := NewGeoDistanceAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "ip_range":
-								o := NewIpRangeAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "ip_prefix":
-								o := NewIpPrefixAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "filters":
-								o := NewFiltersAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "adjacency_matrix":
-								o := NewAdjacencyMatrixAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "siglterms":
-								o := NewSignificantLongTermsAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "sigsterms":
-								o := NewSignificantStringTermsAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "umsigterms":
-								o := NewUnmappedSignificantTermsAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "composite":
-								o := NewCompositeAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "scripted_metric":
-								o := NewScriptedMetricAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "top_hits":
-								o := NewTopHitsAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "inference":
-								o := NewInferenceAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "string_stats":
-								o := NewStringStatsAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "box_plot":
-								o := NewBoxPlotAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "top_metrics":
-								o := NewTopMetricsAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "t_test":
-								o := NewTTestAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "rate":
-								o := NewRateAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "simple_long_value":
-								o := NewCumulativeCardinalityAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "matrix_stats":
-								o := NewMatrixStatsAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "geo_line":
-								o := NewGeoLineAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							default:
-								o := make(map[string]interface{}, 0)
-								if err := dec.Decode(&o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							}
-						} else {
-							return errors.New("cannot decode JSON for field Aggregations")
-						}
-					} else {
-						o := make(map[string]interface{}, 0)
-						if err := dec.Decode(&o); err != nil {
-							return err
-						}
-						s.Aggregations[value] = o
-					}
-				}
-			}
+		switch t {
 
 		case "doc_count":
 			if err := dec.Decode(&s.DocCount); err != nil {
@@ -513,6 +75,442 @@ func (s *LongRareTermsBucket) UnmarshalJSON(data []byte) error {
 				return err
 			}
 
+		default:
+			if value, ok := t.(string); ok {
+				if s.Aggregations == nil {
+					s.Aggregations = make(map[string]Aggregate, 0)
+				}
+
+				if strings.Contains(value, "#") {
+					elems := strings.Split(value, "#")
+					if len(elems) == 2 {
+						switch elems[0] {
+						case "cardinality":
+							o := NewCardinalityAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "hdr_percentiles":
+							o := NewHdrPercentilesAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "hdr_percentile_ranks":
+							o := NewHdrPercentileRanksAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "tdigest_percentiles":
+							o := NewTDigestPercentilesAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "tdigest_percentile_ranks":
+							o := NewTDigestPercentileRanksAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "percentiles_bucket":
+							o := NewPercentilesBucketAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "median_absolute_deviation":
+							o := NewMedianAbsoluteDeviationAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "min":
+							o := NewMinAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "max":
+							o := NewMaxAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "sum":
+							o := NewSumAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "avg":
+							o := NewAvgAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "weighted_avg":
+							o := NewWeightedAvgAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "value_count":
+							o := NewValueCountAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "simple_value":
+							o := NewSimpleValueAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "derivative":
+							o := NewDerivativeAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "bucket_metric_value":
+							o := NewBucketMetricValueAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "stats":
+							o := NewStatsAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "stats_bucket":
+							o := NewStatsBucketAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "extended_stats":
+							o := NewExtendedStatsAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "extended_stats_bucket":
+							o := NewExtendedStatsBucketAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "geo_bounds":
+							o := NewGeoBoundsAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "geo_centroid":
+							o := NewGeoCentroidAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "histogram":
+							o := NewHistogramAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "date_histogram":
+							o := NewDateHistogramAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "auto_date_histogram":
+							o := NewAutoDateHistogramAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "variable_width_histogram":
+							o := NewVariableWidthHistogramAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "sterms":
+							o := NewStringTermsAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "lterms":
+							o := NewLongTermsAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "dterms":
+							o := NewDoubleTermsAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "umterms":
+							o := NewUnmappedTermsAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "lrareterms":
+							o := NewLongRareTermsAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "srareterms":
+							o := NewStringRareTermsAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "umrareterms":
+							o := NewUnmappedRareTermsAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "multi_terms":
+							o := NewMultiTermsAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "missing":
+							o := NewMissingAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "nested":
+							o := NewNestedAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "reverse_nested":
+							o := NewReverseNestedAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "global":
+							o := NewGlobalAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "filter":
+							o := NewFilterAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "children":
+							o := NewChildrenAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "parent":
+							o := NewParentAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "sampler":
+							o := NewSamplerAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "unmapped_sampler":
+							o := NewUnmappedSamplerAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "geohash_grid":
+							o := NewGeoHashGridAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "geotile_grid":
+							o := NewGeoTileGridAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "geohex_grid":
+							o := NewGeoHexGridAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "range":
+							o := NewRangeAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "date_range":
+							o := NewDateRangeAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "geo_distance":
+							o := NewGeoDistanceAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "ip_range":
+							o := NewIpRangeAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "ip_prefix":
+							o := NewIpPrefixAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "filters":
+							o := NewFiltersAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "adjacency_matrix":
+							o := NewAdjacencyMatrixAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "siglterms":
+							o := NewSignificantLongTermsAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "sigsterms":
+							o := NewSignificantStringTermsAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "umsigterms":
+							o := NewUnmappedSignificantTermsAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "composite":
+							o := NewCompositeAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "scripted_metric":
+							o := NewScriptedMetricAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "top_hits":
+							o := NewTopHitsAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "inference":
+							o := NewInferenceAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "string_stats":
+							o := NewStringStatsAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "box_plot":
+							o := NewBoxPlotAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "top_metrics":
+							o := NewTopMetricsAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "t_test":
+							o := NewTTestAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "rate":
+							o := NewRateAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "simple_long_value":
+							o := NewCumulativeCardinalityAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "matrix_stats":
+							o := NewMatrixStatsAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "geo_line":
+							o := NewGeoLineAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						default:
+							o := make(map[string]interface{}, 0)
+							if err := dec.Decode(&o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						}
+					} else {
+						return errors.New("cannot decode JSON for field Aggregations")
+					}
+				} else {
+					o := make(map[string]interface{}, 0)
+					if err := dec.Decode(&o); err != nil {
+						return err
+					}
+					s.Aggregations[value] = o
+				}
+			}
 		}
 	}
 	return nil

--- a/typedapi/types/longtermsbucket.go
+++ b/typedapi/types/longtermsbucket.go
@@ -55,449 +55,11 @@ func (s *LongTermsBucket) UnmarshalJSON(data []byte) error {
 			return err
 		}
 
-		switch t {
+		if _, ok := t.(json.Delim); ok {
+			continue
+		}
 
-		case "aggregations":
-			for dec.More() {
-				tt, err := dec.Token()
-				if err != nil {
-					if errors.Is(err, io.EOF) {
-						break
-					}
-					return err
-				}
-				if value, ok := tt.(string); ok {
-					if strings.Contains(value, "#") {
-						elems := strings.Split(value, "#")
-						if len(elems) == 2 {
-							switch elems[0] {
-							case "cardinality":
-								o := NewCardinalityAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "hdr_percentiles":
-								o := NewHdrPercentilesAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "hdr_percentile_ranks":
-								o := NewHdrPercentileRanksAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "tdigest_percentiles":
-								o := NewTDigestPercentilesAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "tdigest_percentile_ranks":
-								o := NewTDigestPercentileRanksAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "percentiles_bucket":
-								o := NewPercentilesBucketAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "median_absolute_deviation":
-								o := NewMedianAbsoluteDeviationAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "min":
-								o := NewMinAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "max":
-								o := NewMaxAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "sum":
-								o := NewSumAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "avg":
-								o := NewAvgAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "weighted_avg":
-								o := NewWeightedAvgAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "value_count":
-								o := NewValueCountAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "simple_value":
-								o := NewSimpleValueAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "derivative":
-								o := NewDerivativeAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "bucket_metric_value":
-								o := NewBucketMetricValueAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "stats":
-								o := NewStatsAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "stats_bucket":
-								o := NewStatsBucketAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "extended_stats":
-								o := NewExtendedStatsAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "extended_stats_bucket":
-								o := NewExtendedStatsBucketAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "geo_bounds":
-								o := NewGeoBoundsAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "geo_centroid":
-								o := NewGeoCentroidAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "histogram":
-								o := NewHistogramAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "date_histogram":
-								o := NewDateHistogramAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "auto_date_histogram":
-								o := NewAutoDateHistogramAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "variable_width_histogram":
-								o := NewVariableWidthHistogramAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "sterms":
-								o := NewStringTermsAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "lterms":
-								o := NewLongTermsAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "dterms":
-								o := NewDoubleTermsAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "umterms":
-								o := NewUnmappedTermsAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "lrareterms":
-								o := NewLongRareTermsAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "srareterms":
-								o := NewStringRareTermsAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "umrareterms":
-								o := NewUnmappedRareTermsAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "multi_terms":
-								o := NewMultiTermsAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "missing":
-								o := NewMissingAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "nested":
-								o := NewNestedAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "reverse_nested":
-								o := NewReverseNestedAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "global":
-								o := NewGlobalAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "filter":
-								o := NewFilterAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "children":
-								o := NewChildrenAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "parent":
-								o := NewParentAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "sampler":
-								o := NewSamplerAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "unmapped_sampler":
-								o := NewUnmappedSamplerAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "geohash_grid":
-								o := NewGeoHashGridAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "geotile_grid":
-								o := NewGeoTileGridAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "geohex_grid":
-								o := NewGeoHexGridAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "range":
-								o := NewRangeAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "date_range":
-								o := NewDateRangeAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "geo_distance":
-								o := NewGeoDistanceAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "ip_range":
-								o := NewIpRangeAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "ip_prefix":
-								o := NewIpPrefixAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "filters":
-								o := NewFiltersAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "adjacency_matrix":
-								o := NewAdjacencyMatrixAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "siglterms":
-								o := NewSignificantLongTermsAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "sigsterms":
-								o := NewSignificantStringTermsAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "umsigterms":
-								o := NewUnmappedSignificantTermsAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "composite":
-								o := NewCompositeAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "scripted_metric":
-								o := NewScriptedMetricAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "top_hits":
-								o := NewTopHitsAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "inference":
-								o := NewInferenceAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "string_stats":
-								o := NewStringStatsAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "box_plot":
-								o := NewBoxPlotAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "top_metrics":
-								o := NewTopMetricsAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "t_test":
-								o := NewTTestAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "rate":
-								o := NewRateAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "simple_long_value":
-								o := NewCumulativeCardinalityAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "matrix_stats":
-								o := NewMatrixStatsAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "geo_line":
-								o := NewGeoLineAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							default:
-								o := make(map[string]interface{}, 0)
-								if err := dec.Decode(&o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							}
-						} else {
-							return errors.New("cannot decode JSON for field Aggregations")
-						}
-					} else {
-						o := make(map[string]interface{}, 0)
-						if err := dec.Decode(&o); err != nil {
-							return err
-						}
-						s.Aggregations[value] = o
-					}
-				}
-			}
+		switch t {
 
 		case "doc_count":
 			if err := dec.Decode(&s.DocCount); err != nil {
@@ -519,6 +81,442 @@ func (s *LongTermsBucket) UnmarshalJSON(data []byte) error {
 				return err
 			}
 
+		default:
+			if value, ok := t.(string); ok {
+				if s.Aggregations == nil {
+					s.Aggregations = make(map[string]Aggregate, 0)
+				}
+
+				if strings.Contains(value, "#") {
+					elems := strings.Split(value, "#")
+					if len(elems) == 2 {
+						switch elems[0] {
+						case "cardinality":
+							o := NewCardinalityAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "hdr_percentiles":
+							o := NewHdrPercentilesAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "hdr_percentile_ranks":
+							o := NewHdrPercentileRanksAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "tdigest_percentiles":
+							o := NewTDigestPercentilesAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "tdigest_percentile_ranks":
+							o := NewTDigestPercentileRanksAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "percentiles_bucket":
+							o := NewPercentilesBucketAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "median_absolute_deviation":
+							o := NewMedianAbsoluteDeviationAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "min":
+							o := NewMinAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "max":
+							o := NewMaxAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "sum":
+							o := NewSumAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "avg":
+							o := NewAvgAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "weighted_avg":
+							o := NewWeightedAvgAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "value_count":
+							o := NewValueCountAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "simple_value":
+							o := NewSimpleValueAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "derivative":
+							o := NewDerivativeAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "bucket_metric_value":
+							o := NewBucketMetricValueAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "stats":
+							o := NewStatsAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "stats_bucket":
+							o := NewStatsBucketAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "extended_stats":
+							o := NewExtendedStatsAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "extended_stats_bucket":
+							o := NewExtendedStatsBucketAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "geo_bounds":
+							o := NewGeoBoundsAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "geo_centroid":
+							o := NewGeoCentroidAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "histogram":
+							o := NewHistogramAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "date_histogram":
+							o := NewDateHistogramAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "auto_date_histogram":
+							o := NewAutoDateHistogramAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "variable_width_histogram":
+							o := NewVariableWidthHistogramAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "sterms":
+							o := NewStringTermsAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "lterms":
+							o := NewLongTermsAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "dterms":
+							o := NewDoubleTermsAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "umterms":
+							o := NewUnmappedTermsAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "lrareterms":
+							o := NewLongRareTermsAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "srareterms":
+							o := NewStringRareTermsAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "umrareterms":
+							o := NewUnmappedRareTermsAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "multi_terms":
+							o := NewMultiTermsAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "missing":
+							o := NewMissingAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "nested":
+							o := NewNestedAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "reverse_nested":
+							o := NewReverseNestedAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "global":
+							o := NewGlobalAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "filter":
+							o := NewFilterAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "children":
+							o := NewChildrenAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "parent":
+							o := NewParentAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "sampler":
+							o := NewSamplerAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "unmapped_sampler":
+							o := NewUnmappedSamplerAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "geohash_grid":
+							o := NewGeoHashGridAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "geotile_grid":
+							o := NewGeoTileGridAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "geohex_grid":
+							o := NewGeoHexGridAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "range":
+							o := NewRangeAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "date_range":
+							o := NewDateRangeAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "geo_distance":
+							o := NewGeoDistanceAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "ip_range":
+							o := NewIpRangeAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "ip_prefix":
+							o := NewIpPrefixAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "filters":
+							o := NewFiltersAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "adjacency_matrix":
+							o := NewAdjacencyMatrixAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "siglterms":
+							o := NewSignificantLongTermsAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "sigsterms":
+							o := NewSignificantStringTermsAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "umsigterms":
+							o := NewUnmappedSignificantTermsAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "composite":
+							o := NewCompositeAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "scripted_metric":
+							o := NewScriptedMetricAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "top_hits":
+							o := NewTopHitsAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "inference":
+							o := NewInferenceAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "string_stats":
+							o := NewStringStatsAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "box_plot":
+							o := NewBoxPlotAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "top_metrics":
+							o := NewTopMetricsAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "t_test":
+							o := NewTTestAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "rate":
+							o := NewRateAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "simple_long_value":
+							o := NewCumulativeCardinalityAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "matrix_stats":
+							o := NewMatrixStatsAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "geo_line":
+							o := NewGeoLineAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						default:
+							o := make(map[string]interface{}, 0)
+							if err := dec.Decode(&o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						}
+					} else {
+						return errors.New("cannot decode JSON for field Aggregations")
+					}
+				} else {
+					o := make(map[string]interface{}, 0)
+					if err := dec.Decode(&o); err != nil {
+						return err
+					}
+					s.Aggregations[value] = o
+				}
+			}
 		}
 	}
 	return nil

--- a/typedapi/types/multitermsbucket.go
+++ b/typedapi/types/multitermsbucket.go
@@ -55,449 +55,11 @@ func (s *MultiTermsBucket) UnmarshalJSON(data []byte) error {
 			return err
 		}
 
-		switch t {
+		if _, ok := t.(json.Delim); ok {
+			continue
+		}
 
-		case "aggregations":
-			for dec.More() {
-				tt, err := dec.Token()
-				if err != nil {
-					if errors.Is(err, io.EOF) {
-						break
-					}
-					return err
-				}
-				if value, ok := tt.(string); ok {
-					if strings.Contains(value, "#") {
-						elems := strings.Split(value, "#")
-						if len(elems) == 2 {
-							switch elems[0] {
-							case "cardinality":
-								o := NewCardinalityAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "hdr_percentiles":
-								o := NewHdrPercentilesAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "hdr_percentile_ranks":
-								o := NewHdrPercentileRanksAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "tdigest_percentiles":
-								o := NewTDigestPercentilesAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "tdigest_percentile_ranks":
-								o := NewTDigestPercentileRanksAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "percentiles_bucket":
-								o := NewPercentilesBucketAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "median_absolute_deviation":
-								o := NewMedianAbsoluteDeviationAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "min":
-								o := NewMinAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "max":
-								o := NewMaxAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "sum":
-								o := NewSumAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "avg":
-								o := NewAvgAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "weighted_avg":
-								o := NewWeightedAvgAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "value_count":
-								o := NewValueCountAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "simple_value":
-								o := NewSimpleValueAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "derivative":
-								o := NewDerivativeAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "bucket_metric_value":
-								o := NewBucketMetricValueAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "stats":
-								o := NewStatsAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "stats_bucket":
-								o := NewStatsBucketAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "extended_stats":
-								o := NewExtendedStatsAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "extended_stats_bucket":
-								o := NewExtendedStatsBucketAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "geo_bounds":
-								o := NewGeoBoundsAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "geo_centroid":
-								o := NewGeoCentroidAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "histogram":
-								o := NewHistogramAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "date_histogram":
-								o := NewDateHistogramAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "auto_date_histogram":
-								o := NewAutoDateHistogramAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "variable_width_histogram":
-								o := NewVariableWidthHistogramAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "sterms":
-								o := NewStringTermsAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "lterms":
-								o := NewLongTermsAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "dterms":
-								o := NewDoubleTermsAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "umterms":
-								o := NewUnmappedTermsAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "lrareterms":
-								o := NewLongRareTermsAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "srareterms":
-								o := NewStringRareTermsAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "umrareterms":
-								o := NewUnmappedRareTermsAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "multi_terms":
-								o := NewMultiTermsAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "missing":
-								o := NewMissingAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "nested":
-								o := NewNestedAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "reverse_nested":
-								o := NewReverseNestedAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "global":
-								o := NewGlobalAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "filter":
-								o := NewFilterAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "children":
-								o := NewChildrenAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "parent":
-								o := NewParentAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "sampler":
-								o := NewSamplerAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "unmapped_sampler":
-								o := NewUnmappedSamplerAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "geohash_grid":
-								o := NewGeoHashGridAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "geotile_grid":
-								o := NewGeoTileGridAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "geohex_grid":
-								o := NewGeoHexGridAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "range":
-								o := NewRangeAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "date_range":
-								o := NewDateRangeAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "geo_distance":
-								o := NewGeoDistanceAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "ip_range":
-								o := NewIpRangeAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "ip_prefix":
-								o := NewIpPrefixAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "filters":
-								o := NewFiltersAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "adjacency_matrix":
-								o := NewAdjacencyMatrixAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "siglterms":
-								o := NewSignificantLongTermsAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "sigsterms":
-								o := NewSignificantStringTermsAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "umsigterms":
-								o := NewUnmappedSignificantTermsAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "composite":
-								o := NewCompositeAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "scripted_metric":
-								o := NewScriptedMetricAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "top_hits":
-								o := NewTopHitsAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "inference":
-								o := NewInferenceAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "string_stats":
-								o := NewStringStatsAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "box_plot":
-								o := NewBoxPlotAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "top_metrics":
-								o := NewTopMetricsAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "t_test":
-								o := NewTTestAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "rate":
-								o := NewRateAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "simple_long_value":
-								o := NewCumulativeCardinalityAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "matrix_stats":
-								o := NewMatrixStatsAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "geo_line":
-								o := NewGeoLineAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							default:
-								o := make(map[string]interface{}, 0)
-								if err := dec.Decode(&o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							}
-						} else {
-							return errors.New("cannot decode JSON for field Aggregations")
-						}
-					} else {
-						o := make(map[string]interface{}, 0)
-						if err := dec.Decode(&o); err != nil {
-							return err
-						}
-						s.Aggregations[value] = o
-					}
-				}
-			}
+		switch t {
 
 		case "doc_count":
 			if err := dec.Decode(&s.DocCount); err != nil {
@@ -519,6 +81,442 @@ func (s *MultiTermsBucket) UnmarshalJSON(data []byte) error {
 				return err
 			}
 
+		default:
+			if value, ok := t.(string); ok {
+				if s.Aggregations == nil {
+					s.Aggregations = make(map[string]Aggregate, 0)
+				}
+
+				if strings.Contains(value, "#") {
+					elems := strings.Split(value, "#")
+					if len(elems) == 2 {
+						switch elems[0] {
+						case "cardinality":
+							o := NewCardinalityAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "hdr_percentiles":
+							o := NewHdrPercentilesAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "hdr_percentile_ranks":
+							o := NewHdrPercentileRanksAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "tdigest_percentiles":
+							o := NewTDigestPercentilesAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "tdigest_percentile_ranks":
+							o := NewTDigestPercentileRanksAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "percentiles_bucket":
+							o := NewPercentilesBucketAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "median_absolute_deviation":
+							o := NewMedianAbsoluteDeviationAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "min":
+							o := NewMinAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "max":
+							o := NewMaxAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "sum":
+							o := NewSumAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "avg":
+							o := NewAvgAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "weighted_avg":
+							o := NewWeightedAvgAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "value_count":
+							o := NewValueCountAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "simple_value":
+							o := NewSimpleValueAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "derivative":
+							o := NewDerivativeAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "bucket_metric_value":
+							o := NewBucketMetricValueAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "stats":
+							o := NewStatsAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "stats_bucket":
+							o := NewStatsBucketAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "extended_stats":
+							o := NewExtendedStatsAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "extended_stats_bucket":
+							o := NewExtendedStatsBucketAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "geo_bounds":
+							o := NewGeoBoundsAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "geo_centroid":
+							o := NewGeoCentroidAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "histogram":
+							o := NewHistogramAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "date_histogram":
+							o := NewDateHistogramAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "auto_date_histogram":
+							o := NewAutoDateHistogramAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "variable_width_histogram":
+							o := NewVariableWidthHistogramAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "sterms":
+							o := NewStringTermsAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "lterms":
+							o := NewLongTermsAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "dterms":
+							o := NewDoubleTermsAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "umterms":
+							o := NewUnmappedTermsAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "lrareterms":
+							o := NewLongRareTermsAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "srareterms":
+							o := NewStringRareTermsAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "umrareterms":
+							o := NewUnmappedRareTermsAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "multi_terms":
+							o := NewMultiTermsAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "missing":
+							o := NewMissingAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "nested":
+							o := NewNestedAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "reverse_nested":
+							o := NewReverseNestedAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "global":
+							o := NewGlobalAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "filter":
+							o := NewFilterAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "children":
+							o := NewChildrenAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "parent":
+							o := NewParentAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "sampler":
+							o := NewSamplerAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "unmapped_sampler":
+							o := NewUnmappedSamplerAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "geohash_grid":
+							o := NewGeoHashGridAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "geotile_grid":
+							o := NewGeoTileGridAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "geohex_grid":
+							o := NewGeoHexGridAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "range":
+							o := NewRangeAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "date_range":
+							o := NewDateRangeAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "geo_distance":
+							o := NewGeoDistanceAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "ip_range":
+							o := NewIpRangeAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "ip_prefix":
+							o := NewIpPrefixAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "filters":
+							o := NewFiltersAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "adjacency_matrix":
+							o := NewAdjacencyMatrixAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "siglterms":
+							o := NewSignificantLongTermsAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "sigsterms":
+							o := NewSignificantStringTermsAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "umsigterms":
+							o := NewUnmappedSignificantTermsAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "composite":
+							o := NewCompositeAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "scripted_metric":
+							o := NewScriptedMetricAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "top_hits":
+							o := NewTopHitsAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "inference":
+							o := NewInferenceAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "string_stats":
+							o := NewStringStatsAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "box_plot":
+							o := NewBoxPlotAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "top_metrics":
+							o := NewTopMetricsAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "t_test":
+							o := NewTTestAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "rate":
+							o := NewRateAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "simple_long_value":
+							o := NewCumulativeCardinalityAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "matrix_stats":
+							o := NewMatrixStatsAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "geo_line":
+							o := NewGeoLineAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						default:
+							o := make(map[string]interface{}, 0)
+							if err := dec.Decode(&o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						}
+					} else {
+						return errors.New("cannot decode JSON for field Aggregations")
+					}
+				} else {
+					o := make(map[string]interface{}, 0)
+					if err := dec.Decode(&o); err != nil {
+						return err
+					}
+					s.Aggregations[value] = o
+				}
+			}
 		}
 	}
 	return nil

--- a/typedapi/types/rangebucket.go
+++ b/typedapi/types/rangebucket.go
@@ -58,449 +58,11 @@ func (s *RangeBucket) UnmarshalJSON(data []byte) error {
 			return err
 		}
 
-		switch t {
+		if _, ok := t.(json.Delim); ok {
+			continue
+		}
 
-		case "aggregations":
-			for dec.More() {
-				tt, err := dec.Token()
-				if err != nil {
-					if errors.Is(err, io.EOF) {
-						break
-					}
-					return err
-				}
-				if value, ok := tt.(string); ok {
-					if strings.Contains(value, "#") {
-						elems := strings.Split(value, "#")
-						if len(elems) == 2 {
-							switch elems[0] {
-							case "cardinality":
-								o := NewCardinalityAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "hdr_percentiles":
-								o := NewHdrPercentilesAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "hdr_percentile_ranks":
-								o := NewHdrPercentileRanksAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "tdigest_percentiles":
-								o := NewTDigestPercentilesAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "tdigest_percentile_ranks":
-								o := NewTDigestPercentileRanksAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "percentiles_bucket":
-								o := NewPercentilesBucketAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "median_absolute_deviation":
-								o := NewMedianAbsoluteDeviationAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "min":
-								o := NewMinAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "max":
-								o := NewMaxAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "sum":
-								o := NewSumAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "avg":
-								o := NewAvgAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "weighted_avg":
-								o := NewWeightedAvgAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "value_count":
-								o := NewValueCountAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "simple_value":
-								o := NewSimpleValueAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "derivative":
-								o := NewDerivativeAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "bucket_metric_value":
-								o := NewBucketMetricValueAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "stats":
-								o := NewStatsAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "stats_bucket":
-								o := NewStatsBucketAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "extended_stats":
-								o := NewExtendedStatsAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "extended_stats_bucket":
-								o := NewExtendedStatsBucketAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "geo_bounds":
-								o := NewGeoBoundsAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "geo_centroid":
-								o := NewGeoCentroidAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "histogram":
-								o := NewHistogramAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "date_histogram":
-								o := NewDateHistogramAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "auto_date_histogram":
-								o := NewAutoDateHistogramAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "variable_width_histogram":
-								o := NewVariableWidthHistogramAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "sterms":
-								o := NewStringTermsAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "lterms":
-								o := NewLongTermsAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "dterms":
-								o := NewDoubleTermsAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "umterms":
-								o := NewUnmappedTermsAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "lrareterms":
-								o := NewLongRareTermsAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "srareterms":
-								o := NewStringRareTermsAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "umrareterms":
-								o := NewUnmappedRareTermsAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "multi_terms":
-								o := NewMultiTermsAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "missing":
-								o := NewMissingAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "nested":
-								o := NewNestedAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "reverse_nested":
-								o := NewReverseNestedAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "global":
-								o := NewGlobalAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "filter":
-								o := NewFilterAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "children":
-								o := NewChildrenAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "parent":
-								o := NewParentAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "sampler":
-								o := NewSamplerAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "unmapped_sampler":
-								o := NewUnmappedSamplerAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "geohash_grid":
-								o := NewGeoHashGridAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "geotile_grid":
-								o := NewGeoTileGridAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "geohex_grid":
-								o := NewGeoHexGridAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "range":
-								o := NewRangeAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "date_range":
-								o := NewDateRangeAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "geo_distance":
-								o := NewGeoDistanceAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "ip_range":
-								o := NewIpRangeAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "ip_prefix":
-								o := NewIpPrefixAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "filters":
-								o := NewFiltersAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "adjacency_matrix":
-								o := NewAdjacencyMatrixAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "siglterms":
-								o := NewSignificantLongTermsAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "sigsterms":
-								o := NewSignificantStringTermsAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "umsigterms":
-								o := NewUnmappedSignificantTermsAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "composite":
-								o := NewCompositeAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "scripted_metric":
-								o := NewScriptedMetricAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "top_hits":
-								o := NewTopHitsAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "inference":
-								o := NewInferenceAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "string_stats":
-								o := NewStringStatsAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "box_plot":
-								o := NewBoxPlotAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "top_metrics":
-								o := NewTopMetricsAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "t_test":
-								o := NewTTestAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "rate":
-								o := NewRateAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "simple_long_value":
-								o := NewCumulativeCardinalityAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "matrix_stats":
-								o := NewMatrixStatsAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "geo_line":
-								o := NewGeoLineAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							default:
-								o := make(map[string]interface{}, 0)
-								if err := dec.Decode(&o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							}
-						} else {
-							return errors.New("cannot decode JSON for field Aggregations")
-						}
-					} else {
-						o := make(map[string]interface{}, 0)
-						if err := dec.Decode(&o); err != nil {
-							return err
-						}
-						s.Aggregations[value] = o
-					}
-				}
-			}
+		switch t {
 
 		case "doc_count":
 			if err := dec.Decode(&s.DocCount); err != nil {
@@ -532,6 +94,442 @@ func (s *RangeBucket) UnmarshalJSON(data []byte) error {
 				return err
 			}
 
+		default:
+			if value, ok := t.(string); ok {
+				if s.Aggregations == nil {
+					s.Aggregations = make(map[string]Aggregate, 0)
+				}
+
+				if strings.Contains(value, "#") {
+					elems := strings.Split(value, "#")
+					if len(elems) == 2 {
+						switch elems[0] {
+						case "cardinality":
+							o := NewCardinalityAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "hdr_percentiles":
+							o := NewHdrPercentilesAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "hdr_percentile_ranks":
+							o := NewHdrPercentileRanksAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "tdigest_percentiles":
+							o := NewTDigestPercentilesAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "tdigest_percentile_ranks":
+							o := NewTDigestPercentileRanksAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "percentiles_bucket":
+							o := NewPercentilesBucketAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "median_absolute_deviation":
+							o := NewMedianAbsoluteDeviationAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "min":
+							o := NewMinAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "max":
+							o := NewMaxAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "sum":
+							o := NewSumAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "avg":
+							o := NewAvgAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "weighted_avg":
+							o := NewWeightedAvgAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "value_count":
+							o := NewValueCountAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "simple_value":
+							o := NewSimpleValueAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "derivative":
+							o := NewDerivativeAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "bucket_metric_value":
+							o := NewBucketMetricValueAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "stats":
+							o := NewStatsAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "stats_bucket":
+							o := NewStatsBucketAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "extended_stats":
+							o := NewExtendedStatsAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "extended_stats_bucket":
+							o := NewExtendedStatsBucketAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "geo_bounds":
+							o := NewGeoBoundsAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "geo_centroid":
+							o := NewGeoCentroidAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "histogram":
+							o := NewHistogramAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "date_histogram":
+							o := NewDateHistogramAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "auto_date_histogram":
+							o := NewAutoDateHistogramAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "variable_width_histogram":
+							o := NewVariableWidthHistogramAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "sterms":
+							o := NewStringTermsAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "lterms":
+							o := NewLongTermsAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "dterms":
+							o := NewDoubleTermsAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "umterms":
+							o := NewUnmappedTermsAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "lrareterms":
+							o := NewLongRareTermsAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "srareterms":
+							o := NewStringRareTermsAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "umrareterms":
+							o := NewUnmappedRareTermsAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "multi_terms":
+							o := NewMultiTermsAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "missing":
+							o := NewMissingAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "nested":
+							o := NewNestedAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "reverse_nested":
+							o := NewReverseNestedAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "global":
+							o := NewGlobalAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "filter":
+							o := NewFilterAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "children":
+							o := NewChildrenAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "parent":
+							o := NewParentAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "sampler":
+							o := NewSamplerAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "unmapped_sampler":
+							o := NewUnmappedSamplerAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "geohash_grid":
+							o := NewGeoHashGridAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "geotile_grid":
+							o := NewGeoTileGridAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "geohex_grid":
+							o := NewGeoHexGridAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "range":
+							o := NewRangeAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "date_range":
+							o := NewDateRangeAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "geo_distance":
+							o := NewGeoDistanceAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "ip_range":
+							o := NewIpRangeAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "ip_prefix":
+							o := NewIpPrefixAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "filters":
+							o := NewFiltersAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "adjacency_matrix":
+							o := NewAdjacencyMatrixAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "siglterms":
+							o := NewSignificantLongTermsAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "sigsterms":
+							o := NewSignificantStringTermsAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "umsigterms":
+							o := NewUnmappedSignificantTermsAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "composite":
+							o := NewCompositeAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "scripted_metric":
+							o := NewScriptedMetricAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "top_hits":
+							o := NewTopHitsAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "inference":
+							o := NewInferenceAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "string_stats":
+							o := NewStringStatsAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "box_plot":
+							o := NewBoxPlotAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "top_metrics":
+							o := NewTopMetricsAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "t_test":
+							o := NewTTestAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "rate":
+							o := NewRateAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "simple_long_value":
+							o := NewCumulativeCardinalityAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "matrix_stats":
+							o := NewMatrixStatsAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "geo_line":
+							o := NewGeoLineAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						default:
+							o := make(map[string]interface{}, 0)
+							if err := dec.Decode(&o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						}
+					} else {
+						return errors.New("cannot decode JSON for field Aggregations")
+					}
+				} else {
+					o := make(map[string]interface{}, 0)
+					if err := dec.Decode(&o); err != nil {
+						return err
+					}
+					s.Aggregations[value] = o
+				}
+			}
 		}
 	}
 	return nil

--- a/typedapi/types/significantlongtermsbucket.go
+++ b/typedapi/types/significantlongtermsbucket.go
@@ -56,449 +56,11 @@ func (s *SignificantLongTermsBucket) UnmarshalJSON(data []byte) error {
 			return err
 		}
 
-		switch t {
+		if _, ok := t.(json.Delim); ok {
+			continue
+		}
 
-		case "aggregations":
-			for dec.More() {
-				tt, err := dec.Token()
-				if err != nil {
-					if errors.Is(err, io.EOF) {
-						break
-					}
-					return err
-				}
-				if value, ok := tt.(string); ok {
-					if strings.Contains(value, "#") {
-						elems := strings.Split(value, "#")
-						if len(elems) == 2 {
-							switch elems[0] {
-							case "cardinality":
-								o := NewCardinalityAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "hdr_percentiles":
-								o := NewHdrPercentilesAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "hdr_percentile_ranks":
-								o := NewHdrPercentileRanksAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "tdigest_percentiles":
-								o := NewTDigestPercentilesAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "tdigest_percentile_ranks":
-								o := NewTDigestPercentileRanksAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "percentiles_bucket":
-								o := NewPercentilesBucketAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "median_absolute_deviation":
-								o := NewMedianAbsoluteDeviationAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "min":
-								o := NewMinAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "max":
-								o := NewMaxAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "sum":
-								o := NewSumAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "avg":
-								o := NewAvgAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "weighted_avg":
-								o := NewWeightedAvgAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "value_count":
-								o := NewValueCountAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "simple_value":
-								o := NewSimpleValueAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "derivative":
-								o := NewDerivativeAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "bucket_metric_value":
-								o := NewBucketMetricValueAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "stats":
-								o := NewStatsAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "stats_bucket":
-								o := NewStatsBucketAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "extended_stats":
-								o := NewExtendedStatsAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "extended_stats_bucket":
-								o := NewExtendedStatsBucketAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "geo_bounds":
-								o := NewGeoBoundsAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "geo_centroid":
-								o := NewGeoCentroidAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "histogram":
-								o := NewHistogramAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "date_histogram":
-								o := NewDateHistogramAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "auto_date_histogram":
-								o := NewAutoDateHistogramAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "variable_width_histogram":
-								o := NewVariableWidthHistogramAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "sterms":
-								o := NewStringTermsAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "lterms":
-								o := NewLongTermsAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "dterms":
-								o := NewDoubleTermsAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "umterms":
-								o := NewUnmappedTermsAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "lrareterms":
-								o := NewLongRareTermsAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "srareterms":
-								o := NewStringRareTermsAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "umrareterms":
-								o := NewUnmappedRareTermsAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "multi_terms":
-								o := NewMultiTermsAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "missing":
-								o := NewMissingAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "nested":
-								o := NewNestedAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "reverse_nested":
-								o := NewReverseNestedAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "global":
-								o := NewGlobalAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "filter":
-								o := NewFilterAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "children":
-								o := NewChildrenAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "parent":
-								o := NewParentAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "sampler":
-								o := NewSamplerAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "unmapped_sampler":
-								o := NewUnmappedSamplerAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "geohash_grid":
-								o := NewGeoHashGridAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "geotile_grid":
-								o := NewGeoTileGridAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "geohex_grid":
-								o := NewGeoHexGridAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "range":
-								o := NewRangeAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "date_range":
-								o := NewDateRangeAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "geo_distance":
-								o := NewGeoDistanceAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "ip_range":
-								o := NewIpRangeAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "ip_prefix":
-								o := NewIpPrefixAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "filters":
-								o := NewFiltersAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "adjacency_matrix":
-								o := NewAdjacencyMatrixAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "siglterms":
-								o := NewSignificantLongTermsAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "sigsterms":
-								o := NewSignificantStringTermsAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "umsigterms":
-								o := NewUnmappedSignificantTermsAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "composite":
-								o := NewCompositeAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "scripted_metric":
-								o := NewScriptedMetricAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "top_hits":
-								o := NewTopHitsAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "inference":
-								o := NewInferenceAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "string_stats":
-								o := NewStringStatsAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "box_plot":
-								o := NewBoxPlotAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "top_metrics":
-								o := NewTopMetricsAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "t_test":
-								o := NewTTestAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "rate":
-								o := NewRateAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "simple_long_value":
-								o := NewCumulativeCardinalityAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "matrix_stats":
-								o := NewMatrixStatsAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "geo_line":
-								o := NewGeoLineAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							default:
-								o := make(map[string]interface{}, 0)
-								if err := dec.Decode(&o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							}
-						} else {
-							return errors.New("cannot decode JSON for field Aggregations")
-						}
-					} else {
-						o := make(map[string]interface{}, 0)
-						if err := dec.Decode(&o); err != nil {
-							return err
-						}
-						s.Aggregations[value] = o
-					}
-				}
-			}
+		switch t {
 
 		case "bg_count":
 			if err := dec.Decode(&s.BgCount); err != nil {
@@ -525,6 +87,442 @@ func (s *SignificantLongTermsBucket) UnmarshalJSON(data []byte) error {
 				return err
 			}
 
+		default:
+			if value, ok := t.(string); ok {
+				if s.Aggregations == nil {
+					s.Aggregations = make(map[string]Aggregate, 0)
+				}
+
+				if strings.Contains(value, "#") {
+					elems := strings.Split(value, "#")
+					if len(elems) == 2 {
+						switch elems[0] {
+						case "cardinality":
+							o := NewCardinalityAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "hdr_percentiles":
+							o := NewHdrPercentilesAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "hdr_percentile_ranks":
+							o := NewHdrPercentileRanksAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "tdigest_percentiles":
+							o := NewTDigestPercentilesAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "tdigest_percentile_ranks":
+							o := NewTDigestPercentileRanksAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "percentiles_bucket":
+							o := NewPercentilesBucketAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "median_absolute_deviation":
+							o := NewMedianAbsoluteDeviationAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "min":
+							o := NewMinAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "max":
+							o := NewMaxAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "sum":
+							o := NewSumAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "avg":
+							o := NewAvgAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "weighted_avg":
+							o := NewWeightedAvgAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "value_count":
+							o := NewValueCountAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "simple_value":
+							o := NewSimpleValueAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "derivative":
+							o := NewDerivativeAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "bucket_metric_value":
+							o := NewBucketMetricValueAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "stats":
+							o := NewStatsAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "stats_bucket":
+							o := NewStatsBucketAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "extended_stats":
+							o := NewExtendedStatsAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "extended_stats_bucket":
+							o := NewExtendedStatsBucketAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "geo_bounds":
+							o := NewGeoBoundsAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "geo_centroid":
+							o := NewGeoCentroidAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "histogram":
+							o := NewHistogramAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "date_histogram":
+							o := NewDateHistogramAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "auto_date_histogram":
+							o := NewAutoDateHistogramAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "variable_width_histogram":
+							o := NewVariableWidthHistogramAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "sterms":
+							o := NewStringTermsAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "lterms":
+							o := NewLongTermsAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "dterms":
+							o := NewDoubleTermsAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "umterms":
+							o := NewUnmappedTermsAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "lrareterms":
+							o := NewLongRareTermsAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "srareterms":
+							o := NewStringRareTermsAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "umrareterms":
+							o := NewUnmappedRareTermsAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "multi_terms":
+							o := NewMultiTermsAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "missing":
+							o := NewMissingAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "nested":
+							o := NewNestedAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "reverse_nested":
+							o := NewReverseNestedAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "global":
+							o := NewGlobalAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "filter":
+							o := NewFilterAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "children":
+							o := NewChildrenAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "parent":
+							o := NewParentAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "sampler":
+							o := NewSamplerAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "unmapped_sampler":
+							o := NewUnmappedSamplerAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "geohash_grid":
+							o := NewGeoHashGridAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "geotile_grid":
+							o := NewGeoTileGridAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "geohex_grid":
+							o := NewGeoHexGridAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "range":
+							o := NewRangeAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "date_range":
+							o := NewDateRangeAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "geo_distance":
+							o := NewGeoDistanceAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "ip_range":
+							o := NewIpRangeAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "ip_prefix":
+							o := NewIpPrefixAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "filters":
+							o := NewFiltersAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "adjacency_matrix":
+							o := NewAdjacencyMatrixAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "siglterms":
+							o := NewSignificantLongTermsAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "sigsterms":
+							o := NewSignificantStringTermsAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "umsigterms":
+							o := NewUnmappedSignificantTermsAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "composite":
+							o := NewCompositeAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "scripted_metric":
+							o := NewScriptedMetricAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "top_hits":
+							o := NewTopHitsAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "inference":
+							o := NewInferenceAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "string_stats":
+							o := NewStringStatsAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "box_plot":
+							o := NewBoxPlotAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "top_metrics":
+							o := NewTopMetricsAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "t_test":
+							o := NewTTestAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "rate":
+							o := NewRateAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "simple_long_value":
+							o := NewCumulativeCardinalityAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "matrix_stats":
+							o := NewMatrixStatsAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "geo_line":
+							o := NewGeoLineAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						default:
+							o := make(map[string]interface{}, 0)
+							if err := dec.Decode(&o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						}
+					} else {
+						return errors.New("cannot decode JSON for field Aggregations")
+					}
+				} else {
+					o := make(map[string]interface{}, 0)
+					if err := dec.Decode(&o); err != nil {
+						return err
+					}
+					s.Aggregations[value] = o
+				}
+			}
 		}
 	}
 	return nil

--- a/typedapi/types/significantstringtermsbucket.go
+++ b/typedapi/types/significantstringtermsbucket.go
@@ -55,449 +55,11 @@ func (s *SignificantStringTermsBucket) UnmarshalJSON(data []byte) error {
 			return err
 		}
 
-		switch t {
+		if _, ok := t.(json.Delim); ok {
+			continue
+		}
 
-		case "aggregations":
-			for dec.More() {
-				tt, err := dec.Token()
-				if err != nil {
-					if errors.Is(err, io.EOF) {
-						break
-					}
-					return err
-				}
-				if value, ok := tt.(string); ok {
-					if strings.Contains(value, "#") {
-						elems := strings.Split(value, "#")
-						if len(elems) == 2 {
-							switch elems[0] {
-							case "cardinality":
-								o := NewCardinalityAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "hdr_percentiles":
-								o := NewHdrPercentilesAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "hdr_percentile_ranks":
-								o := NewHdrPercentileRanksAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "tdigest_percentiles":
-								o := NewTDigestPercentilesAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "tdigest_percentile_ranks":
-								o := NewTDigestPercentileRanksAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "percentiles_bucket":
-								o := NewPercentilesBucketAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "median_absolute_deviation":
-								o := NewMedianAbsoluteDeviationAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "min":
-								o := NewMinAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "max":
-								o := NewMaxAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "sum":
-								o := NewSumAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "avg":
-								o := NewAvgAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "weighted_avg":
-								o := NewWeightedAvgAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "value_count":
-								o := NewValueCountAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "simple_value":
-								o := NewSimpleValueAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "derivative":
-								o := NewDerivativeAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "bucket_metric_value":
-								o := NewBucketMetricValueAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "stats":
-								o := NewStatsAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "stats_bucket":
-								o := NewStatsBucketAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "extended_stats":
-								o := NewExtendedStatsAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "extended_stats_bucket":
-								o := NewExtendedStatsBucketAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "geo_bounds":
-								o := NewGeoBoundsAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "geo_centroid":
-								o := NewGeoCentroidAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "histogram":
-								o := NewHistogramAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "date_histogram":
-								o := NewDateHistogramAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "auto_date_histogram":
-								o := NewAutoDateHistogramAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "variable_width_histogram":
-								o := NewVariableWidthHistogramAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "sterms":
-								o := NewStringTermsAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "lterms":
-								o := NewLongTermsAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "dterms":
-								o := NewDoubleTermsAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "umterms":
-								o := NewUnmappedTermsAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "lrareterms":
-								o := NewLongRareTermsAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "srareterms":
-								o := NewStringRareTermsAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "umrareterms":
-								o := NewUnmappedRareTermsAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "multi_terms":
-								o := NewMultiTermsAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "missing":
-								o := NewMissingAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "nested":
-								o := NewNestedAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "reverse_nested":
-								o := NewReverseNestedAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "global":
-								o := NewGlobalAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "filter":
-								o := NewFilterAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "children":
-								o := NewChildrenAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "parent":
-								o := NewParentAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "sampler":
-								o := NewSamplerAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "unmapped_sampler":
-								o := NewUnmappedSamplerAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "geohash_grid":
-								o := NewGeoHashGridAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "geotile_grid":
-								o := NewGeoTileGridAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "geohex_grid":
-								o := NewGeoHexGridAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "range":
-								o := NewRangeAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "date_range":
-								o := NewDateRangeAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "geo_distance":
-								o := NewGeoDistanceAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "ip_range":
-								o := NewIpRangeAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "ip_prefix":
-								o := NewIpPrefixAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "filters":
-								o := NewFiltersAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "adjacency_matrix":
-								o := NewAdjacencyMatrixAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "siglterms":
-								o := NewSignificantLongTermsAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "sigsterms":
-								o := NewSignificantStringTermsAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "umsigterms":
-								o := NewUnmappedSignificantTermsAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "composite":
-								o := NewCompositeAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "scripted_metric":
-								o := NewScriptedMetricAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "top_hits":
-								o := NewTopHitsAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "inference":
-								o := NewInferenceAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "string_stats":
-								o := NewStringStatsAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "box_plot":
-								o := NewBoxPlotAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "top_metrics":
-								o := NewTopMetricsAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "t_test":
-								o := NewTTestAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "rate":
-								o := NewRateAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "simple_long_value":
-								o := NewCumulativeCardinalityAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "matrix_stats":
-								o := NewMatrixStatsAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "geo_line":
-								o := NewGeoLineAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							default:
-								o := make(map[string]interface{}, 0)
-								if err := dec.Decode(&o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							}
-						} else {
-							return errors.New("cannot decode JSON for field Aggregations")
-						}
-					} else {
-						o := make(map[string]interface{}, 0)
-						if err := dec.Decode(&o); err != nil {
-							return err
-						}
-						s.Aggregations[value] = o
-					}
-				}
-			}
+		switch t {
 
 		case "bg_count":
 			if err := dec.Decode(&s.BgCount); err != nil {
@@ -519,6 +81,442 @@ func (s *SignificantStringTermsBucket) UnmarshalJSON(data []byte) error {
 				return err
 			}
 
+		default:
+			if value, ok := t.(string); ok {
+				if s.Aggregations == nil {
+					s.Aggregations = make(map[string]Aggregate, 0)
+				}
+
+				if strings.Contains(value, "#") {
+					elems := strings.Split(value, "#")
+					if len(elems) == 2 {
+						switch elems[0] {
+						case "cardinality":
+							o := NewCardinalityAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "hdr_percentiles":
+							o := NewHdrPercentilesAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "hdr_percentile_ranks":
+							o := NewHdrPercentileRanksAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "tdigest_percentiles":
+							o := NewTDigestPercentilesAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "tdigest_percentile_ranks":
+							o := NewTDigestPercentileRanksAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "percentiles_bucket":
+							o := NewPercentilesBucketAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "median_absolute_deviation":
+							o := NewMedianAbsoluteDeviationAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "min":
+							o := NewMinAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "max":
+							o := NewMaxAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "sum":
+							o := NewSumAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "avg":
+							o := NewAvgAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "weighted_avg":
+							o := NewWeightedAvgAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "value_count":
+							o := NewValueCountAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "simple_value":
+							o := NewSimpleValueAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "derivative":
+							o := NewDerivativeAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "bucket_metric_value":
+							o := NewBucketMetricValueAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "stats":
+							o := NewStatsAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "stats_bucket":
+							o := NewStatsBucketAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "extended_stats":
+							o := NewExtendedStatsAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "extended_stats_bucket":
+							o := NewExtendedStatsBucketAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "geo_bounds":
+							o := NewGeoBoundsAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "geo_centroid":
+							o := NewGeoCentroidAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "histogram":
+							o := NewHistogramAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "date_histogram":
+							o := NewDateHistogramAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "auto_date_histogram":
+							o := NewAutoDateHistogramAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "variable_width_histogram":
+							o := NewVariableWidthHistogramAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "sterms":
+							o := NewStringTermsAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "lterms":
+							o := NewLongTermsAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "dterms":
+							o := NewDoubleTermsAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "umterms":
+							o := NewUnmappedTermsAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "lrareterms":
+							o := NewLongRareTermsAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "srareterms":
+							o := NewStringRareTermsAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "umrareterms":
+							o := NewUnmappedRareTermsAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "multi_terms":
+							o := NewMultiTermsAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "missing":
+							o := NewMissingAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "nested":
+							o := NewNestedAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "reverse_nested":
+							o := NewReverseNestedAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "global":
+							o := NewGlobalAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "filter":
+							o := NewFilterAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "children":
+							o := NewChildrenAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "parent":
+							o := NewParentAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "sampler":
+							o := NewSamplerAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "unmapped_sampler":
+							o := NewUnmappedSamplerAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "geohash_grid":
+							o := NewGeoHashGridAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "geotile_grid":
+							o := NewGeoTileGridAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "geohex_grid":
+							o := NewGeoHexGridAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "range":
+							o := NewRangeAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "date_range":
+							o := NewDateRangeAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "geo_distance":
+							o := NewGeoDistanceAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "ip_range":
+							o := NewIpRangeAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "ip_prefix":
+							o := NewIpPrefixAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "filters":
+							o := NewFiltersAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "adjacency_matrix":
+							o := NewAdjacencyMatrixAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "siglterms":
+							o := NewSignificantLongTermsAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "sigsterms":
+							o := NewSignificantStringTermsAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "umsigterms":
+							o := NewUnmappedSignificantTermsAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "composite":
+							o := NewCompositeAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "scripted_metric":
+							o := NewScriptedMetricAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "top_hits":
+							o := NewTopHitsAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "inference":
+							o := NewInferenceAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "string_stats":
+							o := NewStringStatsAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "box_plot":
+							o := NewBoxPlotAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "top_metrics":
+							o := NewTopMetricsAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "t_test":
+							o := NewTTestAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "rate":
+							o := NewRateAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "simple_long_value":
+							o := NewCumulativeCardinalityAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "matrix_stats":
+							o := NewMatrixStatsAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "geo_line":
+							o := NewGeoLineAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						default:
+							o := make(map[string]interface{}, 0)
+							if err := dec.Decode(&o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						}
+					} else {
+						return errors.New("cannot decode JSON for field Aggregations")
+					}
+				} else {
+					o := make(map[string]interface{}, 0)
+					if err := dec.Decode(&o); err != nil {
+						return err
+					}
+					s.Aggregations[value] = o
+				}
+			}
 		}
 	}
 	return nil

--- a/typedapi/types/stringraretermsbucket.go
+++ b/typedapi/types/stringraretermsbucket.go
@@ -53,449 +53,11 @@ func (s *StringRareTermsBucket) UnmarshalJSON(data []byte) error {
 			return err
 		}
 
-		switch t {
+		if _, ok := t.(json.Delim); ok {
+			continue
+		}
 
-		case "aggregations":
-			for dec.More() {
-				tt, err := dec.Token()
-				if err != nil {
-					if errors.Is(err, io.EOF) {
-						break
-					}
-					return err
-				}
-				if value, ok := tt.(string); ok {
-					if strings.Contains(value, "#") {
-						elems := strings.Split(value, "#")
-						if len(elems) == 2 {
-							switch elems[0] {
-							case "cardinality":
-								o := NewCardinalityAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "hdr_percentiles":
-								o := NewHdrPercentilesAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "hdr_percentile_ranks":
-								o := NewHdrPercentileRanksAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "tdigest_percentiles":
-								o := NewTDigestPercentilesAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "tdigest_percentile_ranks":
-								o := NewTDigestPercentileRanksAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "percentiles_bucket":
-								o := NewPercentilesBucketAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "median_absolute_deviation":
-								o := NewMedianAbsoluteDeviationAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "min":
-								o := NewMinAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "max":
-								o := NewMaxAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "sum":
-								o := NewSumAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "avg":
-								o := NewAvgAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "weighted_avg":
-								o := NewWeightedAvgAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "value_count":
-								o := NewValueCountAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "simple_value":
-								o := NewSimpleValueAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "derivative":
-								o := NewDerivativeAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "bucket_metric_value":
-								o := NewBucketMetricValueAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "stats":
-								o := NewStatsAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "stats_bucket":
-								o := NewStatsBucketAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "extended_stats":
-								o := NewExtendedStatsAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "extended_stats_bucket":
-								o := NewExtendedStatsBucketAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "geo_bounds":
-								o := NewGeoBoundsAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "geo_centroid":
-								o := NewGeoCentroidAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "histogram":
-								o := NewHistogramAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "date_histogram":
-								o := NewDateHistogramAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "auto_date_histogram":
-								o := NewAutoDateHistogramAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "variable_width_histogram":
-								o := NewVariableWidthHistogramAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "sterms":
-								o := NewStringTermsAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "lterms":
-								o := NewLongTermsAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "dterms":
-								o := NewDoubleTermsAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "umterms":
-								o := NewUnmappedTermsAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "lrareterms":
-								o := NewLongRareTermsAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "srareterms":
-								o := NewStringRareTermsAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "umrareterms":
-								o := NewUnmappedRareTermsAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "multi_terms":
-								o := NewMultiTermsAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "missing":
-								o := NewMissingAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "nested":
-								o := NewNestedAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "reverse_nested":
-								o := NewReverseNestedAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "global":
-								o := NewGlobalAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "filter":
-								o := NewFilterAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "children":
-								o := NewChildrenAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "parent":
-								o := NewParentAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "sampler":
-								o := NewSamplerAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "unmapped_sampler":
-								o := NewUnmappedSamplerAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "geohash_grid":
-								o := NewGeoHashGridAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "geotile_grid":
-								o := NewGeoTileGridAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "geohex_grid":
-								o := NewGeoHexGridAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "range":
-								o := NewRangeAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "date_range":
-								o := NewDateRangeAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "geo_distance":
-								o := NewGeoDistanceAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "ip_range":
-								o := NewIpRangeAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "ip_prefix":
-								o := NewIpPrefixAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "filters":
-								o := NewFiltersAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "adjacency_matrix":
-								o := NewAdjacencyMatrixAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "siglterms":
-								o := NewSignificantLongTermsAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "sigsterms":
-								o := NewSignificantStringTermsAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "umsigterms":
-								o := NewUnmappedSignificantTermsAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "composite":
-								o := NewCompositeAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "scripted_metric":
-								o := NewScriptedMetricAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "top_hits":
-								o := NewTopHitsAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "inference":
-								o := NewInferenceAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "string_stats":
-								o := NewStringStatsAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "box_plot":
-								o := NewBoxPlotAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "top_metrics":
-								o := NewTopMetricsAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "t_test":
-								o := NewTTestAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "rate":
-								o := NewRateAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "simple_long_value":
-								o := NewCumulativeCardinalityAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "matrix_stats":
-								o := NewMatrixStatsAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "geo_line":
-								o := NewGeoLineAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							default:
-								o := make(map[string]interface{}, 0)
-								if err := dec.Decode(&o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							}
-						} else {
-							return errors.New("cannot decode JSON for field Aggregations")
-						}
-					} else {
-						o := make(map[string]interface{}, 0)
-						if err := dec.Decode(&o); err != nil {
-							return err
-						}
-						s.Aggregations[value] = o
-					}
-				}
-			}
+		switch t {
 
 		case "doc_count":
 			if err := dec.Decode(&s.DocCount); err != nil {
@@ -507,6 +69,442 @@ func (s *StringRareTermsBucket) UnmarshalJSON(data []byte) error {
 				return err
 			}
 
+		default:
+			if value, ok := t.(string); ok {
+				if s.Aggregations == nil {
+					s.Aggregations = make(map[string]Aggregate, 0)
+				}
+
+				if strings.Contains(value, "#") {
+					elems := strings.Split(value, "#")
+					if len(elems) == 2 {
+						switch elems[0] {
+						case "cardinality":
+							o := NewCardinalityAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "hdr_percentiles":
+							o := NewHdrPercentilesAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "hdr_percentile_ranks":
+							o := NewHdrPercentileRanksAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "tdigest_percentiles":
+							o := NewTDigestPercentilesAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "tdigest_percentile_ranks":
+							o := NewTDigestPercentileRanksAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "percentiles_bucket":
+							o := NewPercentilesBucketAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "median_absolute_deviation":
+							o := NewMedianAbsoluteDeviationAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "min":
+							o := NewMinAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "max":
+							o := NewMaxAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "sum":
+							o := NewSumAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "avg":
+							o := NewAvgAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "weighted_avg":
+							o := NewWeightedAvgAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "value_count":
+							o := NewValueCountAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "simple_value":
+							o := NewSimpleValueAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "derivative":
+							o := NewDerivativeAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "bucket_metric_value":
+							o := NewBucketMetricValueAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "stats":
+							o := NewStatsAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "stats_bucket":
+							o := NewStatsBucketAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "extended_stats":
+							o := NewExtendedStatsAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "extended_stats_bucket":
+							o := NewExtendedStatsBucketAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "geo_bounds":
+							o := NewGeoBoundsAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "geo_centroid":
+							o := NewGeoCentroidAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "histogram":
+							o := NewHistogramAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "date_histogram":
+							o := NewDateHistogramAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "auto_date_histogram":
+							o := NewAutoDateHistogramAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "variable_width_histogram":
+							o := NewVariableWidthHistogramAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "sterms":
+							o := NewStringTermsAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "lterms":
+							o := NewLongTermsAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "dterms":
+							o := NewDoubleTermsAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "umterms":
+							o := NewUnmappedTermsAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "lrareterms":
+							o := NewLongRareTermsAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "srareterms":
+							o := NewStringRareTermsAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "umrareterms":
+							o := NewUnmappedRareTermsAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "multi_terms":
+							o := NewMultiTermsAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "missing":
+							o := NewMissingAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "nested":
+							o := NewNestedAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "reverse_nested":
+							o := NewReverseNestedAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "global":
+							o := NewGlobalAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "filter":
+							o := NewFilterAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "children":
+							o := NewChildrenAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "parent":
+							o := NewParentAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "sampler":
+							o := NewSamplerAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "unmapped_sampler":
+							o := NewUnmappedSamplerAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "geohash_grid":
+							o := NewGeoHashGridAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "geotile_grid":
+							o := NewGeoTileGridAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "geohex_grid":
+							o := NewGeoHexGridAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "range":
+							o := NewRangeAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "date_range":
+							o := NewDateRangeAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "geo_distance":
+							o := NewGeoDistanceAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "ip_range":
+							o := NewIpRangeAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "ip_prefix":
+							o := NewIpPrefixAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "filters":
+							o := NewFiltersAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "adjacency_matrix":
+							o := NewAdjacencyMatrixAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "siglterms":
+							o := NewSignificantLongTermsAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "sigsterms":
+							o := NewSignificantStringTermsAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "umsigterms":
+							o := NewUnmappedSignificantTermsAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "composite":
+							o := NewCompositeAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "scripted_metric":
+							o := NewScriptedMetricAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "top_hits":
+							o := NewTopHitsAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "inference":
+							o := NewInferenceAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "string_stats":
+							o := NewStringStatsAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "box_plot":
+							o := NewBoxPlotAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "top_metrics":
+							o := NewTopMetricsAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "t_test":
+							o := NewTTestAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "rate":
+							o := NewRateAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "simple_long_value":
+							o := NewCumulativeCardinalityAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "matrix_stats":
+							o := NewMatrixStatsAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "geo_line":
+							o := NewGeoLineAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						default:
+							o := make(map[string]interface{}, 0)
+							if err := dec.Decode(&o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						}
+					} else {
+						return errors.New("cannot decode JSON for field Aggregations")
+					}
+				} else {
+					o := make(map[string]interface{}, 0)
+					if err := dec.Decode(&o); err != nil {
+						return err
+					}
+					s.Aggregations[value] = o
+				}
+			}
 		}
 	}
 	return nil

--- a/typedapi/types/stringtermsbucket.go
+++ b/typedapi/types/stringtermsbucket.go
@@ -54,449 +54,11 @@ func (s *StringTermsBucket) UnmarshalJSON(data []byte) error {
 			return err
 		}
 
-		switch t {
+		if _, ok := t.(json.Delim); ok {
+			continue
+		}
 
-		case "aggregations":
-			for dec.More() {
-				tt, err := dec.Token()
-				if err != nil {
-					if errors.Is(err, io.EOF) {
-						break
-					}
-					return err
-				}
-				if value, ok := tt.(string); ok {
-					if strings.Contains(value, "#") {
-						elems := strings.Split(value, "#")
-						if len(elems) == 2 {
-							switch elems[0] {
-							case "cardinality":
-								o := NewCardinalityAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "hdr_percentiles":
-								o := NewHdrPercentilesAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "hdr_percentile_ranks":
-								o := NewHdrPercentileRanksAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "tdigest_percentiles":
-								o := NewTDigestPercentilesAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "tdigest_percentile_ranks":
-								o := NewTDigestPercentileRanksAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "percentiles_bucket":
-								o := NewPercentilesBucketAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "median_absolute_deviation":
-								o := NewMedianAbsoluteDeviationAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "min":
-								o := NewMinAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "max":
-								o := NewMaxAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "sum":
-								o := NewSumAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "avg":
-								o := NewAvgAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "weighted_avg":
-								o := NewWeightedAvgAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "value_count":
-								o := NewValueCountAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "simple_value":
-								o := NewSimpleValueAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "derivative":
-								o := NewDerivativeAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "bucket_metric_value":
-								o := NewBucketMetricValueAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "stats":
-								o := NewStatsAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "stats_bucket":
-								o := NewStatsBucketAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "extended_stats":
-								o := NewExtendedStatsAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "extended_stats_bucket":
-								o := NewExtendedStatsBucketAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "geo_bounds":
-								o := NewGeoBoundsAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "geo_centroid":
-								o := NewGeoCentroidAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "histogram":
-								o := NewHistogramAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "date_histogram":
-								o := NewDateHistogramAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "auto_date_histogram":
-								o := NewAutoDateHistogramAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "variable_width_histogram":
-								o := NewVariableWidthHistogramAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "sterms":
-								o := NewStringTermsAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "lterms":
-								o := NewLongTermsAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "dterms":
-								o := NewDoubleTermsAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "umterms":
-								o := NewUnmappedTermsAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "lrareterms":
-								o := NewLongRareTermsAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "srareterms":
-								o := NewStringRareTermsAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "umrareterms":
-								o := NewUnmappedRareTermsAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "multi_terms":
-								o := NewMultiTermsAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "missing":
-								o := NewMissingAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "nested":
-								o := NewNestedAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "reverse_nested":
-								o := NewReverseNestedAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "global":
-								o := NewGlobalAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "filter":
-								o := NewFilterAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "children":
-								o := NewChildrenAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "parent":
-								o := NewParentAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "sampler":
-								o := NewSamplerAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "unmapped_sampler":
-								o := NewUnmappedSamplerAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "geohash_grid":
-								o := NewGeoHashGridAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "geotile_grid":
-								o := NewGeoTileGridAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "geohex_grid":
-								o := NewGeoHexGridAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "range":
-								o := NewRangeAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "date_range":
-								o := NewDateRangeAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "geo_distance":
-								o := NewGeoDistanceAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "ip_range":
-								o := NewIpRangeAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "ip_prefix":
-								o := NewIpPrefixAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "filters":
-								o := NewFiltersAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "adjacency_matrix":
-								o := NewAdjacencyMatrixAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "siglterms":
-								o := NewSignificantLongTermsAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "sigsterms":
-								o := NewSignificantStringTermsAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "umsigterms":
-								o := NewUnmappedSignificantTermsAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "composite":
-								o := NewCompositeAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "scripted_metric":
-								o := NewScriptedMetricAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "top_hits":
-								o := NewTopHitsAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "inference":
-								o := NewInferenceAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "string_stats":
-								o := NewStringStatsAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "box_plot":
-								o := NewBoxPlotAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "top_metrics":
-								o := NewTopMetricsAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "t_test":
-								o := NewTTestAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "rate":
-								o := NewRateAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "simple_long_value":
-								o := NewCumulativeCardinalityAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "matrix_stats":
-								o := NewMatrixStatsAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "geo_line":
-								o := NewGeoLineAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							default:
-								o := make(map[string]interface{}, 0)
-								if err := dec.Decode(&o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							}
-						} else {
-							return errors.New("cannot decode JSON for field Aggregations")
-						}
-					} else {
-						o := make(map[string]interface{}, 0)
-						if err := dec.Decode(&o); err != nil {
-							return err
-						}
-						s.Aggregations[value] = o
-					}
-				}
-			}
+		switch t {
 
 		case "doc_count":
 			if err := dec.Decode(&s.DocCount); err != nil {
@@ -513,6 +75,442 @@ func (s *StringTermsBucket) UnmarshalJSON(data []byte) error {
 				return err
 			}
 
+		default:
+			if value, ok := t.(string); ok {
+				if s.Aggregations == nil {
+					s.Aggregations = make(map[string]Aggregate, 0)
+				}
+
+				if strings.Contains(value, "#") {
+					elems := strings.Split(value, "#")
+					if len(elems) == 2 {
+						switch elems[0] {
+						case "cardinality":
+							o := NewCardinalityAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "hdr_percentiles":
+							o := NewHdrPercentilesAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "hdr_percentile_ranks":
+							o := NewHdrPercentileRanksAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "tdigest_percentiles":
+							o := NewTDigestPercentilesAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "tdigest_percentile_ranks":
+							o := NewTDigestPercentileRanksAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "percentiles_bucket":
+							o := NewPercentilesBucketAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "median_absolute_deviation":
+							o := NewMedianAbsoluteDeviationAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "min":
+							o := NewMinAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "max":
+							o := NewMaxAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "sum":
+							o := NewSumAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "avg":
+							o := NewAvgAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "weighted_avg":
+							o := NewWeightedAvgAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "value_count":
+							o := NewValueCountAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "simple_value":
+							o := NewSimpleValueAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "derivative":
+							o := NewDerivativeAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "bucket_metric_value":
+							o := NewBucketMetricValueAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "stats":
+							o := NewStatsAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "stats_bucket":
+							o := NewStatsBucketAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "extended_stats":
+							o := NewExtendedStatsAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "extended_stats_bucket":
+							o := NewExtendedStatsBucketAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "geo_bounds":
+							o := NewGeoBoundsAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "geo_centroid":
+							o := NewGeoCentroidAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "histogram":
+							o := NewHistogramAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "date_histogram":
+							o := NewDateHistogramAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "auto_date_histogram":
+							o := NewAutoDateHistogramAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "variable_width_histogram":
+							o := NewVariableWidthHistogramAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "sterms":
+							o := NewStringTermsAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "lterms":
+							o := NewLongTermsAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "dterms":
+							o := NewDoubleTermsAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "umterms":
+							o := NewUnmappedTermsAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "lrareterms":
+							o := NewLongRareTermsAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "srareterms":
+							o := NewStringRareTermsAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "umrareterms":
+							o := NewUnmappedRareTermsAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "multi_terms":
+							o := NewMultiTermsAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "missing":
+							o := NewMissingAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "nested":
+							o := NewNestedAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "reverse_nested":
+							o := NewReverseNestedAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "global":
+							o := NewGlobalAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "filter":
+							o := NewFilterAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "children":
+							o := NewChildrenAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "parent":
+							o := NewParentAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "sampler":
+							o := NewSamplerAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "unmapped_sampler":
+							o := NewUnmappedSamplerAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "geohash_grid":
+							o := NewGeoHashGridAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "geotile_grid":
+							o := NewGeoTileGridAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "geohex_grid":
+							o := NewGeoHexGridAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "range":
+							o := NewRangeAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "date_range":
+							o := NewDateRangeAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "geo_distance":
+							o := NewGeoDistanceAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "ip_range":
+							o := NewIpRangeAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "ip_prefix":
+							o := NewIpPrefixAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "filters":
+							o := NewFiltersAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "adjacency_matrix":
+							o := NewAdjacencyMatrixAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "siglterms":
+							o := NewSignificantLongTermsAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "sigsterms":
+							o := NewSignificantStringTermsAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "umsigterms":
+							o := NewUnmappedSignificantTermsAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "composite":
+							o := NewCompositeAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "scripted_metric":
+							o := NewScriptedMetricAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "top_hits":
+							o := NewTopHitsAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "inference":
+							o := NewInferenceAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "string_stats":
+							o := NewStringStatsAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "box_plot":
+							o := NewBoxPlotAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "top_metrics":
+							o := NewTopMetricsAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "t_test":
+							o := NewTTestAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "rate":
+							o := NewRateAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "simple_long_value":
+							o := NewCumulativeCardinalityAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "matrix_stats":
+							o := NewMatrixStatsAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "geo_line":
+							o := NewGeoLineAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						default:
+							o := make(map[string]interface{}, 0)
+							if err := dec.Decode(&o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						}
+					} else {
+						return errors.New("cannot decode JSON for field Aggregations")
+					}
+				} else {
+					o := make(map[string]interface{}, 0)
+					if err := dec.Decode(&o); err != nil {
+						return err
+					}
+					s.Aggregations[value] = o
+				}
+			}
 		}
 	}
 	return nil

--- a/typedapi/types/variablewidthhistogrambucket.go
+++ b/typedapi/types/variablewidthhistogrambucket.go
@@ -58,449 +58,11 @@ func (s *VariableWidthHistogramBucket) UnmarshalJSON(data []byte) error {
 			return err
 		}
 
-		switch t {
+		if _, ok := t.(json.Delim); ok {
+			continue
+		}
 
-		case "aggregations":
-			for dec.More() {
-				tt, err := dec.Token()
-				if err != nil {
-					if errors.Is(err, io.EOF) {
-						break
-					}
-					return err
-				}
-				if value, ok := tt.(string); ok {
-					if strings.Contains(value, "#") {
-						elems := strings.Split(value, "#")
-						if len(elems) == 2 {
-							switch elems[0] {
-							case "cardinality":
-								o := NewCardinalityAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "hdr_percentiles":
-								o := NewHdrPercentilesAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "hdr_percentile_ranks":
-								o := NewHdrPercentileRanksAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "tdigest_percentiles":
-								o := NewTDigestPercentilesAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "tdigest_percentile_ranks":
-								o := NewTDigestPercentileRanksAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "percentiles_bucket":
-								o := NewPercentilesBucketAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "median_absolute_deviation":
-								o := NewMedianAbsoluteDeviationAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "min":
-								o := NewMinAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "max":
-								o := NewMaxAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "sum":
-								o := NewSumAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "avg":
-								o := NewAvgAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "weighted_avg":
-								o := NewWeightedAvgAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "value_count":
-								o := NewValueCountAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "simple_value":
-								o := NewSimpleValueAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "derivative":
-								o := NewDerivativeAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "bucket_metric_value":
-								o := NewBucketMetricValueAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "stats":
-								o := NewStatsAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "stats_bucket":
-								o := NewStatsBucketAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "extended_stats":
-								o := NewExtendedStatsAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "extended_stats_bucket":
-								o := NewExtendedStatsBucketAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "geo_bounds":
-								o := NewGeoBoundsAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "geo_centroid":
-								o := NewGeoCentroidAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "histogram":
-								o := NewHistogramAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "date_histogram":
-								o := NewDateHistogramAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "auto_date_histogram":
-								o := NewAutoDateHistogramAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "variable_width_histogram":
-								o := NewVariableWidthHistogramAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "sterms":
-								o := NewStringTermsAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "lterms":
-								o := NewLongTermsAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "dterms":
-								o := NewDoubleTermsAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "umterms":
-								o := NewUnmappedTermsAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "lrareterms":
-								o := NewLongRareTermsAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "srareterms":
-								o := NewStringRareTermsAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "umrareterms":
-								o := NewUnmappedRareTermsAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "multi_terms":
-								o := NewMultiTermsAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "missing":
-								o := NewMissingAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "nested":
-								o := NewNestedAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "reverse_nested":
-								o := NewReverseNestedAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "global":
-								o := NewGlobalAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "filter":
-								o := NewFilterAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "children":
-								o := NewChildrenAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "parent":
-								o := NewParentAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "sampler":
-								o := NewSamplerAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "unmapped_sampler":
-								o := NewUnmappedSamplerAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "geohash_grid":
-								o := NewGeoHashGridAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "geotile_grid":
-								o := NewGeoTileGridAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "geohex_grid":
-								o := NewGeoHexGridAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "range":
-								o := NewRangeAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "date_range":
-								o := NewDateRangeAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "geo_distance":
-								o := NewGeoDistanceAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "ip_range":
-								o := NewIpRangeAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "ip_prefix":
-								o := NewIpPrefixAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "filters":
-								o := NewFiltersAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "adjacency_matrix":
-								o := NewAdjacencyMatrixAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "siglterms":
-								o := NewSignificantLongTermsAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "sigsterms":
-								o := NewSignificantStringTermsAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "umsigterms":
-								o := NewUnmappedSignificantTermsAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "composite":
-								o := NewCompositeAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "scripted_metric":
-								o := NewScriptedMetricAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "top_hits":
-								o := NewTopHitsAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "inference":
-								o := NewInferenceAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "string_stats":
-								o := NewStringStatsAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "box_plot":
-								o := NewBoxPlotAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "top_metrics":
-								o := NewTopMetricsAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "t_test":
-								o := NewTTestAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "rate":
-								o := NewRateAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "simple_long_value":
-								o := NewCumulativeCardinalityAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "matrix_stats":
-								o := NewMatrixStatsAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							case "geo_line":
-								o := NewGeoLineAggregate()
-								if err := dec.Decode(o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							default:
-								o := make(map[string]interface{}, 0)
-								if err := dec.Decode(&o); err != nil {
-									return err
-								}
-								s.Aggregations[elems[1]] = o
-							}
-						} else {
-							return errors.New("cannot decode JSON for field Aggregations")
-						}
-					} else {
-						o := make(map[string]interface{}, 0)
-						if err := dec.Decode(&o); err != nil {
-							return err
-						}
-						s.Aggregations[value] = o
-					}
-				}
-			}
+		switch t {
 
 		case "doc_count":
 			if err := dec.Decode(&s.DocCount); err != nil {
@@ -537,6 +99,442 @@ func (s *VariableWidthHistogramBucket) UnmarshalJSON(data []byte) error {
 				return err
 			}
 
+		default:
+			if value, ok := t.(string); ok {
+				if s.Aggregations == nil {
+					s.Aggregations = make(map[string]Aggregate, 0)
+				}
+
+				if strings.Contains(value, "#") {
+					elems := strings.Split(value, "#")
+					if len(elems) == 2 {
+						switch elems[0] {
+						case "cardinality":
+							o := NewCardinalityAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "hdr_percentiles":
+							o := NewHdrPercentilesAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "hdr_percentile_ranks":
+							o := NewHdrPercentileRanksAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "tdigest_percentiles":
+							o := NewTDigestPercentilesAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "tdigest_percentile_ranks":
+							o := NewTDigestPercentileRanksAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "percentiles_bucket":
+							o := NewPercentilesBucketAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "median_absolute_deviation":
+							o := NewMedianAbsoluteDeviationAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "min":
+							o := NewMinAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "max":
+							o := NewMaxAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "sum":
+							o := NewSumAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "avg":
+							o := NewAvgAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "weighted_avg":
+							o := NewWeightedAvgAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "value_count":
+							o := NewValueCountAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "simple_value":
+							o := NewSimpleValueAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "derivative":
+							o := NewDerivativeAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "bucket_metric_value":
+							o := NewBucketMetricValueAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "stats":
+							o := NewStatsAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "stats_bucket":
+							o := NewStatsBucketAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "extended_stats":
+							o := NewExtendedStatsAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "extended_stats_bucket":
+							o := NewExtendedStatsBucketAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "geo_bounds":
+							o := NewGeoBoundsAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "geo_centroid":
+							o := NewGeoCentroidAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "histogram":
+							o := NewHistogramAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "date_histogram":
+							o := NewDateHistogramAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "auto_date_histogram":
+							o := NewAutoDateHistogramAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "variable_width_histogram":
+							o := NewVariableWidthHistogramAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "sterms":
+							o := NewStringTermsAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "lterms":
+							o := NewLongTermsAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "dterms":
+							o := NewDoubleTermsAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "umterms":
+							o := NewUnmappedTermsAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "lrareterms":
+							o := NewLongRareTermsAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "srareterms":
+							o := NewStringRareTermsAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "umrareterms":
+							o := NewUnmappedRareTermsAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "multi_terms":
+							o := NewMultiTermsAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "missing":
+							o := NewMissingAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "nested":
+							o := NewNestedAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "reverse_nested":
+							o := NewReverseNestedAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "global":
+							o := NewGlobalAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "filter":
+							o := NewFilterAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "children":
+							o := NewChildrenAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "parent":
+							o := NewParentAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "sampler":
+							o := NewSamplerAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "unmapped_sampler":
+							o := NewUnmappedSamplerAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "geohash_grid":
+							o := NewGeoHashGridAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "geotile_grid":
+							o := NewGeoTileGridAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "geohex_grid":
+							o := NewGeoHexGridAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "range":
+							o := NewRangeAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "date_range":
+							o := NewDateRangeAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "geo_distance":
+							o := NewGeoDistanceAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "ip_range":
+							o := NewIpRangeAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "ip_prefix":
+							o := NewIpPrefixAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "filters":
+							o := NewFiltersAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "adjacency_matrix":
+							o := NewAdjacencyMatrixAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "siglterms":
+							o := NewSignificantLongTermsAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "sigsterms":
+							o := NewSignificantStringTermsAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "umsigterms":
+							o := NewUnmappedSignificantTermsAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "composite":
+							o := NewCompositeAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "scripted_metric":
+							o := NewScriptedMetricAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "top_hits":
+							o := NewTopHitsAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "inference":
+							o := NewInferenceAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "string_stats":
+							o := NewStringStatsAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "box_plot":
+							o := NewBoxPlotAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "top_metrics":
+							o := NewTopMetricsAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "t_test":
+							o := NewTTestAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "rate":
+							o := NewRateAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "simple_long_value":
+							o := NewCumulativeCardinalityAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "matrix_stats":
+							o := NewMatrixStatsAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						case "geo_line":
+							o := NewGeoLineAggregate()
+							if err := dec.Decode(o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						default:
+							o := make(map[string]interface{}, 0)
+							if err := dec.Decode(&o); err != nil {
+								return err
+							}
+							s.Aggregations[elems[1]] = o
+						}
+					} else {
+						return errors.New("cannot decode JSON for field Aggregations")
+					}
+				} else {
+					o := make(map[string]interface{}, 0)
+					if err := dec.Decode(&o); err != nil {
+						return err
+					}
+					s.Aggregations[value] = o
+				}
+			}
 		}
 	}
 	return nil


### PR DESCRIPTION
Hello, 

I was using the TypedClient to perform a search with multiple aggregations and I was not getting the result I expected.
The SDK was not able to parse the reponse as it was expecting an `aggregations` field for each `Bucket aggregations`


Example:
```
GET /_search?typed_keys=true
{
  "aggs": {
    "genres": {
      "terms": {
        "field": "genre"
      },
      "aggs": {
        "max_play_count": { "max": { "field": "play_count" } }
      }
    }
  }
}
```

Expected Response : 
```
{
  ...
  "aggregations": {
    "terms#genres": {
      "doc_count_error_upper_bound": 0,   
      "sum_other_doc_count": 0,           
      "buckets": [                        
        {
          "key": "electronic",
          "doc_count": 6,
          "max#max_play_count": {
            "value": 40
          }
        },
        {
          "key": "rock",
          "doc_count": 3,
          "max#max_play_count": {
            "value": 20
          }
        },
        {
          "key": "jazz",
          "doc_count": 2,
          "max#max_play_count": {
            "value": 10
          }
        }
      ]
    }
  }
}
```

What I propose is to handle everything that is not a well-known field (`doc_count`, `key`, `key_as_string` and so on) as an `Aggregations`.

I manually update all the `*Bucket` structs as I did not find the tool to generate the TypedClient structs but of course, feel free to move it to the right file.

As I am no expert in `ElasticSearch` maybe there is some others files to update, feel free to tell me !

Thanks
Ludo