### PR TITLE
esutil: Modify the `BulkIndexerConfig.Client` type to `esapi.Transport`

### DIFF
--- a/esutil/bulk_indexer.go
+++ b/esutil/bulk_indexer.go
@@ -58,7 +58,7 @@ type BulkIndexerConfig struct {
 	FlushBytes    int           // The flush threshold in bytes. Defaults to 5MB.
 	FlushInterval time.Duration // The flush threshold as duration. Defaults to 30sec.
 
-	Client      *elasticsearch.Client   // The Elasticsearch client.
+	Client      esapi.Transport         // The Elasticsearch client.
 	Decoder     BulkResponseJSONDecoder // A custom JSON decoder.
 	DebugLogger BulkIndexerDebugLogger  // An optional logger for debugging.
 


### PR DESCRIPTION
Now, when using a pre-declared `TypedClient`, a separate `Client` instance had to be created via `NewClient` to pass it to `BulkIndexerConfig`.

To improve usability, this change updates the type of `BulkIndexerConfig.Client` to `esapi.Transport`, allowing both `Client` and `TypedClient` to be passed directly.