### PR TITLE
[Bakcport 8.12] Fix ticker memory leak in BulkIndexer

### DIFF
--- a/esutil/bulk_indexer.go
+++ b/esutil/bulk_indexer.go
@@ -402,8 +402,8 @@ func (w *worker) run() {
 			w.bi.config.DebugLogger.Printf("[worker-%03d] Started\n", w.id)
 		}
 		defer func() {
-			w.ticker.Stop()
 			w.flush(ctx)
+			w.ticker.Stop()
 			w.bi.wg.Done()
 		}()
 


### PR DESCRIPTION
Backport of #797