### PR TITLE
chore: Update release API endpoint

### DIFF
--- a/internal/build/sdk/artifacts/client.go
+++ b/internal/build/sdk/artifacts/client.go
@@ -29,7 +29,7 @@ import (
 )
 
 const (
-	defaultReleasesBaseURL = "https://artifacts.elastic.co/"
+	defaultReleasesBaseURL = "https://elastic-release-api.s3.us-west-2.amazonaws.com/"
 	defaultSnapshotBaseURL = "https://artifacts-snapshot.elastic.co/"
 )
 

--- a/internal/build/sdk/artifacts/rest_resources_download_test.go
+++ b/internal/build/sdk/artifacts/rest_resources_download_test.go
@@ -118,7 +118,7 @@ func TestClient_DownloadRestResources(t *testing.T) {
 			ref:  "8.15.0",
 			dest: "/output",
 			responses: map[string]string{
-				"https://artifacts.elastic.co/releases/stack.json": `{
+				"https://elastic-release-api.s3.us-west-2.amazonaws.com/public/past-releases.json": `{
 					"releases": [
 						{
 							"version": "8.15.0",
@@ -172,7 +172,7 @@ func TestClient_DownloadRestResources(t *testing.T) {
 			ref:  "99.99.99",
 			dest: "/output",
 			responses: map[string]string{
-				"https://artifacts.elastic.co/releases/stack.json": `{
+				"https://elastic-release-api.s3.us-west-2.amazonaws.com/public/past-releases.json": `{
 					"releases": [
 						{
 							"version": "8.15.0",


### PR DESCRIPTION
Release API migration to new endpoints is now complete.

Past Release Endpoint : https://elastic-release-api.s3.us-west-2.amazonaws.com/public/past-releases.json
Future Release Endpoint : https://elastic-release-api.s3.us-west-2.amazonaws.com/public/future-releases.json

This PR updates the old Release API endpoints to new one's

More Info:
https://groups.google.com/a/elastic.co/g/release-eng-team/c/qgXaCX-y29k/m/jzm2S8MeAwAJ