### PR TITLE
ci: add actions:write permission to stale workflow

### DIFF
--- a/.github/workflows/close-stale-issues.yml
+++ b/.github/workflows/close-stale-issues.yml
@@ -7,6 +7,7 @@ on:
     - cron: "0 1 * * *"
 
 permissions:
+  actions: "write"
   issues: "write"
   pull-requests: "write"
 


### PR DESCRIPTION
The actions/stale action needs `actions: write` permission to delete and update its `_state` cache between runs. Without it, the cache becomes permanently frozen, causing stale issues to be skipped as "processed during the previous run" and never closed.