### PR TITLE
fix(gen): support *int64 fields in gen-tests output

### DIFF
--- a/esapi/esapi.go
+++ b/esapi/esapi.go
@@ -54,6 +54,13 @@ func BoolPtr(v bool) *bool { return &v }
 // which expects a pointer.
 func IntPtr(v int) *int { return &v }
 
+// Int64Ptr returns a pointer to v.
+//
+// It is used as a convenience function for converting an int64 value
+// into a pointer when passing the value to a function or struct field
+// which expects a pointer.
+func Int64Ptr(v int64) *int64 { return &v }
+
 // formatDuration converts duration to a string in the format
 // accepted by Elasticsearch.
 func formatDuration(d time.Duration) string {

--- a/internal/build/cmd/generate/commands/gentests/generator.go
+++ b/internal/build/cmd/generate/commands/gentests/generator.go
@@ -1294,6 +1294,24 @@ func (g *Generator) genAction(a Action, skipBody ...bool) {
 				}
 				panic(fmt.Sprintf(` + "`" + `Unexpected type %T for ` + v.(string) + "`" + `, ` + v.(string) + `))
 			}()`
+					case "*int64":
+						value = `func() *int64 {
+				switch ` + v.(string) + `.(type) {
+				case int:
+					v := int64(` + v.(string) + `.(int))
+					return &v
+				case int64:
+					v := ` + v.(string) + `.(int64)
+					return &v
+				case float64:
+					v := int64(` + v.(string) + `.(float64))
+					return &v
+				case json.Number:
+					v, _ := ` + v.(string) + `.(encjson.Number).Int64()
+					return &v
+				}
+				panic(fmt.Sprintf(` + "`" + `Unexpected type %T for ` + v.(string) + "`" + `, ` + v.(string) + `))
+			}()`
 					case "time.Duration":
 						value = `fmt.Sprintf("%d", ` + v.(string) + `)`
 					default:
@@ -1359,6 +1377,17 @@ func (g *Generator) genAction(a Action, skipBody ...bool) {
 				case float64:
 					if vv, ok := v.(float64); ok {
 						g.w(`esapi.IntPtr(` + fmt.Sprintf("%d", int(vv)) + `)`)
+					}
+				default:
+					panic(fmt.Sprintf("Unexpected type [%T] for [%s]", v, k))
+				}
+			case "*int64":
+				switch v.(type) {
+				case int:
+					g.w(`esapi.Int64Ptr(` + fmt.Sprintf("%d", v) + `)`)
+				case float64:
+					if vv, ok := v.(float64); ok {
+						g.w(`esapi.Int64Ptr(` + fmt.Sprintf("%d", int64(vv)) + `)`)
 					}
 				default:
 					panic(fmt.Sprintf("Unexpected type [%T] for [%s]", v, k))


### PR DESCRIPTION
## Summary

Add the generator infrastructure needed for `make gen-tests` to produce compiling YAML-driven tests against esapi fields typed `*int64`.

## Background

Since the spec-`long`-to-`*int64` generator fix (#1387) landed and esapi/ was regenerated (#1402, #1403, #1406, #1414, and soon 9.2), ~25 endpoints have `*int64` request fields (`Version`, `IfSeqNo`, `IfPrimaryTerm`, `MaxNumSegments`, etc.). The YAML-driven tests in `esapi/test/` still use `esapi.IntPtr(1)` for those fields and no longer compile:

```
./indices__forcemerge_test.go:703:20:
  cannot use 1 (untyped int constant) as *int64 value in struct literal
```

The tests need to be regenerated, but the test generator has no `*int64` case, and esapi has no `Int64Ptr` helper. This PR supplies both so `make gen-tests` can emit compiling output.

## Changes

- `esapi/esapi.go`: add `Int64Ptr(v int64) *int64`, mirroring the existing `IntPtr`.
- `internal/build/cmd/generate/commands/gentests/generator.go`: add `case "*int64"` in the two sites that currently handle `*int`:
  - Literal-value path → emits `esapi.Int64Ptr(v)`
  - Stash-variable path → emits a small runtime dispatch function returning `*int64`

No tests or `api_registry.gen.go` are regenerated here; that happens in the follow-up rebase of each regen PR (#1402, #1403, #1406, #1414, and the 9.2 PR once it opens), which will run `make gen-tests` to pick up the new output.

## Test plan

- [x] `cd internal/build && go build ./...` clean
- [x] `cd internal/build && go vet ./...` clean
- [ ] CI passes
- [ ] Backport to 9.4, 9.3, 8.19 (and 9.2 once #1415 lands)
- [ ] Rebase the regen PRs with `make gen-tests` included

## Related

- #548 (root issue)
- #1387 (the int64 generator fix that triggered this need)
- #1402, #1403, #1406, #1414 (regen PRs currently failing CI on `esapi/test`)
