### PR TITLE
implement if_seq_no and if_primary_term parameters in bulk indexer item

### DIFF
--- a/esutil/bulk_indexer.go
+++ b/esutil/bulk_indexer.go
@@ -107,6 +107,8 @@ type BulkIndexerItem struct {
 	VersionType     string
 	Body            io.ReadSeeker
 	RetryOnConflict *int
+	IfSeqNo         *int64
+	IfPrimaryTerm   *int64
 	meta            bytes.Buffer // Item metadata header
 	payloadLength   int          // Item payload total length metadata+newline+body length
 
@@ -175,6 +177,15 @@ func (item *BulkIndexerItem) marshallMeta() {
 		item.meta.WriteString(`"require_alias":`)
 		item.meta.Write(strconv.AppendBool(aux, item.RequireAlias))
 		aux = aux[:0]
+	}
+
+	if item.DocumentID != "" && item.IfSeqNo != nil && item.IfPrimaryTerm != nil {
+		item.meta.WriteRune(',')
+		item.meta.WriteString(`"if_seq_no":`)
+		item.meta.WriteString(strconv.FormatInt(*item.IfSeqNo, 10))
+		item.meta.WriteRune(',')
+		item.meta.WriteString(`"if_primary_term":`)
+		item.meta.WriteString(strconv.FormatInt(*item.IfPrimaryTerm, 10))
 	}
 
 	item.meta.WriteRune('}')

--- a/esutil/bulk_indexer_internal_test.go
+++ b/esutil/bulk_indexer_internal_test.go
@@ -598,6 +598,8 @@ func TestBulkIndexer(t *testing.T) {
 	})
 	t.Run("Worker.writeMeta()", func(t *testing.T) {
 		v := int64(23)
+		ifSeqNo := int64(45)
+		ifPrimaryTerm := int64(67)
 		type args struct {
 			item BulkIndexerItem
 		}
@@ -705,6 +707,16 @@ func TestBulkIndexer(t *testing.T) {
 					RetryOnConflict: esapi.IntPtr(3),
 				}},
 				`{"update":{"_id":"1","retry_on_conflict":3}}` + "\n",
+			},
+			{
+				"with if_seq_no and if_primary_term",
+				args{BulkIndexerItem{
+					Action:        "index",
+					DocumentID:    "1",
+					IfSeqNo:       &ifSeqNo,
+					IfPrimaryTerm: &ifPrimaryTerm,
+				}},
+				`{"index":{"_id":"1","if_seq_no":45,"if_primary_term":67}}` + "\n",
 			},
 		}
 		for _, tt := range tests {


### PR DESCRIPTION
The bulk indexer is missing the capability to set the `if_seq_no` and `if_primary_term` parameters. I added them here with a simple addition to the unit test for the writeMeta function. 

I ran into concurrency problems recently with Elasticsearch. I've built a work around in my own application that was experiencing a problem, but I would like to benefit from this feature in Elasticsearch to improve my own application. 

Hope this is helpful. Let me know if you need anything else from me!

ref: 
- https://www.elastic.co/guide/en/elasticsearch/reference/current/optimistic-concurrency-control.html
- https://www.elastic.co/guide/en/elasticsearch/reference/current/docs-bulk.html#bulk-optimistic-concurrency-control