### PR TITLE
[DOCS] Changes getting started button link on landing page

### DIFF
--- a/.doc/index-custom-title-page.html
+++ b/.doc/index-custom-title-page.html
@@ -63,7 +63,7 @@
         The official Go client provides one-to-one mapping with Elasticsearch REST APIs.
       </p>
       <p>
-        <a href="https://www.elastic.co/guide/en/elasticsearch/client/go-api/current/overview.html">
+        <a href="https://www.elastic.co/guide/en/elasticsearch/client/go-api/current/getting-started-go.html">
           <button class="btn btn-primary">Get started</button>
         </a>
       </p>


### PR DESCRIPTION
## Overview

This PR changes the URL of the getting started button on the landing page.