### PR TITLE
remove scroll id from path and add it to the request with scrollid me…

### DIFF
--- a/typedapi/core/scroll/scroll.go
+++ b/typedapi/core/scroll/scroll.go
@@ -153,28 +153,12 @@ func (r *Scroll) HttpRequest(ctx context.Context) (*http.Request, error) {
 
 	r.path.Scheme = "http"
 
-	switch {
-	case r.paramSet == 0:
-		path.WriteString("/")
-		path.WriteString("_search")
-		path.WriteString("/")
-		path.WriteString("scroll")
+	path.WriteString("/")
+	path.WriteString("_search")
+	path.WriteString("/")
+	path.WriteString("scroll")
 
-		method = http.MethodPost
-	case r.paramSet == scrollidMask:
-		path.WriteString("/")
-		path.WriteString("_search")
-		path.WriteString("/")
-		path.WriteString("scroll")
-		path.WriteString("/")
-
-		if instrument, ok := r.instrument.(elastictransport.Instrumentation); ok {
-			instrument.RecordPathPart(ctx, "scrollid", r.scrollid)
-		}
-		path.WriteString(r.scrollid)
-
-		method = http.MethodPost
-	}
+	method = http.MethodPost
 
 	r.path.Path = path.String()
 	r.path.RawQuery = r.values.Encode()
@@ -315,7 +299,7 @@ func (r *Scroll) Header(key, value string) *Scroll {
 // API Name: scrollid
 func (r *Scroll) ScrollId(scrollid string) *Scroll {
 	r.paramSet |= scrollidMask
-	r.scrollid = scrollid
+	r.req.Scroll = scrollid
 
 	return r
 }


### PR DESCRIPTION
I added scrollid to the request with the ScrollId method and remove it from the path. That's why we don't need insturement for scrollid path. So we'll be able to use it like this :

`typedClient.Scroll().Scroll(15 * time.Minute).ScrollId(scrollId).Do(context.Background())`

If I'm wrong, please let me know.

Happy coding!