### PR TITLE
Update variable names to Go convention + Simplify map lookups

### DIFF
--- a/internal/build/cmd/generate/commands/genexamples/translator.go
+++ b/internal/build/cmd/generate/commands/genexamples/translator.go
@@ -1058,11 +1058,7 @@ var ConsoleToGo = []TranslateRule{
 				fmt.Fprint(&src, args)
 			}
 
-			var hasPretty bool
-			if _, ok := params["pretty"]; ok {
-				hasPretty = true
-			}
-
+			_, hasPretty := params["pretty"]
 			if !hasPretty {
 				src.WriteString("\tes.Scroll.WithPretty(),\n")
 			}
@@ -1109,11 +1105,7 @@ var ConsoleToGo = []TranslateRule{
 				fmt.Fprint(&src, args)
 			}
 
-			var hasPretty bool
-			if _, ok := params["pretty"]; ok {
-				hasPretty = true
-			}
-
+			_, hasPretty := params["pretty"]
 			if !hasPretty {
 				src.WriteString("\tes.Search.WithPretty(),\n")
 			}
@@ -1160,11 +1152,7 @@ var ConsoleToGo = []TranslateRule{
 				fmt.Fprint(&src, args)
 			}
 
-			var hasPretty bool
-			if _, ok := params["pretty"]; ok {
-				hasPretty = true
-			}
-
+			_, hasPretty := params["pretty"]
 			if !hasPretty {
 				src.WriteString("\tes.Count.WithPretty(),\n")
 			}

--- a/internal/build/cmd/generate/commands/genexamples/translator.go
+++ b/internal/build/cmd/generate/commands/genexamples/translator.go
@@ -1059,9 +1059,10 @@ var ConsoleToGo = []TranslateRule{
 			}
 
 			var hasPretty bool
-			for k, _ := range params {
+			for k := range params {
 				if k == "pretty" {
 					hasPretty = true
+					break
 				}
 			}
 
@@ -1112,9 +1113,10 @@ var ConsoleToGo = []TranslateRule{
 			}
 
 			var hasPretty bool
-			for k, _ := range params {
+			for k := range params {
 				if k == "pretty" {
 					hasPretty = true
+					break
 				}
 			}
 
@@ -1165,9 +1167,10 @@ var ConsoleToGo = []TranslateRule{
 			}
 
 			var hasPretty bool
-			for k, _ := range params {
+			for k := range params {
 				if k == "pretty" {
 					hasPretty = true
+					break
 				}
 			}
 

--- a/internal/build/cmd/generate/commands/genexamples/translator.go
+++ b/internal/build/cmd/generate/commands/genexamples/translator.go
@@ -1059,11 +1059,8 @@ var ConsoleToGo = []TranslateRule{
 			}
 
 			var hasPretty bool
-			for k := range params {
-				if k == "pretty" {
-					hasPretty = true
-					break
-				}
+			if _, ok := params["pretty"]; ok {
+				hasPretty = true
 			}
 
 			if !hasPretty {
@@ -1113,11 +1110,8 @@ var ConsoleToGo = []TranslateRule{
 			}
 
 			var hasPretty bool
-			for k := range params {
-				if k == "pretty" {
-					hasPretty = true
-					break
-				}
+			if _, ok := params["pretty"]; ok {
+				hasPretty = true
 			}
 
 			if !hasPretty {
@@ -1167,11 +1161,8 @@ var ConsoleToGo = []TranslateRule{
 			}
 
 			var hasPretty bool
-			for k := range params {
-				if k == "pretty" {
-					hasPretty = true
-					break
-				}
+			if _, ok := params["pretty"]; ok {
+				hasPretty = true
 			}
 
 			if !hasPretty {

--- a/internal/build/cmd/generate/commands/gentests/generator.go
+++ b/internal/build/cmd/generate/commands/gentests/generator.go
@@ -1350,15 +1350,15 @@ func (g *Generator) genAction(a Action, skipBody ...bool) {
 			}
 
 			if name == "Authorization" {
-				auth_fields := strings.Split(value, " ")
-				auth_name := auth_fields[0]
-				auth_value := auth_fields[1]
-				if strings.HasPrefix(auth_value, "$") {
-					auth_value = `fmt.Sprintf("%s", stash["` + strings.ReplaceAll(strings.ReplaceAll(auth_value, "{", ""), "}", "") + `"])`
+				authFields := strings.Split(value, " ")
+				authName := authFields[0]
+				authValue := authFields[1]
+				if strings.HasPrefix(authValue, "$") {
+					authValue = `fmt.Sprintf("%s", stash["` + strings.ReplaceAll(strings.ReplaceAll(authValue, "{", ""), "}", "") + `"])`
 				} else {
-					auth_value = `"` + auth_value + `"`
+					authValue = `"` + authValue + `"`
 				}
-				g.w("\t\t\t" + `"Authorization": []string{"` + auth_name + ` " + ` + auth_value + `},` + "\n")
+				g.w("\t\t\t" + `"Authorization": []string{"` + authName + ` " + ` + authValue + `},` + "\n")
 
 			} else {
 				g.w("\t\t\t\"" + name + "\": []string{\"" + value + "\"},\n")

--- a/internal/build/cmd/generate/commands/gentests/model.go
+++ b/internal/build/cmd/generate/commands/gentests/model.go
@@ -111,9 +111,9 @@ func NewTestSuite(fpath string, payloads []TestPayload) TestSuite {
 	}
 
 	for _, payload := range payloads {
-		sec_keys := utils.MapKeys(payload.Payload)
+		secKeys := utils.MapKeys(payload.Payload)
 		switch {
-		case len(sec_keys) > 0 && strings.Contains(strings.Join(sec_keys, ","), "setup") || strings.Contains(strings.Join(sec_keys, ","), "teardown"):
+		case len(secKeys) > 0 && strings.Contains(strings.Join(secKeys, ","), "setup") || strings.Contains(strings.Join(secKeys, ","), "teardown"):
 			for k, v := range payload.Payload.(map[interface{}]interface{}) {
 				switch k {
 				case "setup":
@@ -144,25 +144,25 @@ func NewTestSuite(fpath string, payloads []TestPayload) TestSuite {
 					case "skip":
 						var (
 							ok     bool
-							skip_v string
-							skip_r string
+							skipV string
+							skipR string
 						)
 
 						skip := vv.(map[interface{}]interface{})["skip"]
 
-						if skip_v, ok = skip.(map[interface{}]interface{})["version"].(string); ok {
-							if skip_rr, ok := skip.(map[interface{}]interface{})["reason"].(string); ok {
-								skip_r = skip_rr
+						if skipV, ok = skip.(map[interface{}]interface{})["version"].(string); ok {
+							if skipRR, ok := skip.(map[interface{}]interface{})["reason"].(string); ok {
+								skipR = skipRR
 							}
-							if skip_v == "all" {
+							if skipV == "all" {
 								t.Skip = true
 								t.SkipInfo = "Skipping all versions"
 								break
 							}
-							if ts.SkipEsVersion(skip_v) {
-								// fmt.Printf("Skip: %q, EsVersion: %s, Skip: %v, Reason: %s\n", skip_v, EsVersion, ts.SkipEsVersion(skip_v), skip_r)
+							if ts.SkipEsVersion(skipV) {
+								// fmt.Printf("Skip: %q, EsVersion: %s, Skip: %v, Reason: %s\n", skipV, EsVersion, ts.SkipEsVersion(skipV), skipR)
 								t.Skip = true
-								t.SkipInfo = skip_r
+								t.SkipInfo = skipR
 							}
 						}
 					case "setup":


### PR DESCRIPTION
Underscore names are not Go convention. See report card here: https://goreportcard.com/report/github.com/elastic/go-elasticsearch#golint

Also simplifying some map lookups.