### PR TITLE
chore(esapi): include date type in path generation logic as string

### DIFF
--- a/internal/build/cmd/generate/commands/gensource/model.go
+++ b/internal/build/cmd/generate/commands/gensource/model.go
@@ -303,6 +303,11 @@ func NewEndpoint(f io.Reader) (*Endpoint, error) {
 			part.Endpoint = &endpoint
 			part.Name = partName
 			applyParamOverride(endpoint.Name, partName, &part.Type)
+
+			// Date types are handled as strings in the esapi client
+			if part.Type == "date" {
+				part.Type = "string"
+			}
 		}
 	}
 
@@ -347,6 +352,11 @@ func NewEndpoint(f io.Reader) (*Endpoint, error) {
 	for paramName, p := range endpoint.URL.Params {
 		p.Endpoint = &endpoint
 		p.Name = paramName
+
+		// Date types are handled as strings in the esapi client
+		if p.Type == "date" {
+			p.Type = "string"
+		}
 	}
 
 	// Update the AllParts field


### PR DESCRIPTION
Date type is included in the `rest-apis-spec`. This was previously handled as a string.

An example

```
{
  "ml.get_buckets": {
   ...
    "url": {
      "paths": [
        {
          "path": "/_ml/anomaly_detectors/{job_id}/results/buckets/{timestamp}",
          "methods": [
            "GET",
            "POST"
          ],
          "parts": {
            "job_id": {
              "type": "string",
              "description": "ID of the job to get bucket results from"
            },
            "timestamp": {
              "type": "date",
              "description": "The timestamp of the desired single bucket result"
            }
          }
        },
        ...
      ]
    },
    "params": {
      ...
      "start": {
        "type": "date",
        "default": "-1",
        "description": "Start time filter for buckets"
      },
      "end": {
        "type": "date",
        "default": "-1",
        "description": "End time filter for buckets"
      },
      ...
    },
    ...
  }
}
```

We can see that `timestamp` in the path part is type `date` in 9.3.
Previously this was a string in the generated code, therefore I have added this case to the generator.

Error was 
```
Processing file "ml.get_buckets.json"
panic: FAIL: "ml.get_buckets": unexpected type "date" for URL part "timestamp"
```

## Struct before `date` was introduced

```
// MLGetBucketsRequest configures the ML Get Buckets API request.
type MLGetBucketsRequest struct {
	Body io.Reader

	JobID     string
	Timestamp string

	AnomalyScore   interface{}
	Desc           *bool
	End            string
	ExcludeInterim *bool
	Expand         *bool
	From           *int
	Size           *int
	Sort           string
	Start          string

	Pretty     bool
	Human      bool
	ErrorTrace bool
	FilterPath []string

	Header http.Header

	ctx context.Context

	Instrument Instrumentation
}
```

This shows `timestamp`, `end` and `start` params have historically been `string`s in the esapi client. And as such, it makes sense to keep them that way