### PR TITLE
fix(typedapi): omit null elements from search_after in SearchRequestBody

### DIFF
--- a/typedapi/types/searchrequestbody_marshal.go
+++ b/typedapi/types/searchrequestbody_marshal.go
@@ -1,0 +1,49 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package types
+
+import "encoding/json"
+
+// MarshalJSON filters nil values from SearchAfter before encoding.
+//
+// Elasticsearch rejects a search_after array that contains a null element
+// (returning a 500 "all shards failed" error). Callers that build sort
+// cursors with a nil FieldValue to mean "no cursor" would otherwise trigger
+// this error silently. Nil entries are stripped here so that:
+//   - []FieldValue{nil}       → search_after field omitted entirely
+//   - []FieldValue{nil, "x"}  → search_after: ["x"]
+func (s SearchRequestBody) MarshalJSON() ([]byte, error) {
+	// Filter nil values from SearchAfter.
+	if len(s.SearchAfter) > 0 {
+		filtered := make([]FieldValue, 0, len(s.SearchAfter))
+		for _, v := range s.SearchAfter {
+			if v != nil {
+				filtered = append(filtered, v)
+			}
+		}
+		if len(filtered) == 0 {
+			s.SearchAfter = nil
+		} else {
+			s.SearchAfter = filtered
+		}
+	}
+
+	// Use a type alias to invoke default JSON encoding without recursion.
+	type Plain SearchRequestBody
+	return json.Marshal(Plain(s))
+}

--- a/typedapi/types/searchrequestbody_marshal_test.go
+++ b/typedapi/types/searchrequestbody_marshal_test.go
@@ -1,0 +1,77 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package types
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+)
+
+func TestSearchRequestBody_MarshalJSON_SearchAfterNil(t *testing.T) {
+	tests := []struct {
+		name        string
+		searchAfter []FieldValue
+		wantInJSON  string
+		wantAbsent  string
+	}{
+		{
+			name:        "nil slice omitted",
+			searchAfter: nil,
+			wantAbsent:  "search_after",
+		},
+		{
+			name:        "empty slice omitted",
+			searchAfter: []FieldValue{},
+			wantAbsent:  "search_after",
+		},
+		{
+			name:        "all-nil slice omitted",
+			searchAfter: []FieldValue{nil, nil},
+			wantAbsent:  "search_after",
+		},
+		{
+			name:        "nil element stripped",
+			searchAfter: []FieldValue{nil, "cursor-value"},
+			wantInJSON:  `"search_after":["cursor-value"]`,
+		},
+		{
+			name:        "non-nil values preserved",
+			searchAfter: []FieldValue{"a", int64(42), true},
+			wantInJSON:  `"search_after":["a",42,true]`,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			body := SearchRequestBody{SearchAfter: tc.searchAfter}
+			data, err := json.Marshal(body)
+			if err != nil {
+				t.Fatalf("unexpected marshal error: %s", err)
+			}
+			got := string(data)
+
+			if tc.wantInJSON != "" && !strings.Contains(got, tc.wantInJSON) {
+				t.Errorf("expected JSON to contain %q, got: %s", tc.wantInJSON, got)
+			}
+			if tc.wantAbsent != "" && strings.Contains(got, tc.wantAbsent) {
+				t.Errorf("expected JSON NOT to contain %q, got: %s", tc.wantAbsent, got)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

- Elasticsearch rejects a `search_after` array that contains a `null` element with a 500 "all shards failed" error. Callers that represent "no cursor" with a nil `FieldValue` trigger this silently.
- A custom `MarshalJSON` on `SearchRequestBody` strips nil values before encoding, keeping the field absent entirely when all elements are nil.

## Changes

- `typedapi/types/searchrequestbody_marshal.go` *(new file)*: `MarshalJSON` filters nil entries from `SearchAfter`; uses a type alias to avoid infinite recursion.
- `typedapi/types/searchrequestbody_marshal_test.go` *(new file)*: table-driven tests covering nil slice, empty slice, all-nil slice, mixed, and non-nil cases.

The fix lives in a separate `_marshal.go` file so it is not overwritten by code generation.

Fixes https://github.com/elastic/go-elasticsearch/issues/755

🤖 Generated with [Claude Code](https://claude.com/claude-code)