### PR TITLE
chore: fix stale paths and worktree check in gen traps

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -416,7 +416,7 @@ endif
 	@printf "\033[2m→ Generating API package from specification ($(version):$(build_hash))...\033[0m\n"
 	@{ \
 		set -e; \
-		trap "test -d .git && git checkout --quiet $(PWD)/internal/build/go.mod" INT TERM EXIT; \
+		trap "test -e $(PWD)/.git && git checkout --quiet $(PWD)/internal/build/go.mod $(PWD)/internal/build/go.sum" INT TERM EXIT; \
 		export ELASTICSEARCH_BUILD_VERSION=$(version) && \
 		export ELASTICSEARCH_BUILD_HASH=$(build_hash) && \
 		cd internal/build && \
@@ -446,7 +446,7 @@ endif
 	@printf "\033[2m→ Generating API tests from specification ($(version):$(build_hash))...\033[0m\n"
 	@{ \
 		set -e; \
-		trap "test -d .git && git checkout --quiet $(PWD)/internal/cmd/generate/go.mod" INT TERM EXIT; \
+		trap "test -e $(PWD)/.git && git checkout --quiet $(PWD)/internal/build/go.mod $(PWD)/internal/build/go.sum" INT TERM EXIT; \
 		export ELASTICSEARCH_BUILD_VERSION=$(version) && \
 		export ELASTICSEARCH_BUILD_HASH=$(build_hash) && \
 		rm -rf $(output)/*_test.go && \
@@ -462,7 +462,7 @@ gen-docs:  ## Generate the skeleton of documentation examples
 	$(eval update ?= no)
 	@{ \
 		set -e; \
-		trap "test -d .git && git checkout --quiet $(PWD)/internal/cmd/generate/go.mod" INT TERM EXIT; \
+		trap "test -e $(PWD)/.git && git checkout --quiet $(PWD)/internal/build/go.mod $(PWD)/internal/build/go.sum" INT TERM EXIT; \
 		if [ "$(update)" = "yes" ]; then \
 			printf "\033[2m→ Updating the alternatives_report.json file\033[0m\n" && \
 			curl -s https://raw.githubusercontent.com/elastic/built-docs/master/raw/en/elasticsearch/reference/master/alternatives_report.json > tmp/alternatives_report.json; \


### PR DESCRIPTION
## Summary

Fix two bugs in the generator Makefile traps that prevented transient
`internal/build/go.mod` mutations from being cleaned up after
`make gen-tests` (and `gen-docs`).

- `gen-tests` and `gen-docs` traps referenced `internal/cmd/generate/go.mod`,
  a path that no longer exists; the generator lives in `internal/build/` now.
  As a result, the `go get golang.org/x/tools/cmd/goimports` performed inside
  `gen-tests` leaked dependency bumps into `internal/build/go.mod` / `go.sum`
  on every run.
- All three generator traps (`gen-api`, `gen-tests`, `gen-docs`) guarded the
  checkout with `test -d .git`, which is false inside a git worktree (where
  `.git` is a file) and also happens to be evaluated after the `cd internal/build`,
  where no `.git` entry exists at all. Replaced with an absolute
  `test -e $(PWD)/.git` so the guard holds regardless of CWD or worktree layout.

No behavior change for `gen-api` itself — it does not mutate `go.mod`, but
the trap is corrected for consistency and future safety.

## Test plan

- [x] `make download-specs`
- [x] `make gen-api` — produces expected esapi/ diff; working tree for `internal/build/` stays clean
- [x] `make gen-tests` — generates `esapi/test/*_test.go`; `internal/build/go.mod` and `go.sum` are restored after the run (previously stayed modified)
- [x] `make lint` passes
- [x] Verified in a git worktree checkout (where `.git` is a file)
