### PR TITLE
[DOCS] Adds compatibility matrix to docs

### DIFF
--- a/.doc/installation.asciidoc
+++ b/.doc/installation.asciidoc
@@ -53,5 +53,19 @@ go run main.go
 [discrete]
 === {es} Version Compatibility
 
-Language clients are forward compatible; meaning that clients support communicating with greater or equal minor versions of {es}.
-{es} language clients are only backwards compatible with default distributions and without guarantees made.
+The language clients are forward compatible; meaning that the clients support
+communicating with greater or equal minor versions of {es} without breaking. It
+does not mean that the clients automatically support new features of newer
+{es} versions; it is only possible after a release of a new client version. For
+example, a 8.12 client version won't automatically support the new features of
+the 8.13 version of {es}, the 8.13 client version is required for that. {es}
+language clients are only backwards compatible with default distributions and
+without guarantees made.
+
+|===
+| Elasticsearch Version | Elasticsearch-Go Branch | Supported
+
+| main                  | main                      | 
+| 8.x                   | 8.x                       | 8.x
+| 7.x                   | 7.x                       | 7.17
+|===


### PR DESCRIPTION
## Overview

This PR adds a compatibility matrix to the Introduction section of the Go book.

### Preview

[Elasticsearch version compatibility](https://go-elasticsearch_bk_816.docs-preview.app.elstc.co/guide/en/elasticsearch/client/go-api/master/installation.html#_elasticsearch_version_compatibility)