### PR TITLE
ci: update apidiff workflow to fetch tags before processing

### DIFF
--- a/.github/workflows/apidiff-pr.yml
+++ b/.github/workflows/apidiff-pr.yml
@@ -32,6 +32,8 @@ jobs:
         run: |
           set -euo pipefail
 
+          git fetch --tags --force
+
           version=$(python - <<'PY'
           import json
           with open(".github/.release-please-manifest.json", "r", encoding="utf-8") as f:
@@ -57,7 +59,6 @@ jobs:
 
           module_path=$(awk '/^module /{print $2}' go.mod)
 
-          git fetch --tags --force
           git worktree add "${old_dir}" "${tag}"
 
           make_comment() {


### PR DESCRIPTION
(cherry picked from commit 067539f0eae8f0705064dcc5cb3d76aba256440b)