### PR TITLE
[DOCS] Adds context selector widget to the getting started page

### DIFF
--- a/.doc/getting-started.asciidoc
+++ b/.doc/getting-started.asciidoc
@@ -27,26 +27,7 @@ Refer to the <<installation>> page to learn more.
 [discrete]
 === Connecting
 
-You can connect to the Elastic Cloud using an API key and the Elasticsearch 
-endpoint for the low level API:
-
-[source,go]
-----
-client, err := elasticsearch.NewClient(elasticsearch.Config{
-    CloudID: "<CloudID>",
-    APIKey: "<ApiKey>",
-})
-----
-
-This is the same for the fully-typed API:
-
-[source,go]
-----
-typedClient, err := elasticsearch.NewTypedClient(elasticsearch.Config{
-    CloudID: "<CloudID>",
-    APIKey:  "<ApiKey>",
-})
-----
+include::tab-widgets/connecting-widget.asciidoc[]
 
 
 Your Elasticsearch endpoint can be found on the **My deployment** page of your 
@@ -72,153 +53,43 @@ examples, refer to the <<examples>> page.
 [discrete]
 ==== Creating an index
 
-This is how you create the `my_index` index with the low level API:
-
-[source,go]
-----
-client.Indices.Create("my_index")
-----
-
-This is how you create the `my_index` index with the fully-typed API:
-
-[source,go]
-----
-typedClient.Indices.Create("my_index").Do(context.TODO())
-----
+include::tab-widgets/create-index-widget.asciidoc[]
 
 
 [discrete]
 ==== Indexing documents
 
-This is a simple way of indexing a document by using the low-level API:
+include::tab-widgets/index-document-widget.asciidoc[]
 
-[source,go]
-----
-document := struct {
-    Name string `json:"name"`
-}{
-    "go-elasticsearch",
-}
-data, _ := json.Marshal(document)
-client.Index("my_index", bytes.NewReader(data))
-----
-
-The same operation by using the fully-typed API:
-
-[source,go]
-----
-document := struct {
-    Name string `json:"name"`
-}{
-    "go-elasticsearch",
-}
-typedClient.Index("my_index").
-		Id("1").
-		Request(document).
-		Do(context.TODO())
-----
 
 [discrete]
 ==== Getting documents
 
-You can get documents by using the following code with the low-level API:
-
-[source,go]
-----
-client.Get("my_index", "id")
-----
-
-This is how you can get documents by using the fully-typed API:
-
-[source,go]
-----
-typedClient.Get("my_index", "id").Do(context.TODO())
-----
+include::tab-widgets/get-documents-widget.asciidoc[]
 
 
 [discrete]
 ==== Searching documents
 
-This is how you can create a single match query with the low-level API: 
-
-[source,go]
-----
-query := `{ "query": { "match_all": {} } }`
-client.Search(
-    client.Search.WithIndex("my_index"),
-    client.Search.WithBody(strings.NewReader(query)),
-)
-----
-
-You can perform a single match query with the fully-typed API, too:
-
-[source,go]
-----
-typedClient.Search().
-    Index("my_index").
-    Request(&search.Request{
-        Query: &types.Query{MatchAll: &types.MatchAllQuery{}},
-    }).
-    Do(context.TODO())
-----
+include::tab-widgets/search-documents-widget.asciidoc[]
 
 
 [discrete]
 ==== Updating documents
 
-This is how you can update a document, for example to add a new field, by using 
-the low-level API:
-
-[source,go]
-----
-client.Update("my_index", "id", strings.NewReader(`{doc: { language: "Go" }}`))
-----
-
-And this is how you can update a document with the fully-typed API:
-
-[source,go]
-----
-typedClient.Update("my_index", "id").
-	Request(&update.Request{
-        Doc: json.RawMessage(`{ language: "Go" }`),
-    }).Do(context.TODO())
-----
+include::tab-widgets/update-documents-widget.asciidoc[]
 
 
 [discrete]
 ==== Deleting documents
 
-Low-level API:
-
-[source,go]
-----
-client.Delete("my_index", "id")
-----
-
-Fully-typed API:
-
-[source,go]
-----
-typedClient.Delete("my_index", "id").Do(context.TODO())
-----
+include::tab-widgets/delete-documents-widget.asciidoc[]
 
 
 [discrete]
 ==== Deleting an index
 
