### PR TITLE
[DOCS] Restructures the repo README

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,40 +53,13 @@ of the getting started documentation.
 
 ## Operations
 
-### Creating an index
-
-Refer to the [Creating an index section](https://www.elastic.co/guide/en/elasticsearch/client/go-api/current/getting-started-go.html#_creating_an_index)
-of the getting started documentation.
-
-### Indexing documents
-
-Refer to the [Indexing documents section](https://www.elastic.co/guide/en/elasticsearch/client/go-api/current/getting-started-go.html#_indexing_documents)
-of the getting started documentation.
-
-### Getting documents
-
-Refer to the [Getting documents section](https://www.elastic.co/guide/en/elasticsearch/client/go-api/current/getting-started-go.html#_getting_documents)
-of the getting started documentation.
-
-### Searching documents
-
-Refer to the [Searching documents section](https://www.elastic.co/guide/en/elasticsearch/client/go-api/current/getting-started-go.html#_searching_documents)
-of the getting started documentation.
-
-### Updating documents
-
-Refer to the [Updating documents section](https://www.elastic.co/guide/en/elasticsearch/client/go-api/current/getting-started-go.html#_updating_documents)
-of the getting started documentation.
-
-### Deleting documents
-
-Refer to the [Deleting documents section](https://www.elastic.co/guide/en/elasticsearch/client/go-api/current/getting-started-go.html#_deleting_documents)
-of the getting started documentation.
-
-### Deleting an index
-
-Refer to the [Deleting an index section](https://www.elastic.co/guide/en/elasticsearch/client/go-api/current/getting-started-go.html#_deleting_an_index)
-of the getting started documentation.
+* [Creating an index](https://www.elastic.co/guide/en/elasticsearch/client/go-api/current/getting-started-go.html#_creating_an_index)
+* [Indexing documents](https://www.elastic.co/guide/en/elasticsearch/client/go-api/current/getting-started-go.html#_indexing_documents)
+* [Getting documents](https://www.elastic.co/guide/en/elasticsearch/client/go-api/current/getting-started-go.html#_getting_documents)
+* [Searching documents](https://www.elastic.co/guide/en/elasticsearch/client/go-api/current/getting-started-go.html#_searching_documents)
+* [Updating documents](https://www.elastic.co/guide/en/elasticsearch/client/go-api/current/getting-started-go.html#_updating_documents)
+* [Deleting documents](https://www.elastic.co/guide/en/elasticsearch/client/go-api/current/getting-started-go.html#_deleting_documents)
+* [Deleting an index](https://www.elastic.co/guide/en/elasticsearch/client/go-api/current/getting-started-go.html#_deleting_an_index)
 <!-- ----------------------------------------------------------------------------------------------- -->
 
 ## Helpers

--- a/README.md
+++ b/README.md
@@ -41,335 +41,52 @@ The `main` branch of the client is compatible with the current `master` branch o
 
 ## Installation
 
-Add the package to your `go.mod` file:
-
-    require github.com/elastic/go-elasticsearch/v8 main
-
-Or, clone the repository:
-
-    git clone --branch main https://github.com/elastic/go-elasticsearch.git $GOPATH/src/github.com/elastic/go-elasticsearch
-
-A complete example:
-
-```bash
-mkdir my-elasticsearch-app && cd my-elasticsearch-app
-
-cat > go.mod <<-END
-  module my-elasticsearch-app
-
-  require github.com/elastic/go-elasticsearch/v8 main
-END
-
-cat > main.go <<-END
-  package main
-
-  import (
-    "log"
-
-    "github.com/elastic/go-elasticsearch/v8"
-  )
-
-  func main() {
-    es, _ := elasticsearch.NewDefaultClient()
-    log.Println(elasticsearch.Version)
-    log.Println(es.Info())
-  }
-END
-
-go run main.go
-```
-
+Refer to the [Installation section][https://www.elastic.co/guide/en/elasticsearch/client/go-api/current/getting-started-go.html#_installation]
+of the getting started documentation.
 
 <!-- ----------------------------------------------------------------------------------------------- -->
 
-## Usage
+## Connecting
 
-The `elasticsearch` package ties together two separate packages for calling the Elasticsearch APIs and transferring data over HTTP: `esapi` and `elastictransport`, respectively.
+Refer to the [Connecting section](https://www.elastic.co/guide/en/elasticsearch/client/go-api/current/getting-started-go.html#_connecting)
+of the getting started documentation.
 
-Use the `elasticsearch.NewDefaultClient()` function to create the client with the default settings.
+## Operations
 
-```golang
-es, err := elasticsearch.NewDefaultClient()
-if err != nil {
-  log.Fatalf("Error creating the client: %s", err)
-}
+### Creating an index
 
-res, err := es.Info()
-if err != nil {
-  log.Fatalf("Error getting response: %s", err)
-}
+Refer to the [Creating an index section](https://www.elastic.co/guide/en/elasticsearch/client/go-api/current/getting-started-go.html#_creating_an_index)
+of the getting started documentation.
 
-defer res.Body.Close()
-log.Println(res)
+### Indexing documents
 
-// [200 OK] {
-//   "name" : "node-1",
-//   "cluster_name" : "go-elasticsearch"
-// ...
-```
+Refer to the [Indexing documents section](https://www.elastic.co/guide/en/elasticsearch/client/go-api/current/getting-started-go.html#_indexing_documents)
+of the getting started documentation.
 
-> NOTE: It is _critical_ to both close the response body _and_ to consume it, in order to re-use persistent TCP connections in the default HTTP transport. If you're not interested in the response body, call `io.Copy(ioutil.Discard, res.Body)`.
+### Getting documents
 
-When you export the `ELASTICSEARCH_URL` environment variable,
-it will be used to set the cluster endpoint(s). Separate multiple addresses by a comma.
+Refer to the [Getting documents section](https://www.elastic.co/guide/en/elasticsearch/client/go-api/current/getting-started-go.html#_getting_documents)
+of the getting started documentation.
 
-To set the cluster endpoint(s) programmatically, pass a configuration object
-to the `elasticsearch.NewClient()` function.
+### Searching documents
 
-```golang
-cfg := elasticsearch.Config{
-  Addresses: []string{
-    "https://localhost:9200",
-    "https://localhost:9201",
-  },
-  // ...
-}
-es, err := elasticsearch.NewClient(cfg)
-```
+Refer to the [Searching documents section](https://www.elastic.co/guide/en/elasticsearch/client/go-api/current/getting-started-go.html#_searching_documents)
+of the getting started documentation.
 
-To set the username and password, include them in the endpoint URL,
-or use the corresponding configuration options.
+### Updating documents
 
-```golang
-cfg := elasticsearch.Config{
-  // ...
-  Username: "foo",
-  Password: "bar",
-}
-```
+Refer to the [Updating documents section](https://www.elastic.co/guide/en/elasticsearch/client/go-api/current/getting-started-go.html#_updating_documents)
+of the getting started documentation.
 
-To set a custom certificate authority used to sign the certificates of cluster nodes,
-use the `CACert` configuration option.
+### Deleting documents
 
-```golang
-cert, _ := ioutil.ReadFile(*cacert)
+Refer to the [Deleting documents section](https://www.elastic.co/guide/en/elasticsearch/client/go-api/current/getting-started-go.html#_deleting_documents)
+of the getting started documentation.
 
-cfg := elasticsearch.Config{
-  // ...
-  CACert: cert,
-}
-```
+### Deleting an index
 
-To set a fingerprint to validate the HTTPS connection use the `CertificateFingerprint` configuration option.
-
-```golang
-cfg := elasticsearch.Config{
-	// ...
-    CertificateFingerprint: fingerPrint,
-}
-```
-
-To configure other HTTP settings, pass an [`http.Transport`](https://golang.org/pkg/net/http/#Transport)
-object in the configuration object.
-
-```golang
-cfg := elasticsearch.Config{
-  Transport: &http.Transport{
-    MaxIdleConnsPerHost:   10,
-    ResponseHeaderTimeout: time.Second,
-    TLSClientConfig: &tls.Config{
-      MinVersion: tls.VersionTLS12,
-      // ...
-    },
-    // ...
-  },
-}
-```
-
-See the [`_examples/configuration.go`](_examples/configuration.go) and
-[`_examples/customization.go`](_examples/customization.go) files for
-more examples of configuration and customization of the client.
-See the [`_examples/security`](_examples/security) for an example of a security configuration.
-
-The following example demonstrates a more complex usage. It fetches the Elasticsearch version from the cluster, indexes a couple of documents concurrently, and prints the search results, using a lightweight wrapper around the response body.
-
-```golang
-// $ go run _examples/main.go
-
-package main
-
-import (
-  "bytes"
-  "context"
-  "encoding/json"
-  "log"
-  "strconv"
-  "strings"
-  "sync"
-
-  "github.com/elastic/go-elasticsearch/v8"
-  "github.com/elastic/go-elasticsearch/v8/esapi"
-)
-
-func main() {
-  log.SetFlags(0)
-
-  var (
-    r  map[string]interface{}
-    wg sync.WaitGroup
-  )
-
-  // Initialize a client with the default settings.
-  //
-  // An `ELASTICSEARCH_URL` environment variable will be used when exported.
-  //
-  es, err := elasticsearch.NewDefaultClient()
-  if err != nil {
-    log.Fatalf("Error creating the client: %s", err)
-  }
-
-  // 1. Get cluster info
-  //
-  res, err := es.Info()
-  if err != nil {
-    log.Fatalf("Error getting response: %s", err)
-  }
-  defer res.Body.Close()
-  // Check response status
-  if res.IsError() {
-    log.Fatalf("Error: %s", res.String())
-  }
-  // Deserialize the response into a map.
-  if err := json.NewDecoder(res.Body).Decode(&r); err != nil {
-    log.Fatalf("Error parsing the response body: %s", err)
-  }
-  // Print client and server version numbers.
-  log.Printf("Client: %s", elasticsearch.Version)
-  log.Printf("Server: %s", r["version"].(map[string]interface{})["number"])
-  log.Println(strings.Repeat("~", 37))
-
-  // 2. Index documents concurrently
-  //
-  for i, title := range []string{"Test One", "Test Two"} {
-    wg.Add(1)
-
-    go func(i int, title string) {
-      defer wg.Done()
-
-      // Build the request body.      
-      data, err := json.Marshal(struct {
-          Title string `json:"title"`
-      }{Title: title})
-      if err != nil {
-        log.Fatalf("Error marshaling document: %s", err)
-      }
-
-      // Set up the request object.
-      req := esapi.IndexRequest{
-        Index:      "test",
-        DocumentID: strconv.Itoa(i + 1),
-        Body:       bytes.NewReader(data),
-        Refresh:    "true",
-      }
-
-      // Perform the request with the client.
-      res, err := req.Do(context.Background(), es)
-      if err != nil {
-        log.Fatalf("Error getting response: %s", err)
-      }
-      defer res.Body.Close()
-
-      if res.IsError() {
-        log.Printf("[%s] Error indexing document ID=%d", res.Status(), i+1)
-      } else {
-        // Deserialize the response into a map.
-        var r map[string]interface{}
-        if err := json.NewDecoder(res.Body).Decode(&r); err != nil {
-          log.Printf("Error parsing the response body: %s", err)
-        } else {
-          // Print the response status and indexed document version.
-          log.Printf("[%s] %s; version=%d", res.Status(), r["result"], int(r["_version"].(float64)))
-        }
-      }
-    }(i, title)
-  }
-  wg.Wait()
-
-  log.Println(strings.Repeat("-", 37))
-
-  // 3. Search for the indexed documents
-  //
-  // Build the request body.
-  var buf bytes.Buffer
-  query := map[string]interface{}{
-    "query": map[string]interface{}{
-      "match": map[string]interface{}{
-        "title": "test",
-      },
-    },
-  }
-  if err := json.NewEncoder(&buf).Encode(query); err != nil {
-    log.Fatalf("Error encoding query: %s", err)
-  }
-
-  // Perform the search request.
-  res, err = es.Search(
-    es.Search.WithContext(context.Background()),
-    es.Search.WithIndex("test"),
-    es.Search.WithBody(&buf),
-    es.Search.WithTrackTotalHits(true),
-    es.Search.WithPretty(),
-  )
-  if err != nil {
-    log.Fatalf("Error getting response: %s", err)
-  }
-  defer res.Body.Close()
-
-  if res.IsError() {
-    var e map[string]interface{}
-    if err := json.NewDecoder(res.Body).Decode(&e); err != nil {
-      log.Fatalf("Error parsing the response body: %s", err)
-    } else {
-      // Print the response status and error information.
-      log.Fatalf("[%s] %s: %s",
-        res.Status(),
-        e["error"].(map[string]interface{})["type"],
-        e["error"].(map[string]interface{})["reason"],
-      )
-    }
-  }
-
-  if err := json.NewDecoder(res.Body).Decode(&r); err != nil {
-    log.Fatalf("Error parsing the response body: %s", err)
-  }
-  // Print the response status, number of results, and request duration.
-  log.Printf(
-    "[%s] %d hits; took: %dms",
-    res.Status(),
-    int(r["hits"].(map[string]interface{})["total"].(map[string]interface{})["value"].(float64)),
-    int(r["took"].(float64)),
-  )
-  // Print the ID and document source for each hit.
-  for _, hit := range r["hits"].(map[string]interface{})["hits"].([]interface{}) {
-    log.Printf(" * ID=%s, %s", hit.(map[string]interface{})["_id"], hit.(map[string]interface{})["_source"])
-  }
-
-  log.Println(strings.Repeat("=", 37))
-}
-
-// Client: 8.0.0-SNAPSHOT
-// Server: 8.0.0-SNAPSHOT
-// ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-// [201 Created] updated; version=1
-// [201 Created] updated; version=1
-// -------------------------------------
-// [200 OK] 2 hits; took: 5ms
-//  * ID=1, map[title:Test One]
-//  * ID=2, map[title:Test Two]
-// =====================================
-```
-
-As you see in the example above, the `esapi` package allows to call the Elasticsearch APIs in two distinct ways: either by creating a struct, such as `IndexRequest`, and calling its `Do()` method by passing it a context and the client, or by calling the `Search()` function on the client directly, using the option functions such as `WithIndex()`. See more information and examples in the
-[package documentation](https://godoc.org/github.com/elastic/go-elasticsearch/esapi).
-
-The `elastictransport` package handles the transfer of data to and from Elasticsearch, including retrying failed requests, keeping a connection pool, discovering cluster nodes and logging.
-
-Read more about the client internals and usage in the following blog posts:
-
-* https://www.elastic.co/blog/the-go-client-for-elasticsearch-introduction
-* https://www.elastic.co/blog/the-go-client-for-elasticsearch-configuration-and-customization
-* https://www.elastic.co/blog/the-go-client-for-elasticsearch-working-with-data
-
+Refer to the [Deleting an index section](https://www.elastic.co/guide/en/elasticsearch/client/go-api/current/getting-started-go.html#_deleting_an_index)
+of the getting started documentation.
 <!-- ----------------------------------------------------------------------------------------------- -->
 
 ## Helpers

--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ The `main` branch of the client is compatible with the current `master` branch o
 
 ## Installation
 
-Refer to the [Installation section][https://www.elastic.co/guide/en/elasticsearch/client/go-api/current/getting-started-go.html#_installation]
+Refer to the [Installation section](https://www.elastic.co/guide/en/elasticsearch/client/go-api/current/getting-started-go.html#_installation)
 of the getting started documentation.
 
 <!-- ----------------------------------------------------------------------------------------------- -->


### PR DESCRIPTION
## Overview

This PR adds links to the different sections of the README file that point to the corresponding section of the getting started page. This way only the getting started documentation needs to be maintained and it will be the source of truth.