### PR TITLE
fix: regenerate esapi with *int64 for long-typed params

### DIFF
--- a/esapi/api._.go
+++ b/esapi/api._.go
@@ -15,7 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 //
-// Code generated from specification version 9.4.0 (da34c45): DO NOT EDIT
+// Code generated from specification version 9.4.0 (5f4b64c): DO NOT EDIT
 
 package esapi
 
@@ -631,6 +631,7 @@ type Security struct {
 	ClearCachedRealms           SecurityClearCachedRealms
 	ClearCachedRoles            SecurityClearCachedRoles
 	ClearCachedServiceTokens    SecurityClearCachedServiceTokens
+	CloneAPIKey                 SecurityCloneAPIKey
 	CreateAPIKey                SecurityCreateAPIKey
 	CreateCrossClusterAPIKey    SecurityCreateCrossClusterAPIKey
 	CreateServiceToken          SecurityCreateServiceToken
@@ -1280,6 +1281,7 @@ func New(t Transport) *API {
 			ClearCachedRealms:           newSecurityClearCachedRealmsFunc(t),
 			ClearCachedRoles:            newSecurityClearCachedRolesFunc(t),
 			ClearCachedServiceTokens:    newSecurityClearCachedServiceTokensFunc(t),
+			CloneAPIKey:                 newSecurityCloneAPIKeyFunc(t),
 			CreateAPIKey:                newSecurityCreateAPIKeyFunc(t),
 			CreateCrossClusterAPIKey:    newSecurityCreateCrossClusterAPIKeyFunc(t),
 			CreateServiceToken:          newSecurityCreateServiceTokenFunc(t),

--- a/esapi/api.cat.segments.go
+++ b/esapi/api.cat.segments.go
@@ -263,7 +263,7 @@ func (f CatSegments) WithAllowClosed(v bool) func(*CatSegmentsRequest) {
 	}
 }
 
-// WithAllowNoIndices - whether to ignore if a wildcard indices expression resolves into no concrete indices. (this includes `_all` string or when no indices have been specified). only allowed when providing an index expression..
+// WithAllowNoIndices - whether to allow (1) wildcard index expressions that match no indices and (2) requests where the final resolved set is empty. only allowed when providing an index expression..
 func (f CatSegments) WithAllowNoIndices(v bool) func(*CatSegmentsRequest) {
 	return func(r *CatSegmentsRequest) {
 		r.AllowNoIndices = &v

--- a/esapi/api.cluster.state.go
+++ b/esapi/api.cluster.state.go
@@ -61,7 +61,7 @@ type ClusterStateRequest struct {
 	IgnoreUnavailable      *bool
 	Local                  *bool
 	MasterTimeout          time.Duration
-	WaitForMetadataVersion *int
+	WaitForMetadataVersion *int64
 	WaitForTimeout         time.Duration
 
 	Pretty     bool
@@ -143,7 +143,7 @@ func (r ClusterStateRequest) Do(providedCtx context.Context, transport Transport
 	}
 
 	if r.WaitForMetadataVersion != nil {
-		params["wait_for_metadata_version"] = strconv.FormatInt(int64(*r.WaitForMetadataVersion), 10)
+		params["wait_for_metadata_version"] = strconv.FormatInt(*r.WaitForMetadataVersion, 10)
 	}
 
 	if r.WaitForTimeout != 0 {
@@ -242,7 +242,7 @@ func (f ClusterState) WithMetric(v ...string) func(*ClusterStateRequest) {
 	}
 }
 
-// WithAllowNoIndices - whether to ignore if a wildcard indices expression resolves into no concrete indices. (this includes `_all` string or when no indices have been specified).
+// WithAllowNoIndices - whether to allow (1) wildcard index expressions that match no indices and (2) requests where the final resolved set is empty..
 func (f ClusterState) WithAllowNoIndices(v bool) func(*ClusterStateRequest) {
 	return func(r *ClusterStateRequest) {
 		r.AllowNoIndices = &v
@@ -285,7 +285,7 @@ func (f ClusterState) WithMasterTimeout(v time.Duration) func(*ClusterStateReque
 }
 
 // WithWaitForMetadataVersion - wait for the metadata version to be equal or greater than the specified metadata version.
-func (f ClusterState) WithWaitForMetadataVersion(v int) func(*ClusterStateRequest) {
+func (f ClusterState) WithWaitForMetadataVersion(v int64) func(*ClusterStateRequest) {
 	return func(r *ClusterStateRequest) {
 		r.WaitForMetadataVersion = &v
 	}

--- a/esapi/api.count.go
+++ b/esapi/api.count.go
@@ -69,7 +69,7 @@ type CountRequest struct {
 	Preference        string
 	Query             string
 	Routing           []string
-	TerminateAfter    *int
+	TerminateAfter    *int64
 
 	Pretty     bool
 	Human      bool
@@ -169,7 +169,7 @@ func (r CountRequest) Do(providedCtx context.Context, transport Transport) (*Res
 	}
 
 	if r.TerminateAfter != nil {
-		params["terminate_after"] = strconv.FormatInt(int64(*r.TerminateAfter), 10)
+		params["terminate_after"] = strconv.FormatInt(*r.TerminateAfter, 10)
 	}
 
 	if r.Pretty {
@@ -271,7 +271,7 @@ func (f Count) WithIndex(v ...string) func(*CountRequest) {
 	}
 }
 
-// WithAllowNoIndices - whether to ignore if a wildcard indices expression resolves into no concrete indices. (this includes `_all` string or when no indices have been specified).
+// WithAllowNoIndices - whether to allow (1) wildcard index expressions that match no indices and (2) requests where the final resolved set is empty..
 func (f Count) WithAllowNoIndices(v bool) func(*CountRequest) {
 	return func(r *CountRequest) {
 		r.AllowNoIndices = &v
@@ -363,7 +363,7 @@ func (f Count) WithRouting(v ...string) func(*CountRequest) {
 }
 
 // WithTerminateAfter - the maximum count for each shard, upon reaching which the query execution will terminate early.
-func (f Count) WithTerminateAfter(v int) func(*CountRequest) {
+func (f Count) WithTerminateAfter(v int64) func(*CountRequest) {
 	return func(r *CountRequest) {
 		r.TerminateAfter = &v
 	}

--- a/esapi/api.create.go
+++ b/esapi/api.create.go
@@ -64,7 +64,7 @@ type CreateRequest struct {
 	RequireDataStream    *bool
 	Routing              []string
 	Timeout              time.Duration
-	Version              *int
+	Version              *int64
 	VersionType          string
 	WaitForActiveShards  string
 
@@ -145,7 +145,7 @@ func (r CreateRequest) Do(providedCtx context.Context, transport Transport) (*Re
 	}
 
 	if r.Version != nil {
-		params["version"] = strconv.FormatInt(int64(*r.Version), 10)
+		params["version"] = strconv.FormatInt(*r.Version, 10)
 	}
 
 	if r.VersionType != "" {
@@ -291,7 +291,7 @@ func (f Create) WithTimeout(v time.Duration) func(*CreateRequest) {
 }
 
 // WithVersion - explicit version number for concurrency control.
-func (f Create) WithVersion(v int) func(*CreateRequest) {
+func (f Create) WithVersion(v int64) func(*CreateRequest) {
 	return func(r *CreateRequest) {
 		r.Version = &v
 	}

--- a/esapi/api.delete.go
+++ b/esapi/api.delete.go
@@ -54,12 +54,12 @@ type DeleteRequest struct {
 	Index      string
 	DocumentID string
 
-	IfPrimaryTerm       *int
-	IfSeqNo             *int
+	IfPrimaryTerm       *int64
+	IfSeqNo             *int64
 	Refresh             string
 	Routing             []string
 	Timeout             time.Duration
-	Version             *int
+	Version             *int64
 	VersionType         string
 	WaitForActiveShards string
 
@@ -112,11 +112,11 @@ func (r DeleteRequest) Do(providedCtx context.Context, transport Transport) (*Re
 	params = make(map[string]string)
 
 	if r.IfPrimaryTerm != nil {
-		params["if_primary_term"] = strconv.FormatInt(int64(*r.IfPrimaryTerm), 10)
+		params["if_primary_term"] = strconv.FormatInt(*r.IfPrimaryTerm, 10)
 	}
 
 	if r.IfSeqNo != nil {
-		params["if_seq_no"] = strconv.FormatInt(int64(*r.IfSeqNo), 10)
+		params["if_seq_no"] = strconv.FormatInt(*r.IfSeqNo, 10)
 	}
 
 	if r.Refresh != "" {
@@ -132,7 +132,7 @@ func (r DeleteRequest) Do(providedCtx context.Context, transport Transport) (*Re
 	}
 
 	if r.Version != nil {
-		params["version"] = strconv.FormatInt(int64(*r.Version), 10)
+		params["version"] = strconv.FormatInt(*r.Version, 10)
 	}
 
 	if r.VersionType != "" {
@@ -222,14 +222,14 @@ func (f Delete) WithContext(v context.Context) func(*DeleteRequest) {
 }
 
 // WithIfPrimaryTerm - only perform the delete operation if the last operation that has changed the document has the specified primary term.
-func (f Delete) WithIfPrimaryTerm(v int) func(*DeleteRequest) {
+func (f Delete) WithIfPrimaryTerm(v int64) func(*DeleteRequest) {
 	return func(r *DeleteRequest) {
 		r.IfPrimaryTerm = &v
 	}
 }
 
 // WithIfSeqNo - only perform the delete operation if the last operation that has changed the document has the specified sequence number.
-func (f Delete) WithIfSeqNo(v int) func(*DeleteRequest) {
+func (f Delete) WithIfSeqNo(v int64) func(*DeleteRequest) {
 	return func(r *DeleteRequest) {
 		r.IfSeqNo = &v
 	}
@@ -257,7 +257,7 @@ func (f Delete) WithTimeout(v time.Duration) func(*DeleteRequest) {
 }
 
 // WithVersion - explicit version number for concurrency control.
-func (f Delete) WithVersion(v int) func(*DeleteRequest) {
+func (f Delete) WithVersion(v int64) func(*DeleteRequest) {
 	return func(r *DeleteRequest) {
 		r.Version = &v
 	}

--- a/esapi/api.delete_by_query.go
+++ b/esapi/api.delete_by_query.go
@@ -65,10 +65,10 @@ type DeleteByQueryRequest struct {
 	DefaultOperator     string
 	Df                  string
 	ExpandWildcards     []string
-	From                *int
+	From                *int64
 	IgnoreUnavailable   *bool
 	Lenient             *bool
-	MaxDocs             *int
+	MaxDocs             *int64
 	Preference          string
 	Query               string
 	Refresh             *bool
@@ -76,13 +76,13 @@ type DeleteByQueryRequest struct {
 	RequestsPerSecond   *int
 	Routing             []string
 	Scroll              time.Duration
-	ScrollSize          *int
+	ScrollSize          *int64
 	SearchTimeout       time.Duration
 	SearchType          string
 	Slices              interface{}
 	Sort                []string
 	Stats               []string
-	TerminateAfter      *int
+	TerminateAfter      *int64
 	Timeout             time.Duration
 	Version             *bool
 	WaitForActiveShards string
@@ -164,7 +164,7 @@ func (r DeleteByQueryRequest) Do(providedCtx context.Context, transport Transpor
 	}
 
 	if r.From != nil {
-		params["from"] = strconv.FormatInt(int64(*r.From), 10)
+		params["from"] = strconv.FormatInt(*r.From, 10)
 	}
 
 	if r.IgnoreUnavailable != nil {
@@ -176,7 +176,7 @@ func (r DeleteByQueryRequest) Do(providedCtx context.Context, transport Transpor
 	}
 
 	if r.MaxDocs != nil {
-		params["max_docs"] = strconv.FormatInt(int64(*r.MaxDocs), 10)
+		params["max_docs"] = strconv.FormatInt(*r.MaxDocs, 10)
 	}
 
 	if r.Preference != "" {
@@ -208,7 +208,7 @@ func (r DeleteByQueryRequest) Do(providedCtx context.Context, transport Transpor
 	}
 
 	if r.ScrollSize != nil {
-		params["scroll_size"] = strconv.FormatInt(int64(*r.ScrollSize), 10)
+		params["scroll_size"] = strconv.FormatInt(*r.ScrollSize, 10)
 	}
 
 	if r.SearchTimeout != 0 {
@@ -232,7 +232,7 @@ func (r DeleteByQueryRequest) Do(providedCtx context.Context, transport Transpor
 	}
 
 	if r.TerminateAfter != nil {
-		params["terminate_after"] = strconv.FormatInt(int64(*r.TerminateAfter), 10)
+		params["terminate_after"] = strconv.FormatInt(*r.TerminateAfter, 10)
 	}
 
 	if r.Timeout != 0 {
@@ -336,7 +336,7 @@ func (f DeleteByQuery) WithContext(v context.Context) func(*DeleteByQueryRequest
 	}
 }
 
-// WithAllowNoIndices - whether to ignore if a wildcard indices expression resolves into no concrete indices. (this includes `_all` string or when no indices have been specified).
+// WithAllowNoIndices - whether to allow (1) wildcard index expressions that match no indices and (2) requests where the final resolved set is empty..
 func (f DeleteByQuery) WithAllowNoIndices(v bool) func(*DeleteByQueryRequest) {
 	return func(r *DeleteByQueryRequest) {
 		r.AllowNoIndices = &v
@@ -386,7 +386,7 @@ func (f DeleteByQuery) WithExpandWildcards(v ...string) func(*DeleteByQueryReque
 }
 
 // WithFrom - starting offset (default: 0).
-func (f DeleteByQuery) WithFrom(v int) func(*DeleteByQueryRequest) {
+func (f DeleteByQuery) WithFrom(v int64) func(*DeleteByQueryRequest) {
 	return func(r *DeleteByQueryRequest) {
 		r.From = &v
 	}
@@ -407,7 +407,7 @@ func (f DeleteByQuery) WithLenient(v bool) func(*DeleteByQueryRequest) {
 }
 
 // WithMaxDocs - maximum number of documents to process (default: all documents).
-func (f DeleteByQuery) WithMaxDocs(v int) func(*DeleteByQueryRequest) {
+func (f DeleteByQuery) WithMaxDocs(v int64) func(*DeleteByQueryRequest) {
 	return func(r *DeleteByQueryRequest) {
 		r.MaxDocs = &v
 	}
@@ -463,7 +463,7 @@ func (f DeleteByQuery) WithScroll(v time.Duration) func(*DeleteByQueryRequest) {
 }
 
 // WithScrollSize - size on the scroll request powering the delete by query.
-func (f DeleteByQuery) WithScrollSize(v int) func(*DeleteByQueryRequest) {
+func (f DeleteByQuery) WithScrollSize(v int64) func(*DeleteByQueryRequest) {
 	return func(r *DeleteByQueryRequest) {
 		r.ScrollSize = &v
 	}
@@ -505,7 +505,7 @@ func (f DeleteByQuery) WithStats(v ...string) func(*DeleteByQueryRequest) {
 }
 
 // WithTerminateAfter - the maximum number of documents to collect for each shard, upon reaching which the query execution will terminate early..
-func (f DeleteByQuery) WithTerminateAfter(v int) func(*DeleteByQueryRequest) {
+func (f DeleteByQuery) WithTerminateAfter(v int64) func(*DeleteByQueryRequest) {
 	return func(r *DeleteByQueryRequest) {
 		r.TerminateAfter = &v
 	}

--- a/esapi/api.exists.go
+++ b/esapi/api.exists.go
@@ -61,7 +61,7 @@ type ExistsRequest struct {
 	SourceExcludes []string
 	SourceIncludes []string
 	StoredFields   []string
-	Version        *int
+	Version        *int64
 	VersionType    string
 
 	Pretty     bool
@@ -145,7 +145,7 @@ func (r ExistsRequest) Do(providedCtx context.Context, transport Transport) (*Re
 	}
 
 	if r.Version != nil {
-		params["version"] = strconv.FormatInt(int64(*r.Version), 10)
+		params["version"] = strconv.FormatInt(*r.Version, 10)
 	}
 
 	if r.VersionType != "" {
@@ -287,7 +287,7 @@ func (f Exists) WithStoredFields(v ...string) func(*ExistsRequest) {
 }
 
 // WithVersion - explicit version number for concurrency control.
-func (f Exists) WithVersion(v int) func(*ExistsRequest) {
+func (f Exists) WithVersion(v int64) func(*ExistsRequest) {
 	return func(r *ExistsRequest) {
 		r.Version = &v
 	}

--- a/esapi/api.exists_source.go
+++ b/esapi/api.exists_source.go
@@ -60,7 +60,7 @@ type ExistsSourceRequest struct {
 	Source         []string
 	SourceExcludes []string
 	SourceIncludes []string
-	Version        *int
+	Version        *int64
 	VersionType    string
 
 	Pretty     bool
@@ -140,7 +140,7 @@ func (r ExistsSourceRequest) Do(providedCtx context.Context, transport Transport
 	}
 
 	if r.Version != nil {
-		params["version"] = strconv.FormatInt(int64(*r.Version), 10)
+		params["version"] = strconv.FormatInt(*r.Version, 10)
 	}
 
 	if r.VersionType != "" {
@@ -275,7 +275,7 @@ func (f ExistsSource) WithSourceIncludes(v ...string) func(*ExistsSourceRequest)
 }
 
 // WithVersion - explicit version number for concurrency control.
-func (f ExistsSource) WithVersion(v int) func(*ExistsSourceRequest) {
+func (f ExistsSource) WithVersion(v int64) func(*ExistsSourceRequest) {
 	return func(r *ExistsSourceRequest) {
 		r.Version = &v
 	}

--- a/esapi/api.field_caps.go
+++ b/esapi/api.field_caps.go
@@ -240,7 +240,7 @@ func (f FieldCaps) WithIndex(v ...string) func(*FieldCapsRequest) {
 	}
 }
 
-// WithAllowNoIndices - whether to ignore if a wildcard indices expression resolves into no concrete indices. (this includes `_all` string or when no indices have been specified).
+// WithAllowNoIndices - whether to allow (1) wildcard index expressions that match no indices and (2) requests where the final resolved set is empty..
 func (f FieldCaps) WithAllowNoIndices(v bool) func(*FieldCapsRequest) {
 	return func(r *FieldCapsRequest) {
 		r.AllowNoIndices = &v

--- a/esapi/api.get.go
+++ b/esapi/api.get.go
@@ -63,7 +63,7 @@ type GetRequest struct {
 	SourceExcludes       []string
 	SourceIncludes       []string
 	StoredFields         []string
-	Version              *int
+	Version              *int64
 	VersionType          string
 
 	Pretty     bool
@@ -155,7 +155,7 @@ func (r GetRequest) Do(providedCtx context.Context, transport Transport) (*Respo
 	}
 
 	if r.Version != nil {
-		params["version"] = strconv.FormatInt(int64(*r.Version), 10)
+		params["version"] = strconv.FormatInt(*r.Version, 10)
 	}
 
 	if r.VersionType != "" {
@@ -311,7 +311,7 @@ func (f Get) WithStoredFields(v ...string) func(*GetRequest) {
 }
 
 // WithVersion - explicit version number for concurrency control.
-func (f Get) WithVersion(v int) func(*GetRequest) {
+func (f Get) WithVersion(v int64) func(*GetRequest) {
 	return func(r *GetRequest) {
 		r.Version = &v
 	}

--- a/esapi/api.get_source.go
+++ b/esapi/api.get_source.go
@@ -60,7 +60,7 @@ type GetSourceRequest struct {
 	Source         []string
 	SourceExcludes []string
 	SourceIncludes []string
-	Version        *int
+	Version        *int64
 	VersionType    string
 
 	Pretty     bool
@@ -140,7 +140,7 @@ func (r GetSourceRequest) Do(providedCtx context.Context, transport Transport) (
 	}
 
 	if r.Version != nil {
-		params["version"] = strconv.FormatInt(int64(*r.Version), 10)
+		params["version"] = strconv.FormatInt(*r.Version, 10)
 	}
 
 	if r.VersionType != "" {
@@ -275,7 +275,7 @@ func (f GetSource) WithSourceIncludes(v ...string) func(*GetSourceRequest) {
 }
 
 // WithVersion - explicit version number for concurrency control.
-func (f GetSource) WithVersion(v int) func(*GetSourceRequest) {
+func (f GetSource) WithVersion(v int64) func(*GetSourceRequest) {
 	return func(r *GetSourceRequest) {
 		r.Version = &v
 	}

--- a/esapi/api.index.go
+++ b/esapi/api.index.go
@@ -57,8 +57,8 @@ type IndexRequest struct {
 
 	Body io.Reader
 
-	IfPrimaryTerm        *int
-	IfSeqNo              *int
+	IfPrimaryTerm        *int64
+	IfSeqNo              *int64
 	IncludeSourceOnError *bool
 	OpType               string
 	Pipeline             string
@@ -67,7 +67,7 @@ type IndexRequest struct {
 	RequireDataStream    *bool
 	Routing              []string
 	Timeout              time.Duration
-	Version              *int
+	Version              *int64
 	VersionType          string
 	WaitForActiveShards  string
 
@@ -126,11 +126,11 @@ func (r IndexRequest) Do(providedCtx context.Context, transport Transport) (*Res
 	params = make(map[string]string)
 
 	if r.IfPrimaryTerm != nil {
-		params["if_primary_term"] = strconv.FormatInt(int64(*r.IfPrimaryTerm), 10)
+		params["if_primary_term"] = strconv.FormatInt(*r.IfPrimaryTerm, 10)
 	}
 
 	if r.IfSeqNo != nil {
-		params["if_seq_no"] = strconv.FormatInt(int64(*r.IfSeqNo), 10)
+		params["if_seq_no"] = strconv.FormatInt(*r.IfSeqNo, 10)
 	}
 
 	if r.IncludeSourceOnError != nil {
@@ -166,7 +166,7 @@ func (r IndexRequest) Do(providedCtx context.Context, transport Transport) (*Res
 	}
 
 	if r.Version != nil {
-		params["version"] = strconv.FormatInt(int64(*r.Version), 10)
+		params["version"] = strconv.FormatInt(*r.Version, 10)
 	}
 
 	if r.VersionType != "" {
@@ -270,14 +270,14 @@ func (f Index) WithDocumentID(v string) func(*IndexRequest) {
 }
 
 // WithIfPrimaryTerm - only perform the index operation if the last operation that has changed the document has the specified primary term.
-func (f Index) WithIfPrimaryTerm(v int) func(*IndexRequest) {
+func (f Index) WithIfPrimaryTerm(v int64) func(*IndexRequest) {
 	return func(r *IndexRequest) {
 		r.IfPrimaryTerm = &v
 	}
 }
 
 // WithIfSeqNo - only perform the index operation if the last operation that has changed the document has the specified sequence number.
-func (f Index) WithIfSeqNo(v int) func(*IndexRequest) {
+func (f Index) WithIfSeqNo(v int64) func(*IndexRequest) {
 	return func(r *IndexRequest) {
 		r.IfSeqNo = &v
 	}
@@ -340,7 +340,7 @@ func (f Index) WithTimeout(v time.Duration) func(*IndexRequest) {
 }
 
 // WithVersion - explicit version number for concurrency control.
-func (f Index) WithVersion(v int) func(*IndexRequest) {
+func (f Index) WithVersion(v int64) func(*IndexRequest) {
 	return func(r *IndexRequest) {
 		r.Version = &v
 	}

--- a/esapi/api.indices.add_block.go
+++ b/esapi/api.indices.add_block.go
@@ -212,7 +212,7 @@ func (f IndicesAddBlock) WithContext(v context.Context) func(*IndicesAddBlockReq
 	}
 }
 
-// WithAllowNoIndices - whether to ignore if a wildcard indices expression resolves into no concrete indices. (this includes `_all` string or when no indices have been specified).
+// WithAllowNoIndices - whether to allow (1) wildcard index expressions that match no indices and (2) requests where the final resolved set is empty..
 func (f IndicesAddBlock) WithAllowNoIndices(v bool) func(*IndicesAddBlockRequest) {
 	return func(r *IndicesAddBlockRequest) {
 		r.AllowNoIndices = &v

--- a/esapi/api.indices.clear_cache.go
+++ b/esapi/api.indices.clear_cache.go
@@ -224,7 +224,7 @@ func (f IndicesClearCache) WithIndex(v ...string) func(*IndicesClearCacheRequest
 	}
 }
 
-// WithAllowNoIndices - whether to ignore if a wildcard indices expression resolves into no concrete indices. (this includes `_all` string or when no indices have been specified).
+// WithAllowNoIndices - whether to allow (1) wildcard index expressions that match no indices and (2) requests where the final resolved set is empty..
 func (f IndicesClearCache) WithAllowNoIndices(v bool) func(*IndicesClearCacheRequest) {
 	return func(r *IndicesClearCacheRequest) {
 		r.AllowNoIndices = &v

--- a/esapi/api.indices.close.go
+++ b/esapi/api.indices.close.go
@@ -210,7 +210,7 @@ func (f IndicesClose) WithContext(v context.Context) func(*IndicesCloseRequest) 
 	}
 }
 
-// WithAllowNoIndices - whether to ignore if a wildcard indices expression resolves into no concrete indices. (this includes `_all` string or when no indices have been specified).
+// WithAllowNoIndices - whether to allow (1) wildcard index expressions that match no indices and (2) requests where the final resolved set is empty..
 func (f IndicesClose) WithAllowNoIndices(v bool) func(*IndicesCloseRequest) {
 	return func(r *IndicesCloseRequest) {
 		r.AllowNoIndices = &v

--- a/esapi/api.indices.delete.go
+++ b/esapi/api.indices.delete.go
@@ -203,7 +203,7 @@ func (f IndicesDelete) WithContext(v context.Context) func(*IndicesDeleteRequest
 	}
 }
 
-// WithAllowNoIndices - ignore if a wildcard expression resolves to no concrete indices (default: false).
+// WithAllowNoIndices - whether to allow (1) wildcard index expressions that match no indices and (2) requests where the final resolved set is empty..
 func (f IndicesDelete) WithAllowNoIndices(v bool) func(*IndicesDeleteRequest) {
 	return func(r *IndicesDeleteRequest) {
 		r.AllowNoIndices = &v

--- a/esapi/api.indices.disk_usage.go
+++ b/esapi/api.indices.disk_usage.go
@@ -206,7 +206,7 @@ func (f IndicesDiskUsage) WithContext(v context.Context) func(*IndicesDiskUsageR
 	}
 }
 
-// WithAllowNoIndices - whether to ignore if a wildcard indices expression resolves into no concrete indices. (this includes `_all` string or when no indices have been specified).
+// WithAllowNoIndices - whether to allow (1) wildcard index expressions that match no indices and (2) requests where the final resolved set is empty..
 func (f IndicesDiskUsage) WithAllowNoIndices(v bool) func(*IndicesDiskUsageRequest) {
 	return func(r *IndicesDiskUsageRequest) {
 		r.AllowNoIndices = &v

--- a/esapi/api.indices.exists.go
+++ b/esapi/api.indices.exists.go
@@ -207,7 +207,7 @@ func (f IndicesExists) WithContext(v context.Context) func(*IndicesExistsRequest
 	}
 }
 
-// WithAllowNoIndices - ignore if a wildcard expression resolves to no concrete indices (default: false).
+// WithAllowNoIndices - whether to allow (1) wildcard index expressions that match no indices and (2) requests where the final resolved set is empty..
 func (f IndicesExists) WithAllowNoIndices(v bool) func(*IndicesExistsRequest) {
 	return func(r *IndicesExistsRequest) {
 		r.AllowNoIndices = &v

--- a/esapi/api.indices.exists_alias.go
+++ b/esapi/api.indices.exists_alias.go
@@ -216,7 +216,7 @@ func (f IndicesExistsAlias) WithIndex(v ...string) func(*IndicesExistsAliasReque
 	}
 }
 
-// WithAllowNoIndices - whether to ignore if a wildcard indices expression resolves into no concrete indices. (this includes `_all` string or when no indices have been specified).
+// WithAllowNoIndices - whether to allow (1) wildcard index expressions that match no indices and (2) requests where the final resolved set is empty..
 func (f IndicesExistsAlias) WithAllowNoIndices(v bool) func(*IndicesExistsAliasRequest) {
 	return func(r *IndicesExistsAliasRequest) {
 		r.AllowNoIndices = &v

--- a/esapi/api.indices.field_usage_stats.go
+++ b/esapi/api.indices.field_usage_stats.go
@@ -201,7 +201,7 @@ func (f IndicesFieldUsageStats) WithContext(v context.Context) func(*IndicesFiel
 	}
 }
 
-// WithAllowNoIndices - whether to ignore if a wildcard indices expression resolves into no concrete indices. (this includes `_all` string or when no indices have been specified).
+// WithAllowNoIndices - whether to allow (1) wildcard index expressions that match no indices and (2) requests where the final resolved set is empty..
 func (f IndicesFieldUsageStats) WithAllowNoIndices(v bool) func(*IndicesFieldUsageStatsRequest) {
 	return func(r *IndicesFieldUsageStatsRequest) {
 		r.AllowNoIndices = &v

--- a/esapi/api.indices.flush.go
+++ b/esapi/api.indices.flush.go
@@ -208,7 +208,7 @@ func (f IndicesFlush) WithIndex(v ...string) func(*IndicesFlushRequest) {
 	}
 }
 
-// WithAllowNoIndices - whether to ignore if a wildcard indices expression resolves into no concrete indices. (this includes `_all` string or when no indices have been specified).
+// WithAllowNoIndices - whether to allow (1) wildcard index expressions that match no indices and (2) requests where the final resolved set is empty..
 func (f IndicesFlush) WithAllowNoIndices(v bool) func(*IndicesFlushRequest) {
 	return func(r *IndicesFlushRequest) {
 		r.AllowNoIndices = &v

--- a/esapi/api.indices.forcemerge.go
+++ b/esapi/api.indices.forcemerge.go
@@ -56,7 +56,7 @@ type IndicesForcemergeRequest struct {
 	ExpandWildcards    []string
 	Flush              *bool
 	IgnoreUnavailable  *bool
-	MaxNumSegments     *int
+	MaxNumSegments     *int64
 	OnlyExpungeDeletes *bool
 	WaitForCompletion  *bool
 
@@ -122,7 +122,7 @@ func (r IndicesForcemergeRequest) Do(providedCtx context.Context, transport Tran
 	}
 
 	if r.MaxNumSegments != nil {
-		params["max_num_segments"] = strconv.FormatInt(int64(*r.MaxNumSegments), 10)
+		params["max_num_segments"] = strconv.FormatInt(*r.MaxNumSegments, 10)
 	}
 
 	if r.OnlyExpungeDeletes != nil {
@@ -218,7 +218,7 @@ func (f IndicesForcemerge) WithIndex(v ...string) func(*IndicesForcemergeRequest
 	}
 }
 
-// WithAllowNoIndices - whether to ignore if a wildcard indices expression resolves into no concrete indices. (this includes `_all` string or when no indices have been specified).
+// WithAllowNoIndices - whether to allow (1) wildcard index expressions that match no indices and (2) requests where the final resolved set is empty..
 func (f IndicesForcemerge) WithAllowNoIndices(v bool) func(*IndicesForcemergeRequest) {
 	return func(r *IndicesForcemergeRequest) {
 		r.AllowNoIndices = &v
@@ -247,7 +247,7 @@ func (f IndicesForcemerge) WithIgnoreUnavailable(v bool) func(*IndicesForcemerge
 }
 
 // WithMaxNumSegments - the number of segments the index should be merged into (default: dynamic).
-func (f IndicesForcemerge) WithMaxNumSegments(v int) func(*IndicesForcemergeRequest) {
+func (f IndicesForcemerge) WithMaxNumSegments(v int64) func(*IndicesForcemergeRequest) {
 	return func(r *IndicesForcemergeRequest) {
 		r.MaxNumSegments = &v
 	}

--- a/esapi/api.indices.get.go
+++ b/esapi/api.indices.get.go
@@ -218,7 +218,7 @@ func (f IndicesGet) WithContext(v context.Context) func(*IndicesGetRequest) {
 	}
 }
 
-// WithAllowNoIndices - ignore if a wildcard expression resolves to no concrete indices (default: false).
+// WithAllowNoIndices - whether to allow (1) wildcard index expressions that match no indices and (2) requests where the final resolved set is empty..
 func (f IndicesGet) WithAllowNoIndices(v bool) func(*IndicesGetRequest) {
 	return func(r *IndicesGetRequest) {
 		r.AllowNoIndices = &v

--- a/esapi/api.indices.get_alias.go
+++ b/esapi/api.indices.get_alias.go
@@ -220,7 +220,7 @@ func (f IndicesGetAlias) WithName(v ...string) func(*IndicesGetAliasRequest) {
 	}
 }
 
-// WithAllowNoIndices - whether to ignore if a wildcard indices expression resolves into no concrete indices. (this includes `_all` string or when no indices have been specified).
+// WithAllowNoIndices - whether to allow (1) wildcard index expressions that match no indices and (2) requests where the final resolved set is empty..
 func (f IndicesGetAlias) WithAllowNoIndices(v bool) func(*IndicesGetAliasRequest) {
 	return func(r *IndicesGetAliasRequest) {
 		r.AllowNoIndices = &v

--- a/esapi/api.indices.get_field_mapping.go
+++ b/esapi/api.indices.get_field_mapping.go
@@ -217,7 +217,7 @@ func (f IndicesGetFieldMapping) WithIndex(v ...string) func(*IndicesGetFieldMapp
 	}
 }
 
-// WithAllowNoIndices - whether to ignore if a wildcard indices expression resolves into no concrete indices. (this includes `_all` string or when no indices have been specified).
+// WithAllowNoIndices - whether to allow (1) wildcard index expressions that match no indices and (2) requests where the final resolved set is empty..
 func (f IndicesGetFieldMapping) WithAllowNoIndices(v bool) func(*IndicesGetFieldMappingRequest) {
 	return func(r *IndicesGetFieldMappingRequest) {
 		r.AllowNoIndices = &v

--- a/esapi/api.indices.get_mapping.go
+++ b/esapi/api.indices.get_mapping.go
@@ -209,7 +209,7 @@ func (f IndicesGetMapping) WithIndex(v ...string) func(*IndicesGetMappingRequest
 	}
 }
 
-// WithAllowNoIndices - whether to ignore if a wildcard indices expression resolves into no concrete indices. (this includes `_all` string or when no indices have been specified).
+// WithAllowNoIndices - whether to allow (1) wildcard index expressions that match no indices and (2) requests where the final resolved set is empty..
 func (f IndicesGetMapping) WithAllowNoIndices(v bool) func(*IndicesGetMappingRequest) {
 	return func(r *IndicesGetMappingRequest) {
 		r.AllowNoIndices = &v

--- a/esapi/api.indices.get_settings.go
+++ b/esapi/api.indices.get_settings.go
@@ -235,7 +235,7 @@ func (f IndicesGetSettings) WithName(v ...string) func(*IndicesGetSettingsReques
 	}
 }
 
-// WithAllowNoIndices - whether to ignore if a wildcard indices expression resolves into no concrete indices. (this includes `_all` string or when no indices have been specified).
+// WithAllowNoIndices - whether to allow (1) wildcard index expressions that match no indices and (2) requests where the final resolved set is empty..
 func (f IndicesGetSettings) WithAllowNoIndices(v bool) func(*IndicesGetSettingsRequest) {
 	return func(r *IndicesGetSettingsRequest) {
 		r.AllowNoIndices = &v

--- a/esapi/api.indices.open.go
+++ b/esapi/api.indices.open.go
@@ -210,7 +210,7 @@ func (f IndicesOpen) WithContext(v context.Context) func(*IndicesOpenRequest) {
 	}
 }
 
-// WithAllowNoIndices - whether to ignore if a wildcard indices expression resolves into no concrete indices. (this includes `_all` string or when no indices have been specified).
+// WithAllowNoIndices - whether to allow (1) wildcard index expressions that match no indices and (2) requests where the final resolved set is empty..
 func (f IndicesOpen) WithAllowNoIndices(v bool) func(*IndicesOpenRequest) {
 	return func(r *IndicesOpenRequest) {
 		r.AllowNoIndices = &v

--- a/esapi/api.indices.put_mapping.go
+++ b/esapi/api.indices.put_mapping.go
@@ -213,7 +213,7 @@ func (f IndicesPutMapping) WithContext(v context.Context) func(*IndicesPutMappin
 	}
 }
 
-// WithAllowNoIndices - whether to ignore if a wildcard indices expression resolves into no concrete indices. (this includes `_all` string or when no indices have been specified).
+// WithAllowNoIndices - whether to allow (1) wildcard index expressions that match no indices and (2) requests where the final resolved set is empty..
 func (f IndicesPutMapping) WithAllowNoIndices(v bool) func(*IndicesPutMappingRequest) {
 	return func(r *IndicesPutMappingRequest) {
 		r.AllowNoIndices = &v

--- a/esapi/api.indices.put_settings.go
+++ b/esapi/api.indices.put_settings.go
@@ -234,7 +234,7 @@ func (f IndicesPutSettings) WithIndex(v ...string) func(*IndicesPutSettingsReque
 	}
 }
 
-// WithAllowNoIndices - whether to ignore if a wildcard indices expression resolves into no concrete indices. (this includes `_all` string or when no indices have been specified).
+// WithAllowNoIndices - whether to allow (1) wildcard index expressions that match no indices and (2) requests where the final resolved set is empty..
 func (f IndicesPutSettings) WithAllowNoIndices(v bool) func(*IndicesPutSettingsRequest) {
 	return func(r *IndicesPutSettingsRequest) {
 		r.AllowNoIndices = &v

--- a/esapi/api.indices.recovery.go
+++ b/esapi/api.indices.recovery.go
@@ -215,7 +215,7 @@ func (f IndicesRecovery) WithActiveOnly(v bool) func(*IndicesRecoveryRequest) {
 	}
 }
 
-// WithAllowNoIndices - whether to ignore if a wildcard indices expression resolves into no concrete indices. (this includes `_all` string or when no indices have been specified).
+// WithAllowNoIndices - whether to allow (1) wildcard index expressions that match no indices and (2) requests where the final resolved set is empty..
 func (f IndicesRecovery) WithAllowNoIndices(v bool) func(*IndicesRecoveryRequest) {
 	return func(r *IndicesRecoveryRequest) {
 		r.AllowNoIndices = &v

--- a/esapi/api.indices.refresh.go
+++ b/esapi/api.indices.refresh.go
@@ -198,7 +198,7 @@ func (f IndicesRefresh) WithIndex(v ...string) func(*IndicesRefreshRequest) {
 	}
 }
 
-// WithAllowNoIndices - whether to ignore if a wildcard indices expression resolves into no concrete indices. (this includes `_all` string or when no indices have been specified).
+// WithAllowNoIndices - whether to allow (1) wildcard index expressions that match no indices and (2) requests where the final resolved set is empty..
 func (f IndicesRefresh) WithAllowNoIndices(v bool) func(*IndicesRefreshRequest) {
 	return func(r *IndicesRefreshRequest) {
 		r.AllowNoIndices = &v

--- a/esapi/api.indices.remove_block.go
+++ b/esapi/api.indices.remove_block.go
@@ -212,7 +212,7 @@ func (f IndicesRemoveBlock) WithContext(v context.Context) func(*IndicesRemoveBl
 	}
 }
 
-// WithAllowNoIndices - whether to ignore if a wildcard indices expression resolves into no concrete indices. (this includes `_all` string or when no indices have been specified).
+// WithAllowNoIndices - whether to allow (1) wildcard index expressions that match no indices and (2) requests where the final resolved set is empty..
 func (f IndicesRemoveBlock) WithAllowNoIndices(v bool) func(*IndicesRemoveBlockRequest) {
 	return func(r *IndicesRemoveBlockRequest) {
 		r.AllowNoIndices = &v

--- a/esapi/api.indices.resolve_cluster.go
+++ b/esapi/api.indices.resolve_cluster.go
@@ -211,7 +211,7 @@ func (f IndicesResolveCluster) WithName(v ...string) func(*IndicesResolveCluster
 	}
 }
 
-// WithAllowNoIndices - whether to ignore if a wildcard indices expression resolves into no concrete indices. (this includes `_all` string or when no indices have been specified). only allowed when providing an index expression..
+// WithAllowNoIndices - whether to allow (1) wildcard index expressions that match no indices and (2) requests where the final resolved set is empty. only allowed when providing an index expression..
 func (f IndicesResolveCluster) WithAllowNoIndices(v bool) func(*IndicesResolveClusterRequest) {
 	return func(r *IndicesResolveClusterRequest) {
 		r.AllowNoIndices = &v

--- a/esapi/api.indices.resolve_index.go
+++ b/esapi/api.indices.resolve_index.go
@@ -201,7 +201,7 @@ func (f IndicesResolveIndex) WithContext(v context.Context) func(*IndicesResolve
 	}
 }
 
-// WithAllowNoIndices - whether to ignore if a wildcard indices expression resolves into no concrete indices. (this includes `_all` string or when no indices have been specified).
+// WithAllowNoIndices - whether to allow (1) wildcard index expressions that match no indices and (2) requests where the final resolved set is empty..
 func (f IndicesResolveIndex) WithAllowNoIndices(v bool) func(*IndicesResolveIndexRequest) {
 	return func(r *IndicesResolveIndexRequest) {
 		r.AllowNoIndices = &v

--- a/esapi/api.indices.segments.go
+++ b/esapi/api.indices.segments.go
@@ -198,7 +198,7 @@ func (f IndicesSegments) WithIndex(v ...string) func(*IndicesSegmentsRequest) {
 	}
 }
 
-// WithAllowNoIndices - whether to ignore if a wildcard indices expression resolves into no concrete indices. (this includes `_all` string or when no indices have been specified).
+// WithAllowNoIndices - whether to allow (1) wildcard index expressions that match no indices and (2) requests where the final resolved set is empty..
 func (f IndicesSegments) WithAllowNoIndices(v bool) func(*IndicesSegmentsRequest) {
 	return func(r *IndicesSegmentsRequest) {
 		r.AllowNoIndices = &v

--- a/esapi/api.indices.shard_stores.go
+++ b/esapi/api.indices.shard_stores.go
@@ -203,7 +203,7 @@ func (f IndicesShardStores) WithIndex(v ...string) func(*IndicesShardStoresReque
 	}
 }
 
-// WithAllowNoIndices - whether to ignore if a wildcard indices expression resolves into no concrete indices. (this includes `_all` string or when no indices have been specified).
+// WithAllowNoIndices - whether to allow (1) wildcard index expressions that match no indices and (2) requests where the final resolved set is empty..
 func (f IndicesShardStores) WithAllowNoIndices(v bool) func(*IndicesShardStoresRequest) {
 	return func(r *IndicesShardStoresRequest) {
 		r.AllowNoIndices = &v

--- a/esapi/api.indices.validate_query.go
+++ b/esapi/api.indices.validate_query.go
@@ -262,7 +262,7 @@ func (f IndicesValidateQuery) WithIndex(v ...string) func(*IndicesValidateQueryR
 	}
 }
 
-// WithAllowNoIndices - whether to ignore if a wildcard indices expression resolves into no concrete indices. (this includes `_all` string or when no indices have been specified).
+// WithAllowNoIndices - whether to allow (1) wildcard index expressions that match no indices and (2) requests where the final resolved set is empty..
 func (f IndicesValidateQuery) WithAllowNoIndices(v bool) func(*IndicesValidateQueryRequest) {
 	return func(r *IndicesValidateQueryRequest) {
 		r.AllowNoIndices = &v

--- a/esapi/api.msearch.go
+++ b/esapi/api.msearch.go
@@ -63,7 +63,7 @@ type MsearchRequest struct {
 	IncludeNamedQueriesScore   *bool
 	MaxConcurrentSearches      *int
 	MaxConcurrentShardRequests *int
-	PreFilterShardSize         *int
+	PreFilterShardSize         *int64
 	ProjectRouting             string
 	RestTotalHitsAsInt         *bool
 	Routing                    []string
@@ -152,7 +152,7 @@ func (r MsearchRequest) Do(providedCtx context.Context, transport Transport) (*R
 	}
 
 	if r.PreFilterShardSize != nil {
-		params["pre_filter_shard_size"] = strconv.FormatInt(int64(*r.PreFilterShardSize), 10)
+		params["pre_filter_shard_size"] = strconv.FormatInt(*r.PreFilterShardSize, 10)
 	}
 
 	if r.ProjectRouting != "" {
@@ -267,7 +267,7 @@ func (f Msearch) WithIndex(v ...string) func(*MsearchRequest) {
 	}
 }
 
-// WithAllowNoIndices - whether to ignore if a wildcard indices expression resolves into no concrete indices. (this includes `_all` string or when no indices have been specified).
+// WithAllowNoIndices - whether to allow (1) wildcard index expressions that match no indices and (2) requests where the final resolved set is empty..
 func (f Msearch) WithAllowNoIndices(v bool) func(*MsearchRequest) {
 	return func(r *MsearchRequest) {
 		r.AllowNoIndices = &v
@@ -324,7 +324,7 @@ func (f Msearch) WithMaxConcurrentShardRequests(v int) func(*MsearchRequest) {
 }
 
 // WithPreFilterShardSize - a threshold that enforces a pre-filter roundtrip to prefilter search shards based on query rewriting if the number of shards the search request expands to exceeds the threshold. this filter roundtrip can limit the number of shards significantly if for instance a shard can not match any documents based on its rewrite method ie. if date filters are mandatory to match but the shard bounds and the query are disjoint..
-func (f Msearch) WithPreFilterShardSize(v int) func(*MsearchRequest) {
+func (f Msearch) WithPreFilterShardSize(v int64) func(*MsearchRequest) {
 	return func(r *MsearchRequest) {
 		r.PreFilterShardSize = &v
 	}

--- a/esapi/api.msearch_template.go
+++ b/esapi/api.msearch_template.go
@@ -56,7 +56,7 @@ type MsearchTemplateRequest struct {
 	Body io.Reader
 
 	CcsMinimizeRoundtrips *bool
-	MaxConcurrentSearches *int
+	MaxConcurrentSearches *int64
 	ProjectRouting        string
 	RestTotalHitsAsInt    *bool
 	SearchType            string
@@ -114,7 +114,7 @@ func (r MsearchTemplateRequest) Do(providedCtx context.Context, transport Transp
 	}
 
 	if r.MaxConcurrentSearches != nil {
-		params["max_concurrent_searches"] = strconv.FormatInt(int64(*r.MaxConcurrentSearches), 10)
+		params["max_concurrent_searches"] = strconv.FormatInt(*r.MaxConcurrentSearches, 10)
 	}
 
 	if r.ProjectRouting != "" {
@@ -233,7 +233,7 @@ func (f MsearchTemplate) WithCcsMinimizeRoundtrips(v bool) func(*MsearchTemplate
 }
 
 // WithMaxConcurrentSearches - controls the maximum number of concurrent searches the multi search api will execute.
-func (f MsearchTemplate) WithMaxConcurrentSearches(v int) func(*MsearchTemplateRequest) {
+func (f MsearchTemplate) WithMaxConcurrentSearches(v int64) func(*MsearchTemplateRequest) {
 	return func(r *MsearchTemplateRequest) {
 		r.MaxConcurrentSearches = &v
 	}

--- a/esapi/api.mtermvectors.go
+++ b/esapi/api.mtermvectors.go
@@ -65,7 +65,7 @@ type MtermvectorsRequest struct {
 	Realtime        *bool
 	Routing         []string
 	TermStatistics  *bool
-	Version         *int
+	Version         *int64
 	VersionType     string
 
 	Pretty     bool
@@ -154,7 +154,7 @@ func (r MtermvectorsRequest) Do(providedCtx context.Context, transport Transport
 	}
 
 	if r.Version != nil {
-		params["version"] = strconv.FormatInt(int64(*r.Version), 10)
+		params["version"] = strconv.FormatInt(*r.Version, 10)
 	}
 
 	if r.VersionType != "" {
@@ -331,7 +331,7 @@ func (f Mtermvectors) WithTermStatistics(v bool) func(*MtermvectorsRequest) {
 }
 
 // WithVersion - explicit version number for concurrency control.
-func (f Mtermvectors) WithVersion(v int) func(*MtermvectorsRequest) {
+func (f Mtermvectors) WithVersion(v int64) func(*MtermvectorsRequest) {
 	return func(r *MtermvectorsRequest) {
 		r.Version = &v
 	}

--- a/esapi/api.nodes.clear_repositories_metering_archive.go
+++ b/esapi/api.nodes.clear_repositories_metering_archive.go
@@ -28,7 +28,7 @@ import (
 )
 
 func newNodesClearRepositoriesMeteringArchiveFunc(t Transport) NodesClearRepositoriesMeteringArchive {
-	return func(max_archive_version *int, node_id []string, o ...func(*NodesClearRepositoriesMeteringArchiveRequest)) (*Response, error) {
+	return func(max_archive_version *int64, node_id []string, o ...func(*NodesClearRepositoriesMeteringArchiveRequest)) (*Response, error) {
 		var r = NodesClearRepositoriesMeteringArchiveRequest{MaxArchiveVersion: max_archive_version, NodeID: node_id}
 		for _, f := range o {
 			f(&r)
@@ -49,11 +49,11 @@ func newNodesClearRepositoriesMeteringArchiveFunc(t Transport) NodesClearReposit
 // This API is experimental.
 //
 // See full documentation at https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-nodes-clear-repositories-metering-archive.
-type NodesClearRepositoriesMeteringArchive func(max_archive_version *int, node_id []string, o ...func(*NodesClearRepositoriesMeteringArchiveRequest)) (*Response, error)
+type NodesClearRepositoriesMeteringArchive func(max_archive_version *int64, node_id []string, o ...func(*NodesClearRepositoriesMeteringArchiveRequest)) (*Response, error)
 
 // NodesClearRepositoriesMeteringArchiveRequest configures the Nodes Clear Repositories Metering Archive API request.
 type NodesClearRepositoriesMeteringArchiveRequest struct {
-	MaxArchiveVersion *int
+	MaxArchiveVersion *int64
 	NodeID            []string
 
 	Pretty     bool
@@ -94,7 +94,7 @@ func (r NodesClearRepositoriesMeteringArchiveRequest) Do(providedCtx context.Con
 		return nil, errors.New("max_archive_version is required and cannot be nil")
 	}
 
-	path.Grow(7 + 1 + len("_nodes") + 1 + len(strings.Join(r.NodeID, ",")) + 1 + len("_repositories_metering") + 1 + len(strconv.Itoa(*r.MaxArchiveVersion)))
+	path.Grow(7 + 1 + len("_nodes") + 1 + len(strings.Join(r.NodeID, ",")) + 1 + len("_repositories_metering") + 1 + len(strconv.FormatInt(*r.MaxArchiveVersion, 10)))
 	path.WriteString("http://")
 	path.WriteString("/")
 	path.WriteString("_nodes")
@@ -106,9 +106,9 @@ func (r NodesClearRepositoriesMeteringArchiveRequest) Do(providedCtx context.Con
 	path.WriteString("/")
 	path.WriteString("_repositories_metering")
 	path.WriteString("/")
-	path.WriteString(strconv.Itoa(*r.MaxArchiveVersion))
+	path.WriteString(strconv.FormatInt(*r.MaxArchiveVersion, 10))
 	if instrument, ok := r.Instrument.(Instrumentation); ok {
-		instrument.RecordPathPart(ctx, "max_archive_version", strconv.Itoa(*r.MaxArchiveVersion))
+		instrument.RecordPathPart(ctx, "max_archive_version", strconv.FormatInt(*r.MaxArchiveVersion, 10))
 	}
 
 	params = make(map[string]string)

--- a/esapi/api.nodes.hot_threads.go
+++ b/esapi/api.nodes.hot_threads.go
@@ -55,9 +55,9 @@ type NodesHotThreadsRequest struct {
 
 	IgnoreIdleThreads *bool
 	Interval          time.Duration
-	Snapshots         *int
+	Snapshots         *int64
 	Sort              string
-	Threads           *int
+	Threads           *int64
 	Timeout           time.Duration
 	DocumentType      string
 
@@ -117,7 +117,7 @@ func (r NodesHotThreadsRequest) Do(providedCtx context.Context, transport Transp
 	}
 
 	if r.Snapshots != nil {
-		params["snapshots"] = strconv.FormatInt(int64(*r.Snapshots), 10)
+		params["snapshots"] = strconv.FormatInt(*r.Snapshots, 10)
 	}
 
 	if r.Sort != "" {
@@ -125,7 +125,7 @@ func (r NodesHotThreadsRequest) Do(providedCtx context.Context, transport Transp
 	}
 
 	if r.Threads != nil {
-		params["threads"] = strconv.FormatInt(int64(*r.Threads), 10)
+		params["threads"] = strconv.FormatInt(*r.Threads, 10)
 	}
 
 	if r.Timeout != 0 {
@@ -236,7 +236,7 @@ func (f NodesHotThreads) WithInterval(v time.Duration) func(*NodesHotThreadsRequ
 }
 
 // WithSnapshots - number of samples of thread stacktrace (default: 10).
-func (f NodesHotThreads) WithSnapshots(v int) func(*NodesHotThreadsRequest) {
+func (f NodesHotThreads) WithSnapshots(v int64) func(*NodesHotThreadsRequest) {
 	return func(r *NodesHotThreadsRequest) {
 		r.Snapshots = &v
 	}
@@ -250,7 +250,7 @@ func (f NodesHotThreads) WithSort(v string) func(*NodesHotThreadsRequest) {
 }
 
 // WithThreads - specify the number of threads to provide information for (default: 3).
-func (f NodesHotThreads) WithThreads(v int) func(*NodesHotThreadsRequest) {
+func (f NodesHotThreads) WithThreads(v int64) func(*NodesHotThreadsRequest) {
 	return func(r *NodesHotThreadsRequest) {
 		r.Threads = &v
 	}

--- a/esapi/api.rank_eval.go
+++ b/esapi/api.rank_eval.go
@@ -213,7 +213,7 @@ func (f RankEval) WithIndex(v ...string) func(*RankEvalRequest) {
 	}
 }
 
-// WithAllowNoIndices - whether to ignore if a wildcard indices expression resolves into no concrete indices. (this includes `_all` string or when no indices have been specified).
+// WithAllowNoIndices - whether to allow (1) wildcard index expressions that match no indices and (2) requests where the final resolved set is empty..
 func (f RankEval) WithAllowNoIndices(v bool) func(*RankEvalRequest) {
 	return func(r *RankEvalRequest) {
 		r.AllowNoIndices = &v

--- a/esapi/api.search.go
+++ b/esapi/api.search.go
@@ -61,7 +61,7 @@ type SearchRequest struct {
 	AllowPartialSearchResults  *bool
 	Analyzer                   string
 	AnalyzeWildcard            *bool
-	BatchedReduceSize          *int
+	BatchedReduceSize          *int64
 	CcsMinimizeRoundtrips      *bool
 	DefaultOperator            string
 	Df                         string
@@ -76,7 +76,7 @@ type SearchRequest struct {
 	Lenient                    *bool
 	MaxConcurrentShardRequests *int
 	Preference                 string
-	PreFilterShardSize         *int
+	PreFilterShardSize         *int64
 	Query                      string
 	RequestCache               *bool
 	RestTotalHitsAsInt         *bool
@@ -94,9 +94,9 @@ type SearchRequest struct {
 	StoredFields               []string
 	SuggestField               string
 	SuggestMode                string
-	SuggestSize                *int
+	SuggestSize                *int64
 	SuggestText                string
-	TerminateAfter             *int
+	TerminateAfter             *int64
 	Timeout                    time.Duration
 	TrackScores                *bool
 	TrackTotalHits             interface{}
@@ -165,7 +165,7 @@ func (r SearchRequest) Do(providedCtx context.Context, transport Transport) (*Re
 	}
 
 	if r.BatchedReduceSize != nil {
-		params["batched_reduce_size"] = strconv.FormatInt(int64(*r.BatchedReduceSize), 10)
+		params["batched_reduce_size"] = strconv.FormatInt(*r.BatchedReduceSize, 10)
 	}
 
 	if r.CcsMinimizeRoundtrips != nil {
@@ -225,7 +225,7 @@ func (r SearchRequest) Do(providedCtx context.Context, transport Transport) (*Re
 	}
 
 	if r.PreFilterShardSize != nil {
-		params["pre_filter_shard_size"] = strconv.FormatInt(int64(*r.PreFilterShardSize), 10)
+		params["pre_filter_shard_size"] = strconv.FormatInt(*r.PreFilterShardSize, 10)
 	}
 
 	if r.Query != "" {
@@ -297,7 +297,7 @@ func (r SearchRequest) Do(providedCtx context.Context, transport Transport) (*Re
 	}
 
 	if r.SuggestSize != nil {
-		params["suggest_size"] = strconv.FormatInt(int64(*r.SuggestSize), 10)
+		params["suggest_size"] = strconv.FormatInt(*r.SuggestSize, 10)
 	}
 
 	if r.SuggestText != "" {
@@ -305,7 +305,7 @@ func (r SearchRequest) Do(providedCtx context.Context, transport Transport) (*Re
 	}
 
 	if r.TerminateAfter != nil {
-		params["terminate_after"] = strconv.FormatInt(int64(*r.TerminateAfter), 10)
+		params["terminate_after"] = strconv.FormatInt(*r.TerminateAfter, 10)
 	}
 
 	if r.Timeout != 0 {
@@ -427,7 +427,7 @@ func (f Search) WithIndex(v ...string) func(*SearchRequest) {
 	}
 }
 
-// WithAllowNoIndices - whether to ignore if a wildcard indices expression resolves into no concrete indices. (this includes `_all` string or when no indices have been specified).
+// WithAllowNoIndices - whether to allow (1) wildcard index expressions that match no indices and (2) requests where the final resolved set is empty..
 func (f Search) WithAllowNoIndices(v bool) func(*SearchRequest) {
 	return func(r *SearchRequest) {
 		r.AllowNoIndices = &v
@@ -456,7 +456,7 @@ func (f Search) WithAnalyzeWildcard(v bool) func(*SearchRequest) {
 }
 
 // WithBatchedReduceSize - the number of shard results that should be reduced at once on the coordinating node. this value should be used as a protection mechanism to reduce the memory overhead per search request if the potential number of shards in the request can be large..
-func (f Search) WithBatchedReduceSize(v int) func(*SearchRequest) {
+func (f Search) WithBatchedReduceSize(v int64) func(*SearchRequest) {
 	return func(r *SearchRequest) {
 		r.BatchedReduceSize = &v
 	}
@@ -561,7 +561,7 @@ func (f Search) WithPreference(v string) func(*SearchRequest) {
 }
 
 // WithPreFilterShardSize - a threshold that enforces a pre-filter roundtrip to prefilter search shards based on query rewriting if the number of shards the search request expands to exceeds the threshold. this filter roundtrip can limit the number of shards significantly if for instance a shard can not match any documents based on its rewrite method ie. if date filters are mandatory to match but the shard bounds and the query are disjoint..
-func (f Search) WithPreFilterShardSize(v int) func(*SearchRequest) {
+func (f Search) WithPreFilterShardSize(v int64) func(*SearchRequest) {
 	return func(r *SearchRequest) {
 		r.PreFilterShardSize = &v
 	}
@@ -687,7 +687,7 @@ func (f Search) WithSuggestMode(v string) func(*SearchRequest) {
 }
 
 // WithSuggestSize - how many suggestions to return in response.
-func (f Search) WithSuggestSize(v int) func(*SearchRequest) {
+func (f Search) WithSuggestSize(v int64) func(*SearchRequest) {
 	return func(r *SearchRequest) {
 		r.SuggestSize = &v
 	}
@@ -701,7 +701,7 @@ func (f Search) WithSuggestText(v string) func(*SearchRequest) {
 }
 
 // WithTerminateAfter - the maximum number of documents to collect for each shard, upon reaching which the query execution will terminate early..
-func (f Search) WithTerminateAfter(v int) func(*SearchRequest) {
+func (f Search) WithTerminateAfter(v int64) func(*SearchRequest) {
 	return func(r *SearchRequest) {
 		r.TerminateAfter = &v
 	}

--- a/esapi/api.search_shards.go
+++ b/esapi/api.search_shards.go
@@ -219,7 +219,7 @@ func (f SearchShards) WithIndex(v ...string) func(*SearchShardsRequest) {
 	}
 }
 
-// WithAllowNoIndices - whether to ignore if a wildcard indices expression resolves into no concrete indices. (this includes `_all` string or when no indices have been specified).
+// WithAllowNoIndices - whether to allow (1) wildcard index expressions that match no indices and (2) requests where the final resolved set is empty..
 func (f SearchShards) WithAllowNoIndices(v bool) func(*SearchShardsRequest) {
 	return func(r *SearchShardsRequest) {
 		r.AllowNoIndices = &v

--- a/esapi/api.search_template.go
+++ b/esapi/api.search_template.go
@@ -261,7 +261,7 @@ func (f SearchTemplate) WithIndex(v ...string) func(*SearchTemplateRequest) {
 	}
 }
 
-// WithAllowNoIndices - whether to ignore if a wildcard indices expression resolves into no concrete indices. (this includes `_all` string or when no indices have been specified).
+// WithAllowNoIndices - whether to allow (1) wildcard index expressions that match no indices and (2) requests where the final resolved set is empty..
 func (f SearchTemplate) WithAllowNoIndices(v bool) func(*SearchTemplateRequest) {
 	return func(r *SearchTemplateRequest) {
 		r.AllowNoIndices = &v

--- a/esapi/api.termvectors.go
+++ b/esapi/api.termvectors.go
@@ -65,7 +65,7 @@ type TermvectorsRequest struct {
 	Realtime        *bool
 	Routing         []string
 	TermStatistics  *bool
-	Version         *int
+	Version         *int64
 	VersionType     string
 
 	Pretty     bool
@@ -155,7 +155,7 @@ func (r TermvectorsRequest) Do(providedCtx context.Context, transport Transport)
 	}
 
 	if r.Version != nil {
-		params["version"] = strconv.FormatInt(int64(*r.Version), 10)
+		params["version"] = strconv.FormatInt(*r.Version, 10)
 	}
 
 	if r.VersionType != "" {
@@ -325,7 +325,7 @@ func (f Termvectors) WithTermStatistics(v bool) func(*TermvectorsRequest) {
 }
 
 // WithVersion - explicit version number for concurrency control.
-func (f Termvectors) WithVersion(v int) func(*TermvectorsRequest) {
+func (f Termvectors) WithVersion(v int64) func(*TermvectorsRequest) {
 	return func(r *TermvectorsRequest) {
 		r.Version = &v
 	}

--- a/esapi/api.update.go
+++ b/esapi/api.update.go
@@ -57,8 +57,8 @@ type UpdateRequest struct {
 
 	Body io.Reader
 
-	IfPrimaryTerm        *int
-	IfSeqNo              *int
+	IfPrimaryTerm        *int64
+	IfSeqNo              *int64
 	IncludeSourceOnError *bool
 	Lang                 string
 	Refresh              string
@@ -120,11 +120,11 @@ func (r UpdateRequest) Do(providedCtx context.Context, transport Transport) (*Re
 	params = make(map[string]string)
 
 	if r.IfPrimaryTerm != nil {
-		params["if_primary_term"] = strconv.FormatInt(int64(*r.IfPrimaryTerm), 10)
+		params["if_primary_term"] = strconv.FormatInt(*r.IfPrimaryTerm, 10)
 	}
 
 	if r.IfSeqNo != nil {
-		params["if_seq_no"] = strconv.FormatInt(int64(*r.IfSeqNo), 10)
+		params["if_seq_no"] = strconv.FormatInt(*r.IfSeqNo, 10)
 	}
 
 	if r.IncludeSourceOnError != nil {
@@ -257,14 +257,14 @@ func (f Update) WithContext(v context.Context) func(*UpdateRequest) {
 }
 
 // WithIfPrimaryTerm - only perform the update operation if the last operation that has changed the document has the specified primary term.
-func (f Update) WithIfPrimaryTerm(v int) func(*UpdateRequest) {
+func (f Update) WithIfPrimaryTerm(v int64) func(*UpdateRequest) {
 	return func(r *UpdateRequest) {
 		r.IfPrimaryTerm = &v
 	}
 }
 
 // WithIfSeqNo - only perform the update operation if the last operation that has changed the document has the specified sequence number.
-func (f Update) WithIfSeqNo(v int) func(*UpdateRequest) {
+func (f Update) WithIfSeqNo(v int64) func(*UpdateRequest) {
 	return func(r *UpdateRequest) {
 		r.IfSeqNo = &v
 	}

--- a/esapi/api.update_by_query.go
+++ b/esapi/api.update_by_query.go
@@ -65,10 +65,10 @@ type UpdateByQueryRequest struct {
 	DefaultOperator     string
 	Df                  string
 	ExpandWildcards     []string
-	From                *int
+	From                *int64
 	IgnoreUnavailable   *bool
 	Lenient             *bool
-	MaxDocs             *int
+	MaxDocs             *int64
 	Pipeline            string
 	Preference          string
 	Query               string
@@ -77,13 +77,13 @@ type UpdateByQueryRequest struct {
 	RequestsPerSecond   *int
 	Routing             []string
 	Scroll              time.Duration
-	ScrollSize          *int
+	ScrollSize          *int64
 	SearchTimeout       time.Duration
 	SearchType          string
 	Slices              interface{}
 	Sort                []string
 	Stats               []string
-	TerminateAfter      *int
+	TerminateAfter      *int64
 	Timeout             time.Duration
 	Version             *bool
 	VersionType         *bool
@@ -166,7 +166,7 @@ func (r UpdateByQueryRequest) Do(providedCtx context.Context, transport Transpor
 	}
 
 	if r.From != nil {
-		params["from"] = strconv.FormatInt(int64(*r.From), 10)
+		params["from"] = strconv.FormatInt(*r.From, 10)
 	}
 
 	if r.IgnoreUnavailable != nil {
@@ -178,7 +178,7 @@ func (r UpdateByQueryRequest) Do(providedCtx context.Context, transport Transpor
 	}
 
 	if r.MaxDocs != nil {
-		params["max_docs"] = strconv.FormatInt(int64(*r.MaxDocs), 10)
+		params["max_docs"] = strconv.FormatInt(*r.MaxDocs, 10)
 	}
 
 	if r.Pipeline != "" {
@@ -214,7 +214,7 @@ func (r UpdateByQueryRequest) Do(providedCtx context.Context, transport Transpor
 	}
 
 	if r.ScrollSize != nil {
-		params["scroll_size"] = strconv.FormatInt(int64(*r.ScrollSize), 10)
+		params["scroll_size"] = strconv.FormatInt(*r.ScrollSize, 10)
 	}
 
 	if r.SearchTimeout != 0 {
@@ -238,7 +238,7 @@ func (r UpdateByQueryRequest) Do(providedCtx context.Context, transport Transpor
 	}
 
 	if r.TerminateAfter != nil {
-		params["terminate_after"] = strconv.FormatInt(int64(*r.TerminateAfter), 10)
+		params["terminate_after"] = strconv.FormatInt(*r.TerminateAfter, 10)
 	}
 
 	if r.Timeout != 0 {
@@ -353,7 +353,7 @@ func (f UpdateByQuery) WithBody(v io.Reader) func(*UpdateByQueryRequest) {
 	}
 }
 
-// WithAllowNoIndices - whether to ignore if a wildcard indices expression resolves into no concrete indices. (this includes `_all` string or when no indices have been specified).
+// WithAllowNoIndices - whether to allow (1) wildcard index expressions that match no indices and (2) requests where the final resolved set is empty..
 func (f UpdateByQuery) WithAllowNoIndices(v bool) func(*UpdateByQueryRequest) {
 	return func(r *UpdateByQueryRequest) {
 		r.AllowNoIndices = &v
@@ -403,7 +403,7 @@ func (f UpdateByQuery) WithExpandWildcards(v ...string) func(*UpdateByQueryReque
 }
 
 // WithFrom - starting offset (default: 0).
-func (f UpdateByQuery) WithFrom(v int) func(*UpdateByQueryRequest) {
+func (f UpdateByQuery) WithFrom(v int64) func(*UpdateByQueryRequest) {
 	return func(r *UpdateByQueryRequest) {
 		r.From = &v
 	}
@@ -424,7 +424,7 @@ func (f UpdateByQuery) WithLenient(v bool) func(*UpdateByQueryRequest) {
 }
 
 // WithMaxDocs - maximum number of documents to process (default: all documents).
-func (f UpdateByQuery) WithMaxDocs(v int) func(*UpdateByQueryRequest) {
+func (f UpdateByQuery) WithMaxDocs(v int64) func(*UpdateByQueryRequest) {
 	return func(r *UpdateByQueryRequest) {
 		r.MaxDocs = &v
 	}
@@ -487,7 +487,7 @@ func (f UpdateByQuery) WithScroll(v time.Duration) func(*UpdateByQueryRequest) {
 }
 
 // WithScrollSize - size on the scroll request powering the update by query.
-func (f UpdateByQuery) WithScrollSize(v int) func(*UpdateByQueryRequest) {
+func (f UpdateByQuery) WithScrollSize(v int64) func(*UpdateByQueryRequest) {
 	return func(r *UpdateByQueryRequest) {
 		r.ScrollSize = &v
 	}
@@ -529,7 +529,7 @@ func (f UpdateByQuery) WithStats(v ...string) func(*UpdateByQueryRequest) {
 }
 
 // WithTerminateAfter - the maximum number of documents to collect for each shard, upon reaching which the query execution will terminate early..
-func (f UpdateByQuery) WithTerminateAfter(v int) func(*UpdateByQueryRequest) {
+func (f UpdateByQuery) WithTerminateAfter(v int64) func(*UpdateByQueryRequest) {
 	return func(r *UpdateByQueryRequest) {
 		r.TerminateAfter = &v
 	}

--- a/esapi/api.xpack.async_search.submit.go
+++ b/esapi/api.xpack.async_search.submit.go
@@ -61,7 +61,7 @@ type AsyncSearchSubmitRequest struct {
 	AllowPartialSearchResults  *bool
 	Analyzer                   string
 	AnalyzeWildcard            *bool
-	BatchedReduceSize          *int
+	BatchedReduceSize          *int64
 	CcsMinimizeRoundtrips      *bool
 	DefaultOperator            string
 	Df                         string
@@ -91,9 +91,9 @@ type AsyncSearchSubmitRequest struct {
 	StoredFields               []string
 	SuggestField               string
 	SuggestMode                string
-	SuggestSize                *int
+	SuggestSize                *int64
 	SuggestText                string
-	TerminateAfter             *int
+	TerminateAfter             *int64
 	Timeout                    time.Duration
 	TrackScores                *bool
 	TrackTotalHits             interface{}
@@ -163,7 +163,7 @@ func (r AsyncSearchSubmitRequest) Do(providedCtx context.Context, transport Tran
 	}
 
 	if r.BatchedReduceSize != nil {
-		params["batched_reduce_size"] = strconv.FormatInt(int64(*r.BatchedReduceSize), 10)
+		params["batched_reduce_size"] = strconv.FormatInt(*r.BatchedReduceSize, 10)
 	}
 
 	if r.CcsMinimizeRoundtrips != nil {
@@ -283,7 +283,7 @@ func (r AsyncSearchSubmitRequest) Do(providedCtx context.Context, transport Tran
 	}
 
 	if r.SuggestSize != nil {
-		params["suggest_size"] = strconv.FormatInt(int64(*r.SuggestSize), 10)
+		params["suggest_size"] = strconv.FormatInt(*r.SuggestSize, 10)
 	}
 
 	if r.SuggestText != "" {
@@ -291,7 +291,7 @@ func (r AsyncSearchSubmitRequest) Do(providedCtx context.Context, transport Tran
 	}
 
 	if r.TerminateAfter != nil {
-		params["terminate_after"] = strconv.FormatInt(int64(*r.TerminateAfter), 10)
+		params["terminate_after"] = strconv.FormatInt(*r.TerminateAfter, 10)
 	}
 
 	if r.Timeout != 0 {
@@ -417,7 +417,7 @@ func (f AsyncSearchSubmit) WithIndex(v ...string) func(*AsyncSearchSubmitRequest
 	}
 }
 
-// WithAllowNoIndices - whether to ignore if a wildcard indices expression resolves into no concrete indices. (this includes `_all` string or when no indices have been specified).
+// WithAllowNoIndices - whether to allow (1) wildcard index expressions that match no indices and (2) requests where the final resolved set is empty..
 func (f AsyncSearchSubmit) WithAllowNoIndices(v bool) func(*AsyncSearchSubmitRequest) {
 	return func(r *AsyncSearchSubmitRequest) {
 		r.AllowNoIndices = &v
@@ -446,7 +446,7 @@ func (f AsyncSearchSubmit) WithAnalyzeWildcard(v bool) func(*AsyncSearchSubmitRe
 }
 
 // WithBatchedReduceSize - the number of shard results that should be reduced at once on the coordinating node. this value should be used as the granularity at which progress results will be made available..
-func (f AsyncSearchSubmit) WithBatchedReduceSize(v int) func(*AsyncSearchSubmitRequest) {
+func (f AsyncSearchSubmit) WithBatchedReduceSize(v int64) func(*AsyncSearchSubmitRequest) {
 	return func(r *AsyncSearchSubmitRequest) {
 		r.BatchedReduceSize = &v
 	}
@@ -656,7 +656,7 @@ func (f AsyncSearchSubmit) WithSuggestMode(v string) func(*AsyncSearchSubmitRequ
 }
 
 // WithSuggestSize - how many suggestions to return in response.
-func (f AsyncSearchSubmit) WithSuggestSize(v int) func(*AsyncSearchSubmitRequest) {
+func (f AsyncSearchSubmit) WithSuggestSize(v int64) func(*AsyncSearchSubmitRequest) {
 	return func(r *AsyncSearchSubmitRequest) {
 		r.SuggestSize = &v
 	}
@@ -670,7 +670,7 @@ func (f AsyncSearchSubmit) WithSuggestText(v string) func(*AsyncSearchSubmitRequ
 }
 
 // WithTerminateAfter - the maximum number of documents to collect for each shard, upon reaching which the query execution will terminate early..
-func (f AsyncSearchSubmit) WithTerminateAfter(v int) func(*AsyncSearchSubmitRequest) {
+func (f AsyncSearchSubmit) WithTerminateAfter(v int64) func(*AsyncSearchSubmitRequest) {
 	return func(r *AsyncSearchSubmitRequest) {
 		r.TerminateAfter = &v
 	}

--- a/esapi/api.xpack.eql.search.go
+++ b/esapi/api.xpack.eql.search.go
@@ -237,7 +237,7 @@ func (f EqlSearch) WithContext(v context.Context) func(*EqlSearchRequest) {
 	}
 }
 
-// WithAllowNoIndices - whether to ignore if a wildcard indices expression resolves into no concrete indices. (this includes `_all` string or when no indices have been specified).
+// WithAllowNoIndices - whether to allow (1) wildcard index expressions that match no indices and (2) requests where the final resolved set is empty..
 func (f EqlSearch) WithAllowNoIndices(v bool) func(*EqlSearchRequest) {
 	return func(r *EqlSearchRequest) {
 		r.AllowNoIndices = &v

--- a/esapi/api.xpack.indices.reload_search_analyzers.go
+++ b/esapi/api.xpack.indices.reload_search_analyzers.go
@@ -199,7 +199,7 @@ func (f IndicesReloadSearchAnalyzers) WithContext(v context.Context) func(*Indic
 	}
 }
 
-// WithAllowNoIndices - whether to ignore if a wildcard indices expression resolves into no concrete indices. (this includes `_all` string or when no indices have been specified).
+// WithAllowNoIndices - whether to allow (1) wildcard index expressions that match no indices and (2) requests where the final resolved set is empty..
 func (f IndicesReloadSearchAnalyzers) WithAllowNoIndices(v bool) func(*IndicesReloadSearchAnalyzersRequest) {
 	return func(r *IndicesReloadSearchAnalyzersRequest) {
 		r.AllowNoIndices = &v

--- a/esapi/api.xpack.ml.get_categories.go
+++ b/esapi/api.xpack.ml.get_categories.go
@@ -53,7 +53,7 @@ type MLGetCategories func(job_id string, o ...func(*MLGetCategoriesRequest)) (*R
 type MLGetCategoriesRequest struct {
 	Body io.Reader
 
-	CategoryID *int
+	CategoryID *int64
 	JobID      string
 
 	From                *int
@@ -223,7 +223,7 @@ func (f MLGetCategories) WithBody(v io.Reader) func(*MLGetCategoriesRequest) {
 }
 
 // WithCategoryID - the identifier of the category definition of interest.
-func (f MLGetCategories) WithCategoryID(v int) func(*MLGetCategoriesRequest) {
+func (f MLGetCategories) WithCategoryID(v int64) func(*MLGetCategoriesRequest) {
 	return func(r *MLGetCategoriesRequest) {
 		r.CategoryID = &v
 	}

--- a/esapi/api.xpack.ml.put_job.go
+++ b/esapi/api.xpack.ml.put_job.go
@@ -206,7 +206,7 @@ func (f MLPutJob) WithContext(v context.Context) func(*MLPutJobRequest) {
 	}
 }
 
-// WithAllowNoIndices - ignore if the source indices expressions resolves to no concrete indices (default: true). only set if datafeed_config is provided..
+// WithAllowNoIndices - whether to allow (1) wildcard index expressions that match no indices and (2) requests where the final resolved set is empty. only set if datafeed_config is provided..
 func (f MLPutJob) WithAllowNoIndices(v bool) func(*MLPutJobRequest) {
 	return func(r *MLPutJobRequest) {
 		r.AllowNoIndices = &v

--- a/esapi/api.xpack.ml.update_datafeed.go
+++ b/esapi/api.xpack.ml.update_datafeed.go
@@ -208,7 +208,7 @@ func (f MLUpdateDatafeed) WithContext(v context.Context) func(*MLUpdateDatafeedR
 	}
 }
 
-// WithAllowNoIndices - ignore if the source indices expressions resolves to no concrete indices (default: true).
+// WithAllowNoIndices - whether to allow (1) wildcard index expressions that match no indices and (2) requests where the final resolved set is empty..
 func (f MLUpdateDatafeed) WithAllowNoIndices(v bool) func(*MLUpdateDatafeedRequest) {
 	return func(r *MLUpdateDatafeedRequest) {
 		r.AllowNoIndices = &v

--- a/esapi/api.xpack.monitoring.bulk.go
+++ b/esapi/api.xpack.monitoring.bulk.go
@@ -28,8 +28,8 @@ import (
 )
 
 func newMonitoringBulkFunc(t Transport) MonitoringBulk {
-	return func(body io.Reader, system_id string, system_api_version string, interval time.Duration, o ...func(*MonitoringBulkRequest)) (*Response, error) {
-		var r = MonitoringBulkRequest{Body: body, SystemID: system_id, SystemAPIVersion: system_api_version, Interval: interval}
+	return func(body io.Reader, interval time.Duration, system_api_version string, system_id string, o ...func(*MonitoringBulkRequest)) (*Response, error) {
+		var r = MonitoringBulkRequest{Body: body, Interval: interval, SystemAPIVersion: system_api_version, SystemID: system_id}
 		for _, f := range o {
 			f(&r)
 		}
@@ -47,7 +47,7 @@ func newMonitoringBulkFunc(t Transport) MonitoringBulk {
 // MonitoringBulk - Send monitoring data
 //
 // See full documentation at https://www.elastic.co/docs/api/doc/elasticsearch.
-type MonitoringBulk func(body io.Reader, system_id string, system_api_version string, interval time.Duration, o ...func(*MonitoringBulkRequest)) (*Response, error)
+type MonitoringBulk func(body io.Reader, interval time.Duration, system_api_version string, system_id string, o ...func(*MonitoringBulkRequest)) (*Response, error)
 
 // MonitoringBulkRequest configures the Monitoring Bulk API request.
 type MonitoringBulkRequest struct {

--- a/esapi/api.xpack.searchable_snapshots.clear_cache.go
+++ b/esapi/api.xpack.searchable_snapshots.clear_cache.go
@@ -204,7 +204,7 @@ func (f SearchableSnapshotsClearCache) WithIndex(v ...string) func(*SearchableSn
 	}
 }
 
-// WithAllowNoIndices - whether to ignore if a wildcard indices expression resolves into no concrete indices. (this includes `_all` string or when no indices have been specified).
+// WithAllowNoIndices - whether to allow (1) wildcard index expressions that match no indices and (2) requests where the final resolved set is empty..
 func (f SearchableSnapshotsClearCache) WithAllowNoIndices(v bool) func(*SearchableSnapshotsClearCacheRequest) {
 	return func(r *SearchableSnapshotsClearCacheRequest) {
 		r.AllowNoIndices = &v

--- a/esapi/api.xpack.security.clone_api_key.go
+++ b/esapi/api.xpack.security.clone_api_key.go
@@ -23,13 +23,12 @@ import (
 	"context"
 	"io"
 	"net/http"
-	"strconv"
 	"strings"
 )
 
-func newMLPutDatafeedFunc(t Transport) MLPutDatafeed {
-	return func(body io.Reader, datafeed_id string, o ...func(*MLPutDatafeedRequest)) (*Response, error) {
-		var r = MLPutDatafeedRequest{Body: body, DatafeedID: datafeed_id}
+func newSecurityCloneAPIKeyFunc(t Transport) SecurityCloneAPIKey {
+	return func(body io.Reader, o ...func(*SecurityCloneAPIKeyRequest)) (*Response, error) {
+		var r = SecurityCloneAPIKeyRequest{Body: body}
 		for _, f := range o {
 			f(&r)
 		}
@@ -44,21 +43,16 @@ func newMLPutDatafeedFunc(t Transport) MLPutDatafeed {
 
 // ----- API Definition -------------------------------------------------------
 
-// MLPutDatafeed - Create a datafeed
+// SecurityCloneAPIKey - Clone an API key. Creates a new API key with the same role descriptors as an existing key, with a new name, id, and optional expiration and metadata.
 //
-// See full documentation at https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-ml-put-datafeed.
-type MLPutDatafeed func(body io.Reader, datafeed_id string, o ...func(*MLPutDatafeedRequest)) (*Response, error)
+// See full documentation at https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-security-clone-api-key.
+type SecurityCloneAPIKey func(body io.Reader, o ...func(*SecurityCloneAPIKeyRequest)) (*Response, error)
 
-// MLPutDatafeedRequest configures the ML Put Datafeed API request.
-type MLPutDatafeedRequest struct {
+// SecurityCloneAPIKeyRequest configures the Security CloneAPI Key API request.
+type SecurityCloneAPIKeyRequest struct {
 	Body io.Reader
 
-	DatafeedID string
-
-	AllowNoIndices    *bool
-	ExpandWildcards   []string
-	IgnoreThrottled   *bool
-	IgnoreUnavailable *bool
+	Refresh string
 
 	Pretty     bool
 	Human      bool
@@ -73,7 +67,7 @@ type MLPutDatafeedRequest struct {
 }
 
 // Do executes the request and returns response or error.
-func (r MLPutDatafeedRequest) Do(providedCtx context.Context, transport Transport) (*Response, error) {
+func (r SecurityCloneAPIKeyRequest) Do(providedCtx context.Context, transport Transport) (*Response, error) {
 	var (
 		method string
 		path   strings.Builder
@@ -82,43 +76,23 @@ func (r MLPutDatafeedRequest) Do(providedCtx context.Context, transport Transpor
 	)
 
 	if instrument, ok := r.Instrument.(Instrumentation); ok {
-		ctx = instrument.Start(providedCtx, "ml.put_datafeed")
+		ctx = instrument.Start(providedCtx, "security.clone_api_key")
 		defer instrument.Close(ctx)
 	}
 	if ctx == nil {
 		ctx = providedCtx
 	}
 
-	method = "PUT"
+	method = "POST"
 
-	path.Grow(7 + 1 + len("_ml") + 1 + len("datafeeds") + 1 + len(r.DatafeedID))
+	path.Grow(7 + len("/_security/api_key/clone"))
 	path.WriteString("http://")
-	path.WriteString("/")
-	path.WriteString("_ml")
-	path.WriteString("/")
-	path.WriteString("datafeeds")
-	path.WriteString("/")
-	path.WriteString(r.DatafeedID)
-	if instrument, ok := r.Instrument.(Instrumentation); ok {
-		instrument.RecordPathPart(ctx, "datafeed_id", r.DatafeedID)
-	}
+	path.WriteString("/_security/api_key/clone")
 
 	params = make(map[string]string)
 
-	if r.AllowNoIndices != nil {
-		params["allow_no_indices"] = strconv.FormatBool(*r.AllowNoIndices)
-	}
-
-	if len(r.ExpandWildcards) > 0 {
-		params["expand_wildcards"] = strings.Join(r.ExpandWildcards, ",")
-	}
-
-	if r.IgnoreThrottled != nil {
-		params["ignore_throttled"] = strconv.FormatBool(*r.IgnoreThrottled)
-	}
-
-	if r.IgnoreUnavailable != nil {
-		params["ignore_unavailable"] = strconv.FormatBool(*r.IgnoreUnavailable)
+	if r.Refresh != "" {
+		params["refresh"] = r.Refresh
 	}
 
 	if r.Pretty {
@@ -174,14 +148,14 @@ func (r MLPutDatafeedRequest) Do(providedCtx context.Context, transport Transpor
 	}
 
 	if instrument, ok := r.Instrument.(Instrumentation); ok {
-		instrument.BeforeRequest(req, "ml.put_datafeed")
-		if reader := instrument.RecordRequestBody(ctx, "ml.put_datafeed", r.Body); reader != nil {
+		instrument.BeforeRequest(req, "security.clone_api_key")
+		if reader := instrument.RecordRequestBody(ctx, "security.clone_api_key", r.Body); reader != nil {
 			req.Body = reader
 		}
 	}
 	res, err := transport.Perform(req)
 	if instrument, ok := r.Instrument.(Instrumentation); ok {
-		instrument.AfterRequest(req, "elasticsearch", "ml.put_datafeed")
+		instrument.AfterRequest(req, "elasticsearch", "security.clone_api_key")
 	}
 	if err != nil {
 		if instrument, ok := r.Instrument.(Instrumentation); ok {
@@ -200,71 +174,50 @@ func (r MLPutDatafeedRequest) Do(providedCtx context.Context, transport Transpor
 }
 
 // WithContext sets the request context.
-func (f MLPutDatafeed) WithContext(v context.Context) func(*MLPutDatafeedRequest) {
-	return func(r *MLPutDatafeedRequest) {
+func (f SecurityCloneAPIKey) WithContext(v context.Context) func(*SecurityCloneAPIKeyRequest) {
+	return func(r *SecurityCloneAPIKeyRequest) {
 		r.ctx = v
 	}
 }
 
-// WithAllowNoIndices - whether to allow (1) wildcard index expressions that match no indices and (2) requests where the final resolved set is empty..
-func (f MLPutDatafeed) WithAllowNoIndices(v bool) func(*MLPutDatafeedRequest) {
-	return func(r *MLPutDatafeedRequest) {
-		r.AllowNoIndices = &v
-	}
-}
-
-// WithExpandWildcards - whether source index expressions should get expanded to open or closed indices (default: open).
-func (f MLPutDatafeed) WithExpandWildcards(v ...string) func(*MLPutDatafeedRequest) {
-	return func(r *MLPutDatafeedRequest) {
-		r.ExpandWildcards = v
-	}
-}
-
-// WithIgnoreThrottled - ignore indices that are marked as throttled (default: true).
-func (f MLPutDatafeed) WithIgnoreThrottled(v bool) func(*MLPutDatafeedRequest) {
-	return func(r *MLPutDatafeedRequest) {
-		r.IgnoreThrottled = &v
-	}
-}
-
-// WithIgnoreUnavailable - ignore unavailable indexes (default: false).
-func (f MLPutDatafeed) WithIgnoreUnavailable(v bool) func(*MLPutDatafeedRequest) {
-	return func(r *MLPutDatafeedRequest) {
-		r.IgnoreUnavailable = &v
+// WithRefresh - if `true` then refresh the affected shards to make this operation visible to search, if `wait_for` then wait for a refresh to make this operation visible to search, if `false` then do nothing with refreshes. default is `wait_for` in stateful and `true` in serverless..
+func (f SecurityCloneAPIKey) WithRefresh(v string) func(*SecurityCloneAPIKeyRequest) {
+	return func(r *SecurityCloneAPIKeyRequest) {
+		r.Refresh = v
 	}
 }
 
 // WithPretty makes the response body pretty-printed.
-func (f MLPutDatafeed) WithPretty() func(*MLPutDatafeedRequest) {
-	return func(r *MLPutDatafeedRequest) {
+func (f SecurityCloneAPIKey) WithPretty() func(*SecurityCloneAPIKeyRequest) {
+	return func(r *SecurityCloneAPIKeyRequest) {
 		r.Pretty = true
 	}
 }
 
 // WithHuman makes statistical values human-readable.
-func (f MLPutDatafeed) WithHuman() func(*MLPutDatafeedRequest) {
-	return func(r *MLPutDatafeedRequest) {
+func (f SecurityCloneAPIKey) WithHuman() func(*SecurityCloneAPIKeyRequest) {
+	return func(r *SecurityCloneAPIKeyRequest) {
 		r.Human = true
 	}
 }
 
 // WithErrorTrace includes the stack trace for errors in the response body.
-func (f MLPutDatafeed) WithErrorTrace() func(*MLPutDatafeedRequest) {
-	return func(r *MLPutDatafeedRequest) {
+func (f SecurityCloneAPIKey) WithErrorTrace() func(*SecurityCloneAPIKeyRequest) {
+	return func(r *SecurityCloneAPIKeyRequest) {
 		r.ErrorTrace = true
 	}
 }
 
 // WithFilterPath filters the properties of the response body.
-func (f MLPutDatafeed) WithFilterPath(v ...string) func(*MLPutDatafeedRequest) {
-	return func(r *MLPutDatafeedRequest) {
+func (f SecurityCloneAPIKey) WithFilterPath(v ...string) func(*SecurityCloneAPIKeyRequest) {
+	return func(r *SecurityCloneAPIKeyRequest) {
 		r.FilterPath = v
 	}
 }
 
 // WithHeader adds the headers to the HTTP request.
-func (f MLPutDatafeed) WithHeader(h map[string]string) func(*MLPutDatafeedRequest) {
-	return func(r *MLPutDatafeedRequest) {
+func (f SecurityCloneAPIKey) WithHeader(h map[string]string) func(*SecurityCloneAPIKeyRequest) {
+	return func(r *SecurityCloneAPIKeyRequest) {
 		if r.Header == nil {
 			r.Header = make(http.Header)
 		}
@@ -275,8 +228,8 @@ func (f MLPutDatafeed) WithHeader(h map[string]string) func(*MLPutDatafeedReques
 }
 
 // WithOpaqueID adds the X-Opaque-Id header to the HTTP request.
-func (f MLPutDatafeed) WithOpaqueID(s string) func(*MLPutDatafeedRequest) {
-	return func(r *MLPutDatafeedRequest) {
+func (f SecurityCloneAPIKey) WithOpaqueID(s string) func(*SecurityCloneAPIKeyRequest) {
+	return func(r *SecurityCloneAPIKeyRequest) {
 		if r.Header == nil {
 			r.Header = make(http.Header)
 		}

--- a/esapi/api.xpack.security.update_user_profile_data.go
+++ b/esapi/api.xpack.security.update_user_profile_data.go
@@ -55,8 +55,8 @@ type SecurityUpdateUserProfileDataRequest struct {
 
 	UID string
 
-	IfPrimaryTerm *int
-	IfSeqNo       *int
+	IfPrimaryTerm *int64
+	IfSeqNo       *int64
 	Refresh       string
 
 	Pretty     bool
@@ -107,11 +107,11 @@ func (r SecurityUpdateUserProfileDataRequest) Do(providedCtx context.Context, tr
 	params = make(map[string]string)
 
 	if r.IfPrimaryTerm != nil {
-		params["if_primary_term"] = strconv.FormatInt(int64(*r.IfPrimaryTerm), 10)
+		params["if_primary_term"] = strconv.FormatInt(*r.IfPrimaryTerm, 10)
 	}
 
 	if r.IfSeqNo != nil {
-		params["if_seq_no"] = strconv.FormatInt(int64(*r.IfSeqNo), 10)
+		params["if_seq_no"] = strconv.FormatInt(*r.IfSeqNo, 10)
 	}
 
 	if r.Refresh != "" {
@@ -204,14 +204,14 @@ func (f SecurityUpdateUserProfileData) WithContext(v context.Context) func(*Secu
 }
 
 // WithIfPrimaryTerm - only perform the update operation if the last operation that has changed the document has the specified primary term.
-func (f SecurityUpdateUserProfileData) WithIfPrimaryTerm(v int) func(*SecurityUpdateUserProfileDataRequest) {
+func (f SecurityUpdateUserProfileData) WithIfPrimaryTerm(v int64) func(*SecurityUpdateUserProfileDataRequest) {
 	return func(r *SecurityUpdateUserProfileDataRequest) {
 		r.IfPrimaryTerm = &v
 	}
 }
 
 // WithIfSeqNo - only perform the update operation if the last operation that has changed the document has the specified sequence number.
-func (f SecurityUpdateUserProfileData) WithIfSeqNo(v int) func(*SecurityUpdateUserProfileDataRequest) {
+func (f SecurityUpdateUserProfileData) WithIfSeqNo(v int64) func(*SecurityUpdateUserProfileDataRequest) {
 	return func(r *SecurityUpdateUserProfileDataRequest) {
 		r.IfSeqNo = &v
 	}

--- a/esapi/api.xpack.text_structure.find_field_structure.go
+++ b/esapi/api.xpack.text_structure.find_field_structure.go
@@ -29,7 +29,7 @@ import (
 
 func newTextStructureFindFieldStructureFunc(t Transport) TextStructureFindFieldStructure {
 	return func(field string, index string, o ...func(*TextStructureFindFieldStructureRequest)) (*Response, error) {
-		var r = TextStructureFindFieldStructureRequest{Index: index, Field: field}
+		var r = TextStructureFindFieldStructureRequest{Field: field, Index: index}
 		for _, f := range o {
 			f(&r)
 		}

--- a/esapi/api.xpack.transform.get_transform_stats.go
+++ b/esapi/api.xpack.transform.get_transform_stats.go
@@ -55,8 +55,8 @@ type TransformGetTransformStatsRequest struct {
 	TransformID []string
 
 	AllowNoMatch *bool
-	From         *int
-	Size         *int
+	From         *int64
+	Size         *int64
 	Timeout      time.Duration
 
 	Pretty     bool
@@ -113,11 +113,11 @@ func (r TransformGetTransformStatsRequest) Do(providedCtx context.Context, trans
 	}
 
 	if r.From != nil {
-		params["from"] = strconv.FormatInt(int64(*r.From), 10)
+		params["from"] = strconv.FormatInt(*r.From, 10)
 	}
 
 	if r.Size != nil {
-		params["size"] = strconv.FormatInt(int64(*r.Size), 10)
+		params["size"] = strconv.FormatInt(*r.Size, 10)
 	}
 
 	if r.Timeout != 0 {
@@ -210,14 +210,14 @@ func (f TransformGetTransformStats) WithAllowNoMatch(v bool) func(*TransformGetT
 }
 
 // WithFrom - skips a number of transform stats, defaults to 0.
-func (f TransformGetTransformStats) WithFrom(v int) func(*TransformGetTransformStatsRequest) {
+func (f TransformGetTransformStats) WithFrom(v int64) func(*TransformGetTransformStatsRequest) {
 	return func(r *TransformGetTransformStatsRequest) {
 		r.From = &v
 	}
 }
 
 // WithSize - specifies a max number of transform stats to get, defaults to 100.
-func (f TransformGetTransformStats) WithSize(v int) func(*TransformGetTransformStatsRequest) {
+func (f TransformGetTransformStats) WithSize(v int64) func(*TransformGetTransformStatsRequest) {
 	return func(r *TransformGetTransformStatsRequest) {
 		r.Size = &v
 	}

--- a/esapi/api.xpack.watcher.put_watch.go
+++ b/esapi/api.xpack.watcher.put_watch.go
@@ -56,9 +56,9 @@ type WatcherPutWatchRequest struct {
 	Body io.Reader
 
 	Active        *bool
-	IfPrimaryTerm *int
-	IfSeqNo       *int
-	Version       *int
+	IfPrimaryTerm *int64
+	IfSeqNo       *int64
+	Version       *int64
 
 	Pretty     bool
 	Human      bool
@@ -110,15 +110,15 @@ func (r WatcherPutWatchRequest) Do(providedCtx context.Context, transport Transp
 	}
 
 	if r.IfPrimaryTerm != nil {
-		params["if_primary_term"] = strconv.FormatInt(int64(*r.IfPrimaryTerm), 10)
+		params["if_primary_term"] = strconv.FormatInt(*r.IfPrimaryTerm, 10)
 	}
 
 	if r.IfSeqNo != nil {
-		params["if_seq_no"] = strconv.FormatInt(int64(*r.IfSeqNo), 10)
+		params["if_seq_no"] = strconv.FormatInt(*r.IfSeqNo, 10)
 	}
 
 	if r.Version != nil {
-		params["version"] = strconv.FormatInt(int64(*r.Version), 10)
+		params["version"] = strconv.FormatInt(*r.Version, 10)
 	}
 
 	if r.Pretty {
@@ -214,21 +214,21 @@ func (f WatcherPutWatch) WithActive(v bool) func(*WatcherPutWatchRequest) {
 }
 
 // WithIfPrimaryTerm - only update the watch if the last operation that has changed the watch has the specified primary term.
-func (f WatcherPutWatch) WithIfPrimaryTerm(v int) func(*WatcherPutWatchRequest) {
+func (f WatcherPutWatch) WithIfPrimaryTerm(v int64) func(*WatcherPutWatchRequest) {
 	return func(r *WatcherPutWatchRequest) {
 		r.IfPrimaryTerm = &v
 	}
 }
 
 // WithIfSeqNo - only update the watch if the last operation that has changed the watch has the specified sequence number.
-func (f WatcherPutWatch) WithIfSeqNo(v int) func(*WatcherPutWatchRequest) {
+func (f WatcherPutWatch) WithIfSeqNo(v int64) func(*WatcherPutWatchRequest) {
 	return func(r *WatcherPutWatchRequest) {
 		r.IfSeqNo = &v
 	}
 }
 
 // WithVersion - explicit version number for concurrency control.
-func (f WatcherPutWatch) WithVersion(v int) func(*WatcherPutWatchRequest) {
+func (f WatcherPutWatch) WithVersion(v int64) func(*WatcherPutWatchRequest) {
 	return func(r *WatcherPutWatchRequest) {
 		r.Version = &v
 	}


### PR DESCRIPTION
## Summary

Regenerate `esapi/` against the latest 9.4 spec. First regeneration since the `long`→`*int64` generator fix landed (#1394), so this PR realizes the fix for issue #548 on 9.4.

## Breaking changes

Params previously typed `*int` are now `*int64` to match the spec's `long` type. This affects ~25 endpoints. Examples:

- Document versioning: `Index`, `Update`, `Delete`, `Get`, `Create`, `Exists`, `GetSource`, `ExistsSource` — `WithVersion`, `WithIfSeqNo`, `WithIfPrimaryTerm` now take `int64`
- Search paging / termination: `Search`, `Count`, `Msearch`, `MsearchTemplate`, etc. — affected `Withxxx` setters flip to `int64`

Call sites passing untyped integer literals (e.g. `WithVersion(42)`) keep compiling. Call sites passing a typed `int` variable need an `int64(...)` cast.

Fixes #548.

## Other spec-driven changes

This regeneration also picks up unrelated 9.4 spec drift that accumulated since the last run:

- New `SecurityCloneAPIKey` endpoint (additive)
- Updated spec build hash
- Reworded descriptions (e.g. `WithAllowNoIndices`)

## Test plan

- [ ] CI build passes
- [ ] CI unit tests pass
- [ ] CI integration tests pass
