### PR TITLE
[8.11.1] Fix path spec

### DIFF
--- a/typedapi/indices/putsettings/put_settings.go
+++ b/typedapi/indices/putsettings/put_settings.go
@@ -243,7 +243,7 @@ func (r *PutSettings) Header(key, value string) *PutSettings {
 	return r
 }
 
-// Index Comma-separated list of data streams, indices, and aliases used to limit
+// Indices Comma-separated list of data streams, indices, and aliases used to limit
 // the request. Supports wildcards (`*`). To target all data streams and
 // indices, omit this parameter or use `*` or `_all`.
 // API Name: index


### PR DESCRIPTION
API: Update typed API v8.11.1 (5fea44e) -- align description
followup to https://github.com/elastic/go-elasticsearch/pull/759