### PR TITLE
fix(gen): accept bool form for deprecated in URL parts and paths

### DIFF
--- a/internal/build/cmd/generate/commands/gensource/model.go
+++ b/internal/build/cmd/generate/commands/gensource/model.go
@@ -451,10 +451,7 @@ type Path struct {
 	Path       string           `json:"path"`
 	Methods    []string         `json:"methods"`
 	Parts      map[string]*Part `json:"parts"`
-	Deprecated struct {
-		Version     string `json:"version"`
-		Description string `json:"description"`
-	}
+	Deprecated Deprecation      `json:"deprecated"`
 }
 
 // Part represents part of the API endpoint URL.
@@ -468,10 +465,28 @@ type Part struct {
 	Description string `json:"description"`
 	Required    bool   `json:"required"`
 
-	Deprecated struct {
-		Version     string `json:"version"`
-		Description string `json:"description"`
+	Deprecated Deprecation `json:"deprecated"`
+}
+
+// Deprecation captures the deprecation state of a Part or Path. Specs express
+// this either as an object with version/description fields or as a bare bool;
+// both forms unmarshal here, with the bool form yielding an empty Version.
+type Deprecation struct {
+	Version     string `json:"version"`
+	Description string `json:"description"`
+}
+
+// UnmarshalJSON accepts either an object ({version, description}) or a bare
+// bool. A bool leaves Version and Description empty, matching the "deprecated
+// but no metadata" case; the existing Version != "" guards then treat it as
+// non-skippable, preserving prior behavior for object-form specs.
+func (d *Deprecation) UnmarshalJSON(data []byte) error {
+	var b bool
+	if err := json.Unmarshal(data, &b); err == nil {
+		return nil
 	}
+	type alias Deprecation
+	return json.Unmarshal(data, (*alias)(d))
 }
 
 // Param represents API endpoint parameter.


### PR DESCRIPTION
## Summary

Accept both object and bool forms for the `deprecated` field in URL parts/paths. Fixes #1405.

## Background

The rest-api-spec expresses deprecation in two shapes depending on the version:

- Object form (9.x): `"deprecated": {"version": "7.0.0", "description": "..."}`
- Bool form (8.19): `"deprecated": true`

The generator's `Path.Deprecated` and `Part.Deprecated` were modeled as an inline object struct, so the 8.19 spec's bool form causes:

```
json: cannot unmarshal bool into Go struct field Part.url.paths.parts.Deprecated
  of type struct { Version string ...; Description string ... }
```

aborting `make gen-api` on 8.19 after processing files alphabetically up to `clear_scroll.json`.

## Fix

- Extract the inline struct into a named type `Deprecation`
- Implement `json.Unmarshaler` that accepts both object and bool, with the bool form yielding zero-valued fields

Zero-valued `Version` preserves existing behavior in the five call sites that gate on `Deprecated.Version != ""` — a bool-deprecated field simply isn't skipped during generation, matching how the generator treats non-deprecated fields today.

## Scope

Affects only 8.19 right now (9.2/9.3/9.4/main specs still use the object form). Fix is forward-safe: future specs that emit the bool form on any branch will decode cleanly.

Backport targets: 8.19 (the only branch currently blocked on this).

## Test plan

- [x] `cd internal/build && go build ./...` clean
- [x] `cd internal/build && go vet ./...` clean
- [x] Regenerated locally against 8.19 spec — runs to completion with no panic (previously aborted on `clear_scroll.json`)
- [x] Regenerated locally against 9.4 spec — produces identical output to pre-fix (object form path unchanged)
- [ ] CI build passes
- [ ] CI unit tests pass

## Related

- #1405 (8.19 regen blocker)
- Unblocks the 8.19 backport of #548 / `long`→`*int64` regeneration
