### PR TITLE
fix(esutil): avoid duplicate bulk indexer OnError callbacks

### DIFF
--- a/esutil/bulk_indexer.go
+++ b/esutil/bulk_indexer.go
@@ -508,9 +508,6 @@ func (w *worker) writeBody(item *BulkIndexerItem) error {
 func (w *worker) flush(ctx context.Context) bool {
 	ok := true
 	if err := w.flushBuffer(ctx); err != nil {
-		if w.bi.config.OnError != nil {
-			w.bi.config.OnError(ctx, err)
-		}
 		ok = false
 	}
 	w.ticker.Reset(w.bi.config.FlushInterval)


### PR DESCRIPTION
Ensure flush-level failures invoke BulkIndexerConfig.OnError only once by removing the extra callback from worker.flush().

Add regression coverage for flush response errors and update decoder failure expectation to match single-callback behavior.


Relates to: #497 