### PR TITLE
[docs] Fix various syntax and rendering errors

### DIFF
--- a/docs/reference/_getting_started_with_the_api.md
+++ b/docs/reference/_getting_started_with_the_api.md
@@ -11,7 +11,7 @@ Connection to an {{es}} cluster is identical to the existing client, only the AP
 
 ```go
 client, err := elasticsearch.NewTypedClient(elasticsearch.Config{
-	// Proper configuration for your {es} cluster.
+	// Proper configuration for your Elasticsearch cluster.
 })
 ```
 


### PR DESCRIPTION
Fixes various syntax and rendering errors that might include:

* Fixing broken images
* Hardcoding book-level substitution values
* Fixing incorrectly closed blocks (admonitions, tab sets, code blocks, dropdowns etc.)
* Fixing poorly migrated complex tables
* Fixing poorly migrated lists
* Fixing poorly migrated tab sets
* Removing inline text formatting from directive titles where they won't be rendered (for example, inline `code` formatting in dropdown titles)
* Specifying if a version is trying to communicate if a feature was added, deprecated, or coming (for example, during migration `deprecated:[8.15.0]` became `[8.15.0]`, which doesn't give any information about _what_ happened in 8.15.0)
* Fixing nested dropdowns / definition lists
* Fixing poorly migrated footnotes
* Updating references to prerelease `9.0.0` versions