### PR TITLE
feat: Add queue size multiplier config to BulkIndexer

### DIFF
--- a/esutil/bulk_indexer.go
+++ b/esutil/bulk_indexer.go
@@ -290,19 +290,19 @@ func NewBulkIndexer(cfg BulkIndexerConfig) (BulkIndexer, error) {
 		cfg.Decoder = defaultJSONDecoder{}
 	}
 
-	if cfg.NumWorkers == 0 {
+	if cfg.NumWorkers <= 0 {
 		cfg.NumWorkers = runtime.NumCPU()
 	}
 
-	if cfg.FlushBytes == 0 {
+	if cfg.FlushBytes <= 0 {
 		cfg.FlushBytes = 5e+6
 	}
 
-	if cfg.FlushInterval == 0 {
+	if cfg.FlushInterval <= 0 {
 		cfg.FlushInterval = 30 * time.Second
 	}
 
-	if cfg.QueueSizeMultiplier == 0 {
+	if cfg.QueueSizeMultiplier <= 0 {
 		cfg.QueueSizeMultiplier = 1
 	}
 


### PR DESCRIPTION
Addresses feature request in https://github.com/elastic/go-elasticsearch/issues/1027.

This pull request exposes a worker queue size multiplier config `QueueSizeMultiplier`, which allows user to more flexibly configure their buffer size. This is especially helpful for systems with bursty traffic.

The default value is set to 1, which maintains the existing behavior as the default.

Tested by locally confirming that setting new config will increase queue capacity.