### PR TITLE
[DOCS] Add ES|QL doc structure

### DIFF
--- a/.doc/index.asciidoc
+++ b/.doc/index.asciidoc
@@ -2,6 +2,8 @@
 
 :doctype:           book
 
+:es-docs: https://www.elastic.co/guide/en/elasticsearch/reference/{branch} 
+
 include::{asciidoc-dir}/../../shared/versions/stack/{source_branch}.asciidoc[]
 
 include::{asciidoc-dir}/../../shared/attributes.asciidoc[]

--- a/.doc/index.asciidoc
+++ b/.doc/index.asciidoc
@@ -2,11 +2,11 @@
 
 :doctype:           book
 
-:es-docs: https://www.elastic.co/guide/en/elasticsearch/reference/{branch} 
-
 include::{asciidoc-dir}/../../shared/versions/stack/{source_branch}.asciidoc[]
 
 include::{asciidoc-dir}/../../shared/attributes.asciidoc[]
+
+:es-docs: https://www.elastic.co/guide/en/elasticsearch/reference/{branch} 
 
 include::overview.asciidoc[]
 

--- a/.doc/typedapi/esql.asciidoc
+++ b/.doc/typedapi/esql.asciidoc
@@ -1,5 +1,8 @@
 [[esql]]
 === ES|QL in the Go client
+++++
+<titleabbrev>Using ES|QL</titleabbrev>
+++++
 
 This page helps you understand and use {ref}/esql.html[ES|QL] in the
 Go client.

--- a/.doc/typedapi/esql.asciidoc
+++ b/.doc/typedapi/esql.asciidoc
@@ -1,0 +1,76 @@
+[[esql]]
+=== ES|QL in the Go client
+
+This page helps you understand and use {ref}/esql.html[ES|QL] in the
+Go client.
+
+There are two ways to use ES|QL in the Go client:
+
+* Use the Elasticsearch {es-docs}/esql-apis.html[ES|QL API] directly: This
+is the most flexible approach, but it's also the most complex because you must handle
+results in their raw form. You can choose the precise format of results,
+such as JSON, CSV, or text.
+* Use ES|QL mapping helpers: These mappers take care of parsing the raw
+response into something readily usable by the application. Several mappers are
+available for different use cases, such as object mapping, cursor
+traversal of results, and dataframes. You can also define your own mapper for specific
+use cases.
+
+
+
+[discrete]
+[[esql-how-to]]
+==== How to use the ES|QL API
+
+The {es-docs}/esql-query-api.html[ES|QL query API] allows you to specify how
+results should be returned. You can choose a
+{es-docs}/esql-rest.html#esql-rest-format[response format] such as CSV, text, or
+JSON, then fine-tune it with parameters like column separators
+and locale.
+
+// Add any Go-specific usage notes
+
+The following example gets ES|QL results as CSV and parses them:
+
+// Code example to be written
+
+
+[discrete]
+[[esql-consume-results]]
+==== Consume ES|QL results
+
+The previous example showed that although the raw ES|QL API offers maximum
+flexibility, additional work is required in order to make use of the
+result data.
+
+To simplify things, try working with these three main representations of ES|QL
+results (each with its own mapping helper):
+
+* **Objects**, where each row in the results is mapped to an object from your
+application domain. This is similar to what ORMs (object relational mappers)
+commonly do.
+* **Cursors**, where you scan the results row by row and access the data using
+column names. This is similar to database access libraries.
+* **Dataframes**, where results are organized in a column-oriented structure that
+allows efficient processing of column data.
+
+// Code examples to be written for each of them, depending on availability in the language
+
+
+[discrete]
+[[esql-custom-mapping]]
+==== Define your own mapping
+
+Although the mappers provided by the Go client cover many use cases, your
+application might require a custom mapping.
+You can write your own mapper and use it in a similar way as the
+built-in ones.
+
+Note that mappers are meant to provide a more usable representation of ES|QL
+results—not to process the result data. Data processing should be based on
+the output of a result mapper.
+
+Here's an example mapper that returns a simple column-oriented
+representation of the data:
+
+// Code example to be written

--- a/.doc/typedapi/esql.asciidoc
+++ b/.doc/typedapi/esql.asciidoc
@@ -14,8 +14,8 @@ is the most flexible approach, but it's also the most complex because you must h
 results in their raw form. You can choose the precise format of results,
 such as JSON, CSV, or text.
 * Use ES|QL mapping helpers: These mappers take care of parsing the raw
-response into something readily usable by the application. Several mappers are
-available for different use cases, such as object mapping and iterative.
+response into something readily usable by the application. Helpers are
+available for object mapping and iterative objects.
 
 
 

--- a/.doc/typedapi/esql.asciidoc
+++ b/.doc/typedapi/esql.asciidoc
@@ -15,9 +15,7 @@ results in their raw form. You can choose the precise format of results,
 such as JSON, CSV, or text.
 * Use ES|QL mapping helpers: These mappers take care of parsing the raw
 response into something readily usable by the application. Several mappers are
-available for different use cases, such as object mapping, cursor
-traversal of results, and dataframes. You can also define your own mapper for specific
-use cases.
+available for different use cases, such as object mapping and iterative.
 
 
 
@@ -31,11 +29,29 @@ results should be returned. You can choose a
 JSON, then fine-tune it with parameters like column separators
 and locale.
 
-// Add any Go-specific usage notes
-
 The following example gets ES|QL results as CSV and parses them:
 
-// Code example to be written
+[source,go]
+------------------------------------
+queryAuthor := `from library
+    | where author == "Isaac Asimov"
+    | sort release_date desc
+    | limit 10`
+
+response, err := client.Esql.Query().
+    Query(queryAuthor).
+    Format("csv").
+    Do(context.Background())
+if err != nil {
+    log.Fatal(err)
+}
+
+reader := csv.NewReader(bytes.NewReader(response))
+rows, err := reader.ReadAll()
+for _, row := range rows {
+    fmt.Println(row)
+}
+------------------------------------
 
 
 [discrete]
@@ -46,34 +62,78 @@ The previous example showed that although the raw ES|QL API offers maximum
 flexibility, additional work is required in order to make use of the
 result data.
 
-To simplify things, try working with these three main representations of ES|QL
+To simplify things, try working with these two main representations of ES|QL
 results (each with its own mapping helper):
 
 * **Objects**, where each row in the results is mapped to an object from your
 application domain. This is similar to what ORMs (object relational mappers)
 commonly do.
-* **Cursors**, where you scan the results row by row and access the data using
-column names. This is similar to database access libraries.
-* **Dataframes**, where results are organized in a column-oriented structure that
-allows efficient processing of column data.
 
-// Code examples to be written for each of them, depending on availability in the language
+[source,go]
+------------------------------------
+package main
 
+import (
+	"context"
+	"fmt"
+	"log"
 
-[discrete]
-[[esql-custom-mapping]]
-==== Define your own mapping
+	"github.com/elastic/go-elasticsearch/v8"
+	"github.com/elastic/go-elasticsearch/v8/typedapi/esql/query"
+)
 
-Although the mappers provided by the Go client cover many use cases, your
-application might require a custom mapping.
-You can write your own mapper and use it in a similar way as the
-built-in ones.
+type Book struct {
+	Name        string `json:"name"`
+	Author      string `json:"author"`
+	ReleaseDate string `json:"release_date"`
+	PageCount   int    `json:"page_count"`
+}
 
-Note that mappers are meant to provide a more usable representation of ES|QL
-results—not to process the result data. Data processing should be based on
-the output of a result mapper.
+func main() {
+	client, err := elasticsearch.NewTypedClient(elasticsearch.Config{Addresses: []string{"ELASTICSEARCH_URL"}})
+	if err != nil {
+		log.Fatal(err)
+	}
 
-Here's an example mapper that returns a simple column-oriented
-representation of the data:
+	queryAuthor := `from library
+        | where author == "Isaac Asimov"
+        | sort release_date desc
+        | limit 10`
 
-// Code example to be written
+	qry := client.Esql.Query().Query(queryAuthor)
+	books, err := query.Helper[Book](context.Background(), qry)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	for _, book := range books {
+		fmt.Println(book)
+	}
+}
+
+------------------------------------
+
+* **Iterative Objects**, where each row in the results is mapped to an object from your
+application domain, one at a time.
+
+[source,go]
+------------------------------------
+queryAuthor := `from library
+    | where author == "Isaac Asimov"
+    | sort release_date desc
+    | limit 10`
+
+qry := client.Esql.Query().Query(queryAuthor)
+books, err := query.NewIteratorHelper[Book](context.Background(), qry)
+if err != nil {
+    log.Fatal(err)
+}
+
+for books.More() {
+    book, err := books.Next()
+    if err != nil {
+        log.Fatal(err)
+    }
+    fmt.Println(book)
+}
+------------------------------------

--- a/.doc/typedapi/index.asciidoc
+++ b/.doc/typedapi/index.asciidoc
@@ -34,4 +34,5 @@ https://github.com/elastic/elasticsearch-specification[elasticsearch-specificati
 
 include::conventions/index.asciidoc[]
 include::queries.asciidoc[]
+include::esql.asciidoc[]
 include::examples/index.asciidoc[]


### PR DESCRIPTION
Adds an `esql.asciidoc` file that sets up a basic structure for the ES|QL documentation. Based on @szabosteve's Java client docs PR ([#789](https://github.com/elastic/elasticsearch-java/pull/789/files)).

@Anaethelion This needs expanding and tailoring for the Go client (it's really just placeholder text from the Java client docs). All feedback is welcome, especially because I'm still so new to Elastic and to the client docs.

[Preview](https://go-elasticsearch_bk_860.docs-preview.app.elstc.co/guide/en/elasticsearch/client/go-api/master/esql.html)