### PR TITLE
ci: add 9.4 branch to scheduled esapi generation

### DIFF
--- a/.github/workflows/generate-esapi.yml
+++ b/.github/workflows/generate-esapi.yml
@@ -41,7 +41,7 @@ jobs:
         run: |
           set -euo pipefail
 
-          input="${{ github.event_name == 'schedule' && 'main,9.3,9.2,8.19' || inputs.branches }}"
+          input="${{ github.event_name == 'schedule' && 'main,9.4,9.3,9.2,8.19' || inputs.branches }}"
 
           # Remove spaces around commas and split into array
           IFS=',' read -ra entries <<< "${input//[[:space:]]/}"


### PR DESCRIPTION
## Summary
- Add `9.4` to the scheduled branch list in `generate-esapi.yml` so the weekly run covers the new version branch alongside `main`, `9.3`, `9.2`, and `8.19`.

## Test plan
- [ ] Manually trigger the workflow via `workflow_dispatch` with `branches: 9.4` to confirm the matrix plan step parses correctly and the generate job runs against the 9.4 branch.