### PR TITLE
fix(build): update releases API URL to new S3 endpoint

### DIFF
--- a/internal/build/sdk/artifacts/releases_list.go
+++ b/internal/build/sdk/artifacts/releases_list.go
@@ -42,7 +42,7 @@ type ListReleasesResponse struct {
 
 // ListReleases lists all releases.
 func (c *Client) ListReleases(ctx context.Context) (*ListReleasesResponse, error) {
-	requestUrl, err := url.JoinPath(c.releasesBaseURL, "releases", "stack.json")
+	requestUrl, err := url.JoinPath(c.releasesBaseURL, "public", "past-releases.json")
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
## Summary
- The Elastic release listing S3 endpoint moved from `releases/stack.json` to `public/past-releases.json`, causing 403 errors when CI tries to download Elasticsearch specs on non-main branches.
- Updates the URL path in `ListReleases` to use the new endpoint.

## Test plan
- [x] `make lint` passes
- [x] `make test-unit` passes (268 tests, including existing tests in `rest_resources_download_test.go` that already mock the new URL)