### PR TITLE
fix(gen): map spec long to *int64 for esapi params

### DIFF
--- a/internal/build/cmd/generate/commands/gensource/generator.go
+++ b/internal/build/cmd/generate/commands/gensource/generator.go
@@ -362,6 +362,8 @@ func (f ` + g.Endpoint.MethodWithNamespace() + `) WithContext(v context.Context)
 			b.WriteString(`v bool`)
 		case "*int":
 			b.WriteString(`v int`)
+		case "*int64":
+			b.WriteString(`v int64`)
 		case "[]string":
 			b.WriteString(`v ...string`)
 		default:
@@ -374,7 +376,7 @@ func (f ` + g.Endpoint.MethodWithNamespace() + `) WithContext(v context.Context)
 		switch pGoType {
 		case "bool":
 			b.WriteString("\t\t" + `r.` + pFieldName + ` = true`)
-		case "*bool", "*int":
+		case "*bool", "*int", "*int64":
 			b.WriteString("\t\t" + `r.` + pFieldName + ` = &v`)
 		default:
 			b.WriteString("\t\t" + `r.` + pFieldName + ` = v`)
@@ -675,10 +677,10 @@ func (r ` + g.Endpoint.MethodWithNamespace() + `Request) Do(providedCtx context.
 							}` + "\n")
 						case "long":
 							requiredArgsValidation.WriteString(`if r.` + p + ` == nil { return nil, errors.New("` + a.Name + ` is required and cannot be nil") }` + "\n")
-							pathGrow.WriteString(`len(strconv.Itoa(*r.` + p + `)) + `)
-							pathContent.WriteString(`	path.WriteString(strconv.Itoa(*r.` + p + `))` + "\n")
+							pathGrow.WriteString(`len(strconv.FormatInt(*r.` + p + `, 10)) + `)
+							pathContent.WriteString(`	path.WriteString(strconv.FormatInt(*r.` + p + `, 10))` + "\n")
 							pathContent.WriteString(`if instrument, ok := r.Instrument.(Instrumentation); ok {
-								instrument.RecordPathPart(ctx, "` + a.Name + `", strconv.Itoa(*r.` + p + `))
+								instrument.RecordPathPart(ctx, "` + a.Name + `", strconv.FormatInt(*r.` + p + `, 10))
 							}` + "\n")
 						default:
 							panic(fmt.Sprintf("FAIL: %q: unexpected type %q for URL part %q\n", g.Endpoint.Name, a.Type, a.Name))
@@ -800,6 +802,9 @@ func (r ` + g.Endpoint.MethodWithNamespace() + `Request) Do(providedCtx context.
 			case "*int":
 				fieldCondition = `r.` + fieldName + ` != nil`
 				fieldValue = `strconv.FormatInt(int64(*r.` + fieldName + `), 10)`
+			case "*int64":
+				fieldCondition = `r.` + fieldName + ` != nil`
+				fieldValue = `strconv.FormatInt(*r.` + fieldName + `, 10)`
 			case "uint":
 				fieldCondition = `r.` + fieldName + ` != 0`
 				fieldValue = `strconv.FormatUint(uint64(r.` + fieldName + `), 10)`

--- a/internal/build/utils/naming.go
+++ b/internal/build/utils/naming.go
@@ -28,7 +28,7 @@ var (
 		"number":  "*int",
 		"int":     "*int",
 		"integer": "*int",
-		"long":    "*int",
+		"long":    "*int64",
 		"string":  "string",
 		"time":    "time.Duration",
 	}


### PR DESCRIPTION
## Summary

Fix the `esapi` code generator to map spec type `long` to Go `*int64` instead of `*int`. Closes the root cause of #548.

The generator's type table in `internal/build/utils/naming.go` mapped spec `long` to Go `*int`, which is 32 bits on 32-bit platforms and can't represent the full Elasticsearch version range (up to ~9.2e18). This also diverged from:

- `esutil.BulkIndexerItem.Version`, already typed `*int64`
- `elasticsearch-specification`, where `VersionNumber` is defined as `long`

This PR changes only the generator. Regenerating `esapi/` (the breaking signature change visible to downstream consumers, e.g. `WithVersion(v int)` becoming `WithVersion(v int64)`) will ship as a separate PR.

## Changes

- `internal/build/utils/naming.go`: `"long": "*int"` becomes `"long": "*int64"`
- `internal/build/cmd/generate/commands/gensource/generator.go`:
  - Required path-part rendering for `long` uses `strconv.FormatInt` instead of `strconv.Itoa` (Itoa doesn't take `int64`)
  - Query-param rendering gets a `*int64` case emitting `strconv.FormatInt(*r.X, 10)`
  - `WithXxx` setter generation handles `*int64` in both the argument-type and body-assignment switches

## Scope of the breaking change (follow-up PR)

Regenerating affects ~25 endpoints that use `long` params. Examples:

- Document version: `Index`, `Update`, `Delete`, `Get`, `Create`, `Exists`, `GetSource`, `ExistsSource`
- Paging/size: `Search.WithFrom`, `Search.WithSize`, `Search.WithTerminateAfter`, etc.

Call sites passing untyped integer literals (e.g. `WithVersion(42)`) keep compiling. Call sites passing a typed `int` variable need an `int64(...)` cast.

## Test plan

- [x] `cd internal/build && go build ./...` clean
- [x] `cd internal/build && go vet ./...` clean
- [x] `make lint` clean
- [x] `make test-unit` passes (310 tests)
- [ ] Verify regenerated `esapi/` compiles (follow-up PR)
- [ ] Verify regenerated `esapi/` integration tests pass (follow-up PR)
