### PR TITLE
Include RootCause in ElasticsearchError.Error()

### DIFF
--- a/typedapi/types/elasticsearcherror.go
+++ b/typedapi/types/elasticsearcherror.go
@@ -35,6 +35,14 @@ func (e ElasticsearchError) Error() string {
 	if e.ErrorCause.Reason != nil {
 		reason = *e.ErrorCause.Reason
 	}
+	for _, r := range e.ErrorCause.RootCause {
+		if r.Reason != nil {
+			if reason != "" {
+				reason += ": "
+			}
+			reason += *r.Reason
+		}
+	}
 	return fmt.Sprintf("status: %d, failed: [%s], reason: %s", e.Status, e.ErrorCause.Type, reason)
 }
 

--- a/typedapi/types/elasticsearcherror_test.go
+++ b/typedapi/types/elasticsearcherror_test.go
@@ -1,0 +1,56 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package types
+
+import "testing"
+
+func ptr[T any](t T) *T { return &t }
+
+func TestElasticsearchError(t *testing.T) {
+	tests := []struct {
+		in   ElasticsearchError
+		want string
+	}{
+		{
+			ElasticsearchError{
+				Status: 400,
+				ErrorCause: ErrorCause{
+					Reason: ptr("[1:77] [bool] failed to parse field [filter]"),
+					Type:   "x_content_parse_exception",
+					CausedBy: &ErrorCause{
+						Reason: ptr("[term] query doesn't support multiple fields, found [collection_id] and [entities]"),
+						Type:   "parsing_exception",
+					},
+					RootCause: []ErrorCause{{
+						Reason: ptr("[term] query doesn't support multiple fields, found [collection_id] and [entities]"),
+						Type:   "parsing_exception",
+					}},
+				},
+			},
+			"status: 400, failed: [x_content_parse_exception], reason: [1:77] [bool] failed to parse field [filter]: [term] query doesn't support multiple fields, found [collection_id] and [entities]"},
+	}
+
+	for _, tt := range tests {
+		t.Run("", func(t *testing.T) {
+			have := tt.in.Error()
+			if have != tt.want {
+				t.Errorf("\nhave: %q\nwant: %q", have, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Previously it would just report:

	status: 400, failed: [x_content_parse_exception], reason: [1:77] [bool] failed to parse field [filter]

Which is just not very helpful; no idea what's wrong here. I've noticed this with quite a few errors over the last few weeks. The real error is "hidden" in the RootCause, so add that to the Error():

	status: 400, failed: [x_content_parse_exception], reason: [1:77] [bool] failed to parse field [filter]: [term] query doesn't support multiple fields, found [collection_id] and [entities]

Which is a bit long, but at least it has the actual error in there.