### PR TITLE
Fix ticker memory leak in bulk indexer due to internal flush call resetting the ticker

### DIFF
--- a/esutil/bulk_indexer.go
+++ b/esutil/bulk_indexer.go
@@ -402,8 +402,8 @@ func (w *worker) run() {
 			w.bi.config.DebugLogger.Printf("[worker-%03d] Started\n", w.id)
 		}
 		defer func() {
-			w.ticker.Stop()
 			w.flush(ctx)
+			w.ticker.Stop()
 			w.bi.wg.Done()
 		}()
 


### PR DESCRIPTION
Hello, I discovered that the [`time.Ticker`](https://pkg.go.dev/time#Ticker) instance within the [`BulkIndexer`](./esutil/bulk_indexer.go) is consuming a bunch of memory in my long running application that creates and closes many instances of the [`BulkIndexer`](./esutil/bulk_indexer.go). See the following screenshots of a [pprof heap visualization](https://pkg.go.dev/net/http/pprof) that I took of the application (forcing a garbage collection run too).

![pprof](https://github.com/elastic/go-elasticsearch/assets/782695/0fd575f3-a9eb-4132-925a-516f02b556af)

![pprof flamegraph](https://github.com/elastic/go-elasticsearch/assets/782695/6e31b91a-480f-49b7-b3c6-1aef20846ddf)


It appears that the [`time.Ticker`](https://pkg.go.dev/time#Ticker) instance is [`Reset`](https://pkg.go.dev/time#Ticker.Reset) within the `flush` method, thus causing the memory leak. The fix that I have tested and confirmed working is to simply call [`Stop`](https://pkg.go.dev/time#Ticker.Stop) on the ticker after the `flush` call since it is valid to have that [`Reset`](https://pkg.go.dev/time#Ticker.Reset) call within the `flush` method for other parts of the [`BulkIndexer`](./esutil/bulk_indexer.go).

I would attach another screenshot of pprof, but the [`time.Ticker`](https://pkg.go.dev/time#Ticker) doesn't show up in the visualization due to its small memory footprint.
