### PR TITLE
fix(gen): normalize date URL part and param types to string

### DIFF
--- a/internal/build/cmd/generate/commands/gensource/model.go
+++ b/internal/build/cmd/generate/commands/gensource/model.go
@@ -280,6 +280,11 @@ func NewEndpoint(f io.Reader) (*Endpoint, error) {
 		}
 
 		applyParamOverride(endpoint.Name, name, &param.Type)
+
+		// Date types are handled as strings in the esapi client
+		if param.Type == "date" {
+			param.Type = "string"
+		}
 	}
 
 	if fpath, ok := f.(*os.File); ok {
@@ -303,6 +308,11 @@ func NewEndpoint(f io.Reader) (*Endpoint, error) {
 			part.Endpoint = &endpoint
 			part.Name = partName
 			applyParamOverride(endpoint.Name, partName, &part.Type)
+
+			// Date types are handled as strings in the esapi client
+			if part.Type == "date" {
+				part.Type = "string"
+			}
 		}
 	}
 


### PR DESCRIPTION
## Summary

Backport the date-type-to-string normalization from main to 9.2. Fixes #1404.

## Background

The 9.2 rest-api-spec declares `"type": "date"` for URL parts on `ml.get_buckets` (`timestamp`) and a few other endpoints. The generator's switch statements only handle `string`, `enum`, `list`, `int`, `integer`, `long`, so `date` hits the `default:` branch and panics:

```
panic: FAIL: "ml.get_buckets": unexpected type "date" for URL part "timestamp"
```

This aborts `make gen-api` on 9.2, leaving `esapi/` partially regenerated.

## What main does

On main, `model.go` normalizes `Part.Type == "date"` and `Param.Type == "date"` to `"string"` during endpoint loading, so the generator's switch never sees `date`. The fix landed in the big `feat: Update APIs to 9.3.0` (3c657dad) along with many other changes and was never backported to 9.2.

## Fix

Port the two normalization hunks (one for Parts, one for Params) from main to 9.2. Placed immediately after the existing `applyParamOverride` calls so the blanket normalization sits alongside the legacy per-endpoint overrides.

## Test plan

- [x] `cd internal/build && go build ./...` clean
- [x] Downloaded 9.2.5 spec and ran `make gen-api` locally — runs to completion with no panic (previously aborted on `ml.get_buckets.json`)
- [ ] CI build passes
- [ ] CI unit tests pass

## Related

- Fixes #1404
- Unblocks the 9.2 backport of #548 / `long`→`*int64` regeneration
