### PR TITLE
fix(gen): sort required URL params deterministically

### DIFF
--- a/internal/build/cmd/generate/commands/gensource/model.go
+++ b/internal/build/cmd/generate/commands/gensource/model.go
@@ -631,7 +631,13 @@ func (e *Endpoint) RequiredArguments() []MethodArgument {
 	}
 
 	// Return URL params
-	for _, p := range e.URL.Params {
+	var paramKeys []string
+	for k := range e.URL.Params {
+		paramKeys = append(paramKeys, k)
+	}
+	sort.Strings(paramKeys)
+	for _, k := range paramKeys {
+		p := e.URL.Params[k]
 		if contains(p.Name) {
 			continue
 		}


### PR DESCRIPTION
## Summary

Fix a latent generator bug that produces broken esapi files on endpoints with multiple required URL params.

## Root cause

`Endpoint.RequiredArguments()` in `internal/build/cmd/generate/commands/gensource/model.go` iterates `e.URL.Params` as a bare `map[string]*Param`:

```go
for _, p := range e.URL.Params {
    if p.Required { ... }
}
```

Go randomizes map iteration, and this method is called twice within a single generator run (once by `genConstructor`, once by `genMethodDefinition`). When the two calls return required URL params in different orders, the generated constructor signature no longer matches the type alias it's supposed to satisfy.

Example failure on `api.xpack.monitoring.bulk.go` (three required URL params: `system_id`, `system_api_version`, `interval`):

```
cannot use func(body, system_api_version, interval, system_id) ... {…}
  (value of type func(body io.Reader, system_api_version string, interval time.Duration, system_id string, ...) (*Response, error))
as MonitoringBulk value in return statement
```

Required URL *parts* already iterate over a sorted `keys` slice (lines 582–586). Required URL *params* were missed.

## Fix

Build and sort a `paramKeys` slice before iterating, matching the existing pattern for URL parts.

## Note for callers

On `monitoring.bulk`, the positional order of required params becomes alphabetical: `(body, interval, system_api_version, system_id)`. The previously-committed order was `(body, system_id, system_api_version, interval)` — but that was whichever order the last random iteration happened to produce, not a deliberate contract. After this fix, the order is stable across regenerations.

Callers who invoke `client.Monitoring.Bulk(...)` positionally may need to reorder their arguments.

## Blast radius

- Affects only endpoints with 2+ required URL params (where the map iteration mismatch can manifest).
- `monitoring.bulk` is the observed case; other endpoints in the same category will have their generated signatures stabilized as a side effect.

## Test plan

- [x] `cd internal/build && go build ./...` clean
- [x] `cd internal/build && go vet ./...` clean
- [x] Re-ran `make gen-api` locally; constructor and type alias for `MonitoringBulk` now match
- [ ] CI build passes
- [ ] CI unit tests pass

## Related

Unblocks the CI on #1402 and #1406 (regenerate esapi with `*int64` for long-typed params, issue #548). Those PRs will be rebased after this lands and backports to 9.4/9.3/9.2/8.19.
