### PR TITLE
feat: Add queue size multiplier config to BulkIndexer (#1029)

### DIFF
--- a/esutil/bulk_indexer.go
+++ b/esutil/bulk_indexer.go
@@ -54,9 +54,10 @@ type BulkIndexer interface {
 
 // BulkIndexerConfig represents configuration of the indexer.
 type BulkIndexerConfig struct {
-	NumWorkers    int           // The number of workers. Defaults to runtime.NumCPU().
-	FlushBytes    int           // The flush threshold in bytes. Defaults to 5MB.
-	FlushInterval time.Duration // The flush threshold as duration. Defaults to 30sec.
+	NumWorkers          int           // The number of workers. Defaults to runtime.NumCPU().
+	FlushBytes          int           // The flush threshold in bytes. Defaults to 5MB.
+	FlushInterval       time.Duration // The flush threshold as duration. Defaults to 30sec.
+	QueueSizeMultiplier int           // The multiplier on the size of the worker queue. Defaults to 1.
 
 	Client      esapi.Transport         // The Elasticsearch client.
 	Decoder     BulkResponseJSONDecoder // A custom JSON decoder.
@@ -289,16 +290,20 @@ func NewBulkIndexer(cfg BulkIndexerConfig) (BulkIndexer, error) {
 		cfg.Decoder = defaultJSONDecoder{}
 	}
 
-	if cfg.NumWorkers == 0 {
+	if cfg.NumWorkers <= 0 {
 		cfg.NumWorkers = runtime.NumCPU()
 	}
 
-	if cfg.FlushBytes == 0 {
+	if cfg.FlushBytes <= 0 {
 		cfg.FlushBytes = 5e+6
 	}
 
-	if cfg.FlushInterval == 0 {
+	if cfg.FlushInterval <= 0 {
 		cfg.FlushInterval = 30 * time.Second
+	}
+
+	if cfg.QueueSizeMultiplier <= 0 {
+		cfg.QueueSizeMultiplier = 1
 	}
 
 	bi := bulkIndexer{
@@ -371,7 +376,7 @@ func (bi *bulkIndexer) Stats() BulkIndexerStats {
 
 // init initializes the bulk indexer.
 func (bi *bulkIndexer) init() {
-	bi.queue = make(chan BulkIndexerItem, bi.config.NumWorkers)
+	bi.queue = make(chan BulkIndexerItem, bi.config.NumWorkers*bi.config.QueueSizeMultiplier)
 
 	for i := 1; i <= bi.config.NumWorkers; i++ {
 		bi.wg.Add(1)


### PR DESCRIPTION
* Add queue size multiplier config to BulkIndexer

* test: add unit tests for QueueSizeMultiplier BulkIndexerConfig value

---------

Co-authored-by: Matt Devy <matt.devy@elastic.co>
(cherry picked from commit c2f52b53a9d0ca70b16f2bfd5f97f0ae570eb066)