-Low-level API:
-
-[source,go]
-----
-client.Indices.Delete([]string{"my_index"})
-----
-
-Fully-typed API:
-
-[source,go]
-----
-typedClient.Indices.Delete("my_index").Do(context.TODO())
-----
+include::tab-widgets/delete-index-widget.asciidoc[]
 
 
 [discrete]

--- a/.doc/tab-widgets/connecting-widget.asciidoc
+++ b/.doc/tab-widgets/connecting-widget.asciidoc
@@ -1,0 +1,39 @@
+++++
+<div class="tabs" data-tab-group="go-get-started">
+  <div role="tablist" aria-label="go-get-started">
+    <button role="tab"
+            aria-selected="true"
+            aria-controls="low-level-api-tab-connecting"
+            id="low-level-api-connecting">
+      Low-level API
+    </button>
+    <button role="tab"
+            aria-selected="false"
+            aria-controls="fully-typed-api-tab-connecting"
+            id="fully-typed-api-connecting">
+      Fully-typed API
+    </button>
+  </div>
+  <div tabindex="0"
+       role="tabpanel"
+       id="low-level-api-tab-connecting"
+       aria-labelledby="low-level-api-connecting">
+++++
+
+include::connecting.asciidoc[tag=low-level]
+
+++++
+  </div>
+  <div tabindex="0"
+       role="tabpanel"
+       id="fully-typed-api-tab-connecting"
+       aria-labelledby="fully-typed-api-connecting"
+       hidden="">
+++++
+
+include::connecting.asciidoc[tag=fully-typed]
+
+++++
+  </div>
+</div>
+++++

--- a/.doc/tab-widgets/connecting.asciidoc
+++ b/.doc/tab-widgets/connecting.asciidoc
@@ -1,0 +1,30 @@
+// tag::low-level[]
+
+You can connect to the Elastic Cloud using an API key and the Elasticsearch 
+endpoint for the low level API:
+
+[source,go]
+----
+client, err := elasticsearch.NewClient(elasticsearch.Config{
+    CloudID: "<CloudID>",
+    APIKey: "<ApiKey>",
+})
+----
+
+// end::low-level[]
+
+
+// tag::fully-typed[]
+
+You can connect to the Elastic Cloud using an API key and the Elasticsearch 
+endpoint for the fully-typed API:
+
+[source,go]
+----
+typedClient, err := elasticsearch.NewTypedClient(elasticsearch.Config{
+    CloudID: "<CloudID>",
+    APIKey:  "<ApiKey>",
+})
+----
+
+// end::fully-typed[]

--- a/.doc/tab-widgets/create-index-widget.asciidoc
+++ b/.doc/tab-widgets/create-index-widget.asciidoc
@@ -1,0 +1,39 @@
+++++
+<div class="tabs" data-tab-group="go-get-started">
+  <div role="tablist" aria-label="go-get-started">
+    <button role="tab"
+            aria-selected="true"
+            aria-controls="low-level-api-tab-create-index"
+            id="low-level-api-create-index">
+      Low-level API
+    </button>
+    <button role="tab"
+            aria-selected="false"
+            aria-controls="fully-typed-api-tab-create-index"
+            id="fully-typed-api-create-index">
+      Fully-typed API
+    </button>
+  </div>
+  <div tabindex="0"
+       role="tabpanel"
+       id="low-level-api-tab-create-index"
+       aria-labelledby="low-level-api-create-index">
+++++
+
+include::create-index.asciidoc[tag=low-level]
+
+++++
+  </div>
+  <div tabindex="0"
+       role="tabpanel"
+       id="fully-typed-api-tab-create-index"
+       aria-labelledby="fully-typed-api-create-index"
+       hidden="">
+++++
+
+include::create-index.asciidoc[tag=fully-typed]
+
+++++
+  </div>
+</div>
+++++

--- a/.doc/tab-widgets/create-index.asciidoc
+++ b/.doc/tab-widgets/create-index.asciidoc
@@ -1,0 +1,22 @@
+// tag::low-level[]
+
+This is how you create the `my_index` index with the low level API:
+
+[source,go]
+----
+client.Indices.Create("my_index")
+----
+
+// end::low-level[]
+
+
+// tag::fully-typed[]
+
+This is how you create the `my_index` index with the fully-typed API:
+
+[source,go]
+----
+typedClient.Indices.Create("my_index").Do(context.TODO())
+----
+
+// end::fully-typed[]

--- a/.doc/tab-widgets/delete-documents-widget.asciidoc
+++ b/.doc/tab-widgets/delete-documents-widget.asciidoc
@@ -1,0 +1,39 @@
+++++
+<div class="tabs" data-tab-group="go-get-started">
+  <div role="tablist" aria-label="go-get-started">
+    <button role="tab"
+            aria-selected="true"
+            aria-controls="low-level-api-tab-delete-document"
+            id="low-level-api-delete-document">
+      Low-level API
+    </button>
+    <button role="tab"
+            aria-selected="false"
+            aria-controls="fully-typed-api-tab-delete-document"
+            id="fully-typed-api-delete-document">
+      Fully-typed API
+    </button>
+  </div>
+  <div tabindex="0"
+       role="tabpanel"
+       id="low-level-api-tab-delete-document"
+       aria-labelledby="low-level-api-delete-document">
+++++
+
+include::delete-documents.asciidoc[tag=low-level]
+
+++++
+  </div>
+  <div tabindex="0"
+       role="tabpanel"
+       id="fully-typed-api-tab-delete-document"
+       aria-labelledby="fully-typed-api-delete-document"
+       hidden="">
+++++
+
+include::delete-documents.asciidoc[tag=fully-typed]
+
+++++
+  </div>
+</div>
+++++

--- a/.doc/tab-widgets/delete-documents.asciidoc
+++ b/.doc/tab-widgets/delete-documents.asciidoc
@@ -1,0 +1,18 @@
+// tag::low-level[]
+
+[source,go]
+----
+client.Delete("my_index", "id")
+----
+
+// end::low-level[]
+
+
+// tag::fully-typed[]
+
+[source,go]
+----
+typedClient.Delete("my_index", "id").Do(context.TODO())
+----
+
+// end::fully-typed[]

--- a/.doc/tab-widgets/delete-index-widget.asciidoc
+++ b/.doc/tab-widgets/delete-index-widget.asciidoc
@@ -1,0 +1,39 @@
+++++
+<div class="tabs" data-tab-group="go-get-started">
+  <div role="tablist" aria-label="go-get-started">
+    <button role="tab"
+            aria-selected="true"
+            aria-controls="low-level-api-tab-delete-index"
+            id="low-level-api-delete-index">
+      Low-level API
+    </button>
+    <button role="tab"
+            aria-selected="false"
+            aria-controls="fully-typed-api-tab-delete-index"
+            id="fully-typed-api-delete-index">
+      Fully-typed API
+    </button>
+  </div>
+  <div tabindex="0"
+       role="tabpanel"
+       id="low-level-api-tab-delete-index"
+       aria-labelledby="low-level-api-delete-index">
+++++
+
+include::delete-index.asciidoc[tag=low-level]
+
+++++
+  </div>
+  <div tabindex="0"
+       role="tabpanel"
+       id="fully-typed-api-tab-delete-index"
+       aria-labelledby="fully-typed-api-delete-index"
+       hidden="">
+++++
+
+include::delete-index.asciidoc[tag=fully-typed]
+
+++++
+  </div>
+</div>
+++++

--- a/.doc/tab-widgets/delete-index.asciidoc
+++ b/.doc/tab-widgets/delete-index.asciidoc
@@ -1,0 +1,18 @@
+// tag::low-level[]
+
+[source,go]
+----
+client.Indices.Delete([]string{"my_index"})
+----
+
+// end::low-level[]
+
+
+// tag::fully-typed[]
+
+[source,go]
+----
+typedClient.Indices.Delete("my_index").Do(context.TODO())
+----
+
+// end::fully-typed[]

--- a/.doc/tab-widgets/get-documents-widget.asciidoc
+++ b/.doc/tab-widgets/get-documents-widget.asciidoc
@@ -1,0 +1,39 @@
+++++
+<div class="tabs" data-tab-group="go-get-started">
+  <div role="tablist" aria-label="go-get-started">
+    <button role="tab"
+            aria-selected="true"
+            aria-controls="low-level-api-tab-get-document"
+            id="low-level-api-get-document">
+      Low-level API
+    </button>
+    <button role="tab"
+            aria-selected="false"
+            aria-controls="fully-typed-api-tab-get-document"
+            id="fully-typed-api-get-document">
+      Fully-typed API
+    </button>
+  </div>
+  <div tabindex="0"
+       role="tabpanel"
+       id="low-level-api-tab-get-document"
+       aria-labelledby="low-level-api-get-document">
+++++
+
+include::get-documents.asciidoc[tag=low-level]
+
+++++
+  </div>
+  <div tabindex="0"
+       role="tabpanel"
+       id="fully-typed-api-tab-get-document"
+       aria-labelledby="fully-typed-api-get-document"
+       hidden="">
+++++
+
+include::get-documents.asciidoc[tag=fully-typed]
+
+++++
+  </div>
+</div>
+++++

--- a/.doc/tab-widgets/get-documents.asciidoc
+++ b/.doc/tab-widgets/get-documents.asciidoc
@@ -1,0 +1,22 @@
+// tag::low-level[]
+
+You can get documents by using the following code with the low-level API:
+
+[source,go]
+----
+client.Get("my_index", "id")
+----
+
+// end::low-level[]
+
+
+// tag::fully-typed[]
+
+This is how you can get documents by using the fully-typed API:
+
+[source,go]
+----
+typedClient.Get("my_index", "id").Do(context.TODO())
+----
+
+// end::fully-typed[]

--- a/.doc/tab-widgets/index-document-widget.asciidoc
+++ b/.doc/tab-widgets/index-document-widget.asciidoc
@@ -1,0 +1,39 @@
+++++
+<div class="tabs" data-tab-group="go-get-started">
+  <div role="tablist" aria-label="go-get-started">
+    <button role="tab"
+            aria-selected="true"
+            aria-controls="low-level-api-tab-index-document"
+            id="low-level-api-index-document">
+      Low-level API
+    </button>
+    <button role="tab"
+            aria-selected="false"
+            aria-controls="fully-typed-api-tab-index-document"
+            id="fully-typed-api-index-document">
+      Fully-typed API
+    </button>
+  </div>
+  <div tabindex="0"
+       role="tabpanel"
+       id="low-level-api-tab-index-document"
+       aria-labelledby="low-level-api-index-document">
+++++
+
+include::index-document.asciidoc[tag=low-level]
+
+++++
+  </div>
+  <div tabindex="0"
+       role="tabpanel"
+       id="fully-typed-api-tab-index-document"
+       aria-labelledby="fully-typed-api-index-document"
+       hidden="">
+++++
+
+include::index-document.asciidoc[tag=fully-typed]
+
+++++
+  </div>
+</div>
+++++

--- a/.doc/tab-widgets/index-document.asciidoc
+++ b/.doc/tab-widgets/index-document.asciidoc
@@ -1,0 +1,36 @@
+// tag::low-level[]
+
+This is a simple way of indexing a document by using the low-level API:
+
+[source,go]
+----
+document := struct {
+    Name string `json:"name"`
+}{
+    "go-elasticsearch",
+}
+data, _ := json.Marshal(document)
+client.Index("my_index", bytes.NewReader(data))
+----
+
+// end::low-level[]
+
+
+// tag::fully-typed[]
+
+This is a simple way of indexing a documen by using the fully-typed API:
+
+[source,go]
+----
+document := struct {
+    Name string `json:"name"`
+}{
+    "go-elasticsearch",
+}
+typedClient.Index("my_index").
+		Id("1").
+		Request(document).
+		Do(context.TODO())
+----
+
+// end::fully-typed[]

--- a/.doc/tab-widgets/search-documents-widget.asciidoc
+++ b/.doc/tab-widgets/search-documents-widget.asciidoc
@@ -1,0 +1,39 @@
+++++
+<div class="tabs" data-tab-group="go-get-started">
+  <div role="tablist" aria-label="go-get-started">
+    <button role="tab"
+            aria-selected="true"
+            aria-controls="low-level-api-tab-search-document"
+            id="low-level-api-search-document">
+      Low-level API
+    </button>
+    <button role="tab"
+            aria-selected="false"
+            aria-controls="fully-typed-api-tab-search-document"
+            id="fully-typed-api-search-document">
+      Fully-typed API
+    </button>
+  </div>
+  <div tabindex="0"
+       role="tabpanel"
+       id="low-level-api-tab-search-document"
+       aria-labelledby="low-level-api-search-document">
+++++
+
+include::search-documents.asciidoc[tag=low-level]
+
+++++
+  </div>
+  <div tabindex="0"
+       role="tabpanel"
+       id="fully-typed-api-tab-search-document"
+       aria-labelledby="fully-typed-api-search-document"
+       hidden="">
+++++
+
+include::search-documents.asciidoc[tag=fully-typed]
+
+++++
+  </div>
+</div>
+++++

--- a/.doc/tab-widgets/search-documents.asciidoc
+++ b/.doc/tab-widgets/search-documents.asciidoc
@@ -1,0 +1,31 @@
+// tag::low-level[]
+
+This is how you can create a single match query with the low-level API: 
+
+[source,go]
+----
+query := `{ "query": { "match_all": {} } }`
+client.Search(
+    client.Search.WithIndex("my_index"),
+    client.Search.WithBody(strings.NewReader(query)),
+)
+----
+
+// end::low-level[]
+
+
+// tag::fully-typed[]
+
+This is how you can perform a single match query with the fully-typed API:
+
+[source,go]
+----
+typedClient.Search().
+    Index("my_index").
+    Request(&search.Request{
+        Query: &types.Query{MatchAll: &types.MatchAllQuery{}},
+    }).
+    Do(context.TODO())
+----
+
+// end::fully-typed[]

--- a/.doc/tab-widgets/update-documents-widget.asciidoc
+++ b/.doc/tab-widgets/update-documents-widget.asciidoc
@@ -1,0 +1,39 @@
+++++
+<div class="tabs" data-tab-group="go-get-started">
+  <div role="tablist" aria-label="go-get-started">
+    <button role="tab"
+            aria-selected="true"
+            aria-controls="low-level-api-tab-update-document"
+            id="low-level-api-update-document">
+      Low-level API
+    </button>
+    <button role="tab"
+            aria-selected="false"
+            aria-controls="fully-typed-api-tab-update-document"
+            id="fully-typed-api-update-document">
+      Fully-typed API
+    </button>
+  </div>
+  <div tabindex="0"
+       role="tabpanel"
+       id="low-level-api-tab-update-document"
+       aria-labelledby="low-level-api-update-document">
+++++
+
+include::update-documents.asciidoc[tag=low-level]
+
+++++
+  </div>
+  <div tabindex="0"
+       role="tabpanel"
+       id="fully-typed-api-tab-update-document"
+       aria-labelledby="fully-typed-api-update-document"
+       hidden="">
+++++
+
+include::update-documents.asciidoc[tag=fully-typed]
+
+++++
+  </div>
+</div>
+++++

--- a/.doc/tab-widgets/update-documents.asciidoc
+++ b/.doc/tab-widgets/update-documents.asciidoc
@@ -1,0 +1,26 @@
+// tag::low-level[]
+
+This is how you can update a document, for example to add a new field, by using 
+the low-level API:
+
+[source,go]
+----
+client.Update("my_index", "id", strings.NewReader(`{doc: { language: "Go" }}`))
+----
+
+// end::low-level[]
+
+
+// tag::fully-typed[]
+
+This is how you can update a document with the fully-typed API:
+
+[source,go]
+----
+typedClient.Update("my_index", "id").
+	Request(&update.Request{
+        Doc: json.RawMessage(`{ language: "Go" }`),
+    }).Do(context.TODO())
+----
+
+// end::fully-typed[]


### PR DESCRIPTION
## Overview

This PR adds context selector widgets to the Getting started page. As the Go client utilizes two sets of APIs – low-level and fully-typed – it is useful to provide the possibility for the user to choose the context as it makes it easier to interpret the docs properly. The user's choice impacts all the widgets on the page; if they choose `fully-typed` in either of the widgets, the rest will also show the `fully-typed` tabs.

### Preview

* [Getting started](https://go-elasticsearch_751.docs-preview.app.elstc.co/guide/en/elasticsearch/client/go-api/master/getting-started-go.html)