### PR TITLE
[docs] Clean up cross-repo links

### DIFF
--- a/docs/reference/connecting.md
+++ b/docs/reference/connecting.md
@@ -116,7 +116,7 @@ Running {{es}} without security enabled is not recommended.
 ::::
 
 
-If your cluster is configured with [security explicitly disabled](elasticsearch://docs/reference/elasticsearch/configuration-reference/security-settings.md) then you can connect via HTTP:
+If your cluster is configured with [security explicitly disabled](elasticsearch://reference/elasticsearch/configuration-reference/security-settings.md) then you can connect via HTTP:
 
 ```go
 cfg := elasticsearch.Config{


### PR DESCRIPTION
Follow up to #960 

When using cross-repo links, the path should be relative to the `docset.yml` not the full path within the repo ([updated docs-builder docs](https://elastic.github.io/docs-builder/syntax/links/#cross-repository-links)).