### PR TITLE
Unmarshal NaN and Infinite values correctly

### DIFF
--- a/typedapi/types/float64.go
+++ b/typedapi/types/float64.go
@@ -46,8 +46,11 @@ func (f Float64) MarshalJSON() ([]byte, error) {
 func (f *Float64) UnmarshalJSON(data []byte) error {
 	switch {
 	case bytes.Equal(data, []byte(`"NaN"`)):
-		nan := Float64(math.NaN())
-		f = &nan
+		*f = Float64(math.NaN())
+	case bytes.Equal(data, []byte(`"+Infinity"`)):
+		*f = Float64(math.Inf(1))
+	case bytes.Equal(data, []byte(`"-Infinity"`)):
+		*f = Float64(math.Inf(-1))
 	case bytes.Equal(data, []byte(`null`)):
 		return nil
 	default:


### PR DESCRIPTION
The current implementation of unmarshaling Float64s does not handle Infinity values. This can be tested by creating a Sum aggregate of two document attributes that are both "Max Float" values or "Negative Max Float" values. The current behavior is a bubbled up error from `strconv.ParseFloat(string(data), 64)` which cannot handle a value like `"+Infinity"`.