### PR TITLE
Bulk indexer: Follow convention and increment waitgroup in loop before creating goroutines

### DIFF
--- a/esutil/bulk_indexer.go
+++ b/esutil/bulk_indexer.go
@@ -370,6 +370,7 @@ func (bi *bulkIndexer) init() {
 	bi.queue = make(chan BulkIndexerItem, bi.config.NumWorkers)
 
 	for i := 1; i <= bi.config.NumWorkers; i++ {
+		bi.wg.Add(1)
 		w := worker{
 			id:     i,
 			ch:     bi.queue,
@@ -380,7 +381,6 @@ func (bi *bulkIndexer) init() {
 		w.run()
 		bi.workers = append(bi.workers, &w)
 	}
-	bi.wg.Add(bi.config.NumWorkers)
 }
 
 // worker represents an indexer worker.


### PR DESCRIPTION
The wg Delta should generally be added before relevant go-routines are launched. Reference: https://pkg.go.dev/sync#WaitGroup.Add

This also aligns the code with our other uses of waitgroups.

Closes https://github.com/elastic/go-elasticsearch/issues/796.