### PR TITLE
fix(typedapi): unmarshal DateDecayFunction

### DIFF
--- a/typedapi/types/datedecayfunction.go
+++ b/typedapi/types/datedecayfunction.go
@@ -21,8 +21,11 @@
 package types
 
 import (
+	"bytes"
 	"encoding/json"
+	"errors"
 	"fmt"
+	"io"
 
 	"github.com/elastic/go-elasticsearch/v8/typedapi/types/enums/multivaluemode"
 )
@@ -35,6 +38,42 @@ type DateDecayFunction struct {
 	// MultiValueMode Determines how the distance is calculated when a field used for computing the
 	// decay contains multiple values.
 	MultiValueMode *multivaluemode.MultiValueMode `json:"multi_value_mode,omitempty"`
+}
+
+func (s *DateDecayFunction) UnmarshalJSON(data []byte) error {
+
+	dec := json.NewDecoder(bytes.NewReader(data))
+
+	for {
+		t, err := dec.Token()
+		if err != nil {
+			if errors.Is(err, io.EOF) {
+				break
+			}
+			return err
+		}
+
+		switch t {
+
+		case "multi_value_mode":
+			if err := dec.Decode(&s.MultiValueMode); err != nil {
+				return fmt.Errorf("%s | %w", "MultiValueMode", err)
+			}
+		default:
+			if key, ok := t.(string); ok {
+				if s.DecayFunctionBaseDateMathDuration == nil {
+					s.DecayFunctionBaseDateMathDuration = make(map[string]DecayPlacementDateMathDuration)
+				}
+				raw := new(DecayPlacementDateMathDuration)
+				if err := dec.Decode(&raw); err != nil {
+					return fmt.Errorf("%s | %w", "DecayPlacementDateMathDuration", err)
+				}
+				s.DecayFunctionBaseDateMathDuration[key] = *raw
+			}
+
+		}
+	}
+	return nil
 }
 
 // MarhsalJSON overrides marshalling for types with additional properties


### PR DESCRIPTION
## WHAT
Add a custom UnmarshalJSON function to DateDecayFunction.

## WHY
There is an issue where deserialization does not work properly for `DateDecayFunction`, similar to [elastic/go-elasticsearch#830](https://github.com/elastic/go-elasticsearch/issues/830).
It seems necessary to implement the UnmarshalJSON function, just like in other parts of the code.

## TEST
Verified that the values remain unchanged after performing Marshal & Unmarshal using the following test code. This test fails without this pull request.
```
package typedapi

import (
	"encoding/json"
	"testing"

	"github.com/google/go-cmp/cmp"

	"github.com/elastic/go-elasticsearch/v8/typedapi/types"
	"github.com/elastic/go-elasticsearch/v8/typedapi/types/enums/multivaluemode"
)

func TestUnmarshalDateDecayFunction(t *testing.T) {
	a := types.Float64(1)
	s := "2025-03-12"

	before := types.DateDecayFunction{
		DecayFunctionBaseDateMathDuration: map[string]types.DecayPlacementDateMathDuration{
			"example_field": {
				Decay:  &a,
				Origin: &s,
				Scale:  "1d",
			},
		},
		MultiValueMode: &multivaluemode.Min,
	}

	// marshal and unmarshal the DateDecayFunction object, compare diff
	v, err := json.Marshal(before)
	if err != nil {
		t.Fatal(err)
	}

	var after types.DateDecayFunction
	err = json.Unmarshal(v, &after)
	if err != nil {
		t.Fatal(err)
	}

	if d := cmp.Diff(before, after); d != "" {
		t.Errorf(d)
	}
}

```
