### PR TITLE
fix(examples): guard retryBackoff with a mutex to prevent data race

### DIFF
--- a/_examples/bulk/indexer.go
+++ b/_examples/bulk/indexer.go
@@ -35,6 +35,7 @@ import (
 	"runtime"
 	"strconv"
 	"strings"
+	"sync"
 	"sync/atomic"
 	"time"
 
@@ -96,6 +97,7 @@ func main() {
 	//
 	// Use a third-party package for implementing the backoff function
 	//
+	var retryBackoffMu sync.Mutex
 	retryBackoff := backoff.NewExponentialBackOff()
 	// <<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<
 
@@ -114,6 +116,8 @@ func main() {
 		// Configure the backoff function
 		//
 		RetryBackoff: func(i int) time.Duration {
+			retryBackoffMu.Lock()
+			defer retryBackoffMu.Unlock()
 			if i == 1 {
 				retryBackoff.Reset()
 			}


### PR DESCRIPTION
## Summary

- The `RetryBackoff` closure in `_examples/bulk/indexer.go` captures a `*backoff.ExponentialBackOff` that is shared across all goroutines in the HTTP transport. Concurrent retries call `Reset()` and `NextBackOff()` without synchronisation, which the Go race detector flags as a data race.

## Changes

- `_examples/bulk/indexer.go`: added `sync.Mutex` (`retryBackoffMu`) guarding `retryBackoff.Reset()` and `retryBackoff.NextBackOff()` inside the closure.

Fixes https://github.com/elastic/go-elasticsearch/issues/271

🤖 Generated with [Claude Code](https://claude.com/claude-code)