### PR TITLE
Use double-quote to start field name

### DIFF
--- a/.doc/getting-started.asciidoc
+++ b/.doc/getting-started.asciidoc
@@ -143,7 +143,7 @@ This is how you can create a single match query with the low-level API:
 
 [source,go]
 ----
-query := `{ query: { match_all: {} } }`
+query := `{ "query": { "match_all": {} } }`
 client.Search(
     client.Search.WithIndex("my_index"),
     client.Search.WithBody(strings.NewReader(query)),


### PR DESCRIPTION
`{ query: { match_all: {} } }` response: 
```json
{
  "error": {
    "type": "x_content_parse_exception",
    "caused_by": {
      "type": "json_parse_exception",
      "reason": "Unexpected character ('m' (code 109)): was expecting double-quote to start field name\n at [Source: (org.elasticsearch.common.io.stream.ByteBufferStreamInput); line: 1, column: 15]"
    }
  },
  "status": 400
}
```