### PR TITLE
Reties With not empty URL Path

### DIFF
--- a/estransport/estransport.go
+++ b/estransport/estransport.go
@@ -327,6 +327,8 @@ func (c *Client) Perform(req *http.Request) (*http.Response, error) {
 			}
 		}
 	}
+	
+	originalPath := req.URL.Path
 
 	for i := 0; i <= c.maxRetries; i++ {
 		var (
@@ -422,6 +424,8 @@ func (c *Client) Perform(req *http.Request) (*http.Response, error) {
 		if !shouldRetry {
 			break
 		}
+		
+		req.URL.Path = originalPath
 
 		// Drain and close body when retrying after response
 		if shouldCloseBody && i < c.maxRetries {

--- a/estransport/estransport.go
+++ b/estransport/estransport.go
@@ -329,7 +329,6 @@ func (c *Client) Perform(req *http.Request) (*http.Response, error) {
 	}
 	
 	originalPath := req.URL.Path
-
 	for i := 0; i <= c.maxRetries; i++ {
 		var (
 			conn            *Connection
@@ -424,8 +423,6 @@ func (c *Client) Perform(req *http.Request) (*http.Response, error) {
 		if !shouldRetry {
 			break
 		}
-		
-		req.URL.Path = originalPath
 
 		// Drain and close body when retrying after response
 		if shouldCloseBody && i < c.maxRetries {
@@ -451,6 +448,10 @@ func (c *Client) Perform(req *http.Request) (*http.Response, error) {
 				break
 			}
 		}
+
+		// Re-init the path of the request to its original state
+		// This will be re-enriched by the connection upon retry
+		req.URL.Path = originalPath
 	}
 
 	// TODO(karmi): Wrap error

--- a/estransport/estransport_internal_test.go
+++ b/estransport/estransport_internal_test.go
@@ -657,7 +657,10 @@ func TestTransportPerformRetries(t *testing.T) {
 
 	t.Run("Reset request body during retry", func(t *testing.T) {
 		var bodies []string
-		u, _ := url.Parse("https://foo.com/bar")
+		esUrl := "https://foo.com/bar"
+		endpoint := "/abc"
+
+		u, _ := url.Parse(esUrl)
 		tp, _ := New(Config{
 			URLs: []*url.URL{u},
 			Transport: &mockTransp{
@@ -665,6 +668,10 @@ func TestTransportPerformRetries(t *testing.T) {
 					body, err := ioutil.ReadAll(req.Body)
 					if err != nil {
 						panic(err)
+					}
+					expectedUrl := strings.Join([]string{esUrl, endpoint}, "")
+					if !strings.EqualFold(req.URL.String(), expectedUrl) {
+						t.Fatalf("expected request url to be %s, got: %s", expectedUrl, req.URL.String())
 					}
 					bodies = append(bodies, string(body))
 					return &http.Response{Status: "MOCK", StatusCode: 502}, nil

--- a/estransport/estransport_internal_test.go
+++ b/estransport/estransport_internal_test.go
@@ -657,10 +657,10 @@ func TestTransportPerformRetries(t *testing.T) {
 
 	t.Run("Reset request body during retry", func(t *testing.T) {
 		var bodies []string
-		esUrl := "https://foo.com/bar"
+		esURL := "https://foo.com/bar"
 		endpoint := "/abc"
 
-		u, _ := url.Parse(esUrl)
+		u, _ := url.Parse(esURL)
 		tp, _ := New(Config{
 			URLs: []*url.URL{u},
 			Transport: &mockTransp{
@@ -669,9 +669,9 @@ func TestTransportPerformRetries(t *testing.T) {
 					if err != nil {
 						panic(err)
 					}
-					expectedUrl := strings.Join([]string{esUrl, endpoint}, "")
-					if !strings.EqualFold(req.URL.String(), expectedUrl) {
-						t.Fatalf("expected request url to be %s, got: %s", expectedUrl, req.URL.String())
+					expectedURL := strings.Join([]string{esURL, endpoint}, "")
+					if !strings.EqualFold(req.URL.String(), expectedURL) {
+						t.Fatalf("expected request url to be %s, got: %s", expectedURL, req.URL.String())
 					}
 					bodies = append(bodies, string(body))
 					return &http.Response{Status: "MOCK", StatusCode: 502}, nil


### PR DESCRIPTION
transport builds an incorrect request path if the address is configured with a path, for example:

```
	eCnf := elasticsearch.Config{
		Addresses: []string{
			"https://server.com/somepath"
		},
	}
``` 
it happens when retries is enabled and the API returns an error, transports adds to the request "/somepath" on each retry instead of building a new path.