### PR TITLE
fix(esutil): handle error from Seek in BulkIndexer.writeBody

### DIFF
--- a/esutil/bulk_indexer.go
+++ b/esutil/bulk_indexer.go
@@ -488,7 +488,12 @@ func (w *worker) writeBody(item *BulkIndexerItem) error {
 			}
 			return err
 		}
-		item.Body.Seek(0, io.SeekStart)
+		if _, err := item.Body.Seek(0, io.SeekStart); err != nil {
+			if w.bi.config.OnError != nil {
+				w.bi.config.OnError(context.Background(), err)
+			}
+			return err
+		}
 		w.buf.WriteRune('\n')
 	}
 	return nil


### PR DESCRIPTION
## Summary

- Fix unchecked error from `item.Body.Seek(0, io.SeekStart)` in `writeBody` function

## Problem

In `esutil/bulk_indexer.go`, the `writeBody` function was ignoring the error returned from `item.Body.Seek(0, io.SeekStart)`. This is inconsistent with how errors are handled elsewhere in the codebase:

1. In `computeLength()` (lines 200-217), both Seek calls properly check and return errors
2. In `writeBody()`, the `ReadFrom` error is properly handled, but the subsequent Seek error was ignored

## Impact

If the Seek operation fails:
- The body position would be incorrect for subsequent operations
- Users expecting to re-read the body in `OnSuccess`/`OnFailure` callbacks would get unexpected results
- Silent failures could occur without proper error notification

## Fix

The change adds proper error handling for the Seek call, following the same pattern as the existing ReadFrom error handling:
1. Call the `OnError` callback if configured
2. Return the error to the caller

## Testing

All existing tests pass:
```
go test ./esutil/... -v
```