### PR TITLE
fix: regenerate esapi with *int64 for long-typed params

### DIFF
--- a/esapi/api._.go
+++ b/esapi/api._.go
@@ -15,7 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 //
-// Code generated from specification version 9.2.0 (3a7bef4): DO NOT EDIT
+// Code generated from specification version 9.2.0 (c26a265): DO NOT EDIT
 
 package esapi
 

--- a/esapi/api.cat.segments.go
+++ b/esapi/api.cat.segments.go
@@ -56,7 +56,7 @@ type CatSegmentsRequest struct {
 	AllowClosed       *bool
 	AllowNoIndices    *bool
 	Bytes             string
-	ExpandWildcards   string
+	ExpandWildcards   []string
 	Format            string
 	H                 []string
 	Help              *bool
@@ -127,8 +127,8 @@ func (r CatSegmentsRequest) Do(providedCtx context.Context, transport Transport)
 		params["bytes"] = r.Bytes
 	}
 
-	if r.ExpandWildcards != "" {
-		params["expand_wildcards"] = r.ExpandWildcards
+	if len(r.ExpandWildcards) > 0 {
+		params["expand_wildcards"] = strings.Join(r.ExpandWildcards, ",")
 	}
 
 	if r.Format != "" {
@@ -278,7 +278,7 @@ func (f CatSegments) WithBytes(v string) func(*CatSegmentsRequest) {
 }
 
 // WithExpandWildcards - whether to expand wildcard expression to concrete indices that are open, closed or both..
-func (f CatSegments) WithExpandWildcards(v string) func(*CatSegmentsRequest) {
+func (f CatSegments) WithExpandWildcards(v ...string) func(*CatSegmentsRequest) {
 	return func(r *CatSegmentsRequest) {
 		r.ExpandWildcards = v
 	}

--- a/esapi/api.cluster.delete_component_template.go
+++ b/esapi/api.cluster.delete_component_template.go
@@ -21,13 +21,14 @@ package esapi
 
 import (
 	"context"
+	"errors"
 	"net/http"
 	"strings"
 	"time"
 )
 
 func newClusterDeleteComponentTemplateFunc(t Transport) ClusterDeleteComponentTemplate {
-	return func(name string, o ...func(*ClusterDeleteComponentTemplateRequest)) (*Response, error) {
+	return func(name []string, o ...func(*ClusterDeleteComponentTemplateRequest)) (*Response, error) {
 		var r = ClusterDeleteComponentTemplateRequest{Name: name}
 		for _, f := range o {
 			f(&r)
@@ -46,11 +47,11 @@ func newClusterDeleteComponentTemplateFunc(t Transport) ClusterDeleteComponentTe
 // ClusterDeleteComponentTemplate delete component templates
 //
 // See full documentation at https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-cluster-put-component-template.
-type ClusterDeleteComponentTemplate func(name string, o ...func(*ClusterDeleteComponentTemplateRequest)) (*Response, error)
+type ClusterDeleteComponentTemplate func(name []string, o ...func(*ClusterDeleteComponentTemplateRequest)) (*Response, error)
 
 // ClusterDeleteComponentTemplateRequest configures the Cluster Delete Component Template API request.
 type ClusterDeleteComponentTemplateRequest struct {
-	Name string
+	Name []string
 
 	MasterTimeout time.Duration
 	Timeout       time.Duration
@@ -86,14 +87,18 @@ func (r ClusterDeleteComponentTemplateRequest) Do(providedCtx context.Context, t
 
 	method = "DELETE"
 
-	path.Grow(7 + 1 + len("_component_template") + 1 + len(r.Name))
+	if len(r.Name) == 0 {
+		return nil, errors.New("name is required and cannot be nil or empty")
+	}
+
+	path.Grow(7 + 1 + len("_component_template") + 1 + len(strings.Join(r.Name, ",")))
 	path.WriteString("http://")
 	path.WriteString("/")
 	path.WriteString("_component_template")
 	path.WriteString("/")
-	path.WriteString(r.Name)
+	path.WriteString(strings.Join(r.Name, ","))
 	if instrument, ok := r.Instrument.(Instrumentation); ok {
-		instrument.RecordPathPart(ctx, "name", r.Name)
+		instrument.RecordPathPart(ctx, "name", strings.Join(r.Name, ","))
 	}
 
 	params = make(map[string]string)

--- a/esapi/api.cluster.exists_component_template.go
+++ b/esapi/api.cluster.exists_component_template.go
@@ -21,6 +21,7 @@ package esapi
 
 import (
 	"context"
+	"errors"
 	"net/http"
 	"strconv"
 	"strings"
@@ -28,7 +29,7 @@ import (
 )
 
 func newClusterExistsComponentTemplateFunc(t Transport) ClusterExistsComponentTemplate {
-	return func(name string, o ...func(*ClusterExistsComponentTemplateRequest)) (*Response, error) {
+	return func(name []string, o ...func(*ClusterExistsComponentTemplateRequest)) (*Response, error) {
 		var r = ClusterExistsComponentTemplateRequest{Name: name}
 		for _, f := range o {
 			f(&r)
@@ -47,11 +48,11 @@ func newClusterExistsComponentTemplateFunc(t Transport) ClusterExistsComponentTe
 // ClusterExistsComponentTemplate check component templates
 //
 // See full documentation at https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-cluster-put-component-template.
-type ClusterExistsComponentTemplate func(name string, o ...func(*ClusterExistsComponentTemplateRequest)) (*Response, error)
+type ClusterExistsComponentTemplate func(name []string, o ...func(*ClusterExistsComponentTemplateRequest)) (*Response, error)
 
 // ClusterExistsComponentTemplateRequest configures the Cluster Exists Component Template API request.
 type ClusterExistsComponentTemplateRequest struct {
-	Name string
+	Name []string
 
 	Local         *bool
 	MasterTimeout time.Duration
@@ -87,14 +88,18 @@ func (r ClusterExistsComponentTemplateRequest) Do(providedCtx context.Context, t
 
 	method = "HEAD"
 
-	path.Grow(7 + 1 + len("_component_template") + 1 + len(r.Name))
+	if len(r.Name) == 0 {
+		return nil, errors.New("name is required and cannot be nil or empty")
+	}
+
+	path.Grow(7 + 1 + len("_component_template") + 1 + len(strings.Join(r.Name, ",")))
 	path.WriteString("http://")
 	path.WriteString("/")
 	path.WriteString("_component_template")
 	path.WriteString("/")
-	path.WriteString(r.Name)
+	path.WriteString(strings.Join(r.Name, ","))
 	if instrument, ok := r.Instrument.(Instrumentation); ok {
-		instrument.RecordPathPart(ctx, "name", r.Name)
+		instrument.RecordPathPart(ctx, "name", strings.Join(r.Name, ","))
 	}
 
 	params = make(map[string]string)

--- a/esapi/api.cluster.get_component_template.go
+++ b/esapi/api.cluster.get_component_template.go
@@ -57,7 +57,7 @@ type ClusterGetComponentTemplateRequest struct {
 	IncludeDefaults *bool
 	Local           *bool
 	MasterTimeout   time.Duration
-	SettingsFilter  string
+	SettingsFilter  []string
 
 	Pretty     bool
 	Human      bool
@@ -120,8 +120,8 @@ func (r ClusterGetComponentTemplateRequest) Do(providedCtx context.Context, tran
 		params["master_timeout"] = formatDuration(r.MasterTimeout)
 	}
 
-	if r.SettingsFilter != "" {
-		params["settings_filter"] = r.SettingsFilter
+	if len(r.SettingsFilter) > 0 {
+		params["settings_filter"] = strings.Join(r.SettingsFilter, ",")
 	}
 
 	if r.Pretty {
@@ -202,7 +202,7 @@ func (f ClusterGetComponentTemplate) WithContext(v context.Context) func(*Cluste
 	}
 }
 
-// WithName - the comma separated names of the component templates.
+// WithName - the name of the component template. wildcard (`*`) expressions are supported..
 func (f ClusterGetComponentTemplate) WithName(v ...string) func(*ClusterGetComponentTemplateRequest) {
 	return func(r *ClusterGetComponentTemplateRequest) {
 		r.Name = v
@@ -238,7 +238,7 @@ func (f ClusterGetComponentTemplate) WithMasterTimeout(v time.Duration) func(*Cl
 }
 
 // WithSettingsFilter - filter out results, for example to filter out sensitive information. supports wildcards or full settings keys.
-func (f ClusterGetComponentTemplate) WithSettingsFilter(v string) func(*ClusterGetComponentTemplateRequest) {
+func (f ClusterGetComponentTemplate) WithSettingsFilter(v ...string) func(*ClusterGetComponentTemplateRequest) {
 	return func(r *ClusterGetComponentTemplateRequest) {
 		r.SettingsFilter = v
 	}

--- a/esapi/api.cluster.post_voting_config_exclusions.go
+++ b/esapi/api.cluster.post_voting_config_exclusions.go
@@ -51,8 +51,8 @@ type ClusterPostVotingConfigExclusions func(o ...func(*ClusterPostVotingConfigEx
 // ClusterPostVotingConfigExclusionsRequest configures the Cluster Post Voting Config Exclusions API request.
 type ClusterPostVotingConfigExclusionsRequest struct {
 	MasterTimeout time.Duration
-	NodeIds       string
-	NodeNames     string
+	NodeIds       []string
+	NodeNames     []string
 	Timeout       time.Duration
 
 	Pretty     bool
@@ -96,12 +96,12 @@ func (r ClusterPostVotingConfigExclusionsRequest) Do(providedCtx context.Context
 		params["master_timeout"] = formatDuration(r.MasterTimeout)
 	}
 
-	if r.NodeIds != "" {
-		params["node_ids"] = r.NodeIds
+	if len(r.NodeIds) > 0 {
+		params["node_ids"] = strings.Join(r.NodeIds, ",")
 	}
 
-	if r.NodeNames != "" {
-		params["node_names"] = r.NodeNames
+	if len(r.NodeNames) > 0 {
+		params["node_names"] = strings.Join(r.NodeNames, ",")
 	}
 
 	if r.Timeout != 0 {
@@ -194,14 +194,14 @@ func (f ClusterPostVotingConfigExclusions) WithMasterTimeout(v time.Duration) fu
 }
 
 // WithNodeIds - a list of the persistent ids of the nodes to exclude from the voting configuration. if specified, you may not also specify ?node_names..
-func (f ClusterPostVotingConfigExclusions) WithNodeIds(v string) func(*ClusterPostVotingConfigExclusionsRequest) {
+func (f ClusterPostVotingConfigExclusions) WithNodeIds(v ...string) func(*ClusterPostVotingConfigExclusionsRequest) {
 	return func(r *ClusterPostVotingConfigExclusionsRequest) {
 		r.NodeIds = v
 	}
 }
 
 // WithNodeNames - a list of the names of the nodes to exclude from the voting configuration. if specified, you may not also specify ?node_ids..
-func (f ClusterPostVotingConfigExclusions) WithNodeNames(v string) func(*ClusterPostVotingConfigExclusionsRequest) {
+func (f ClusterPostVotingConfigExclusions) WithNodeNames(v ...string) func(*ClusterPostVotingConfigExclusionsRequest) {
 	return func(r *ClusterPostVotingConfigExclusionsRequest) {
 		r.NodeNames = v
 	}

--- a/esapi/api.cluster.put_settings.go
+++ b/esapi/api.cluster.put_settings.go
@@ -192,7 +192,7 @@ func (f ClusterPutSettings) WithContext(v context.Context) func(*ClusterPutSetti
 	}
 }
 
-// WithFlatSettings - return settings in flat format (default: false).
+// WithFlatSettings - return settings in flat format.
 func (f ClusterPutSettings) WithFlatSettings(v bool) func(*ClusterPutSettingsRequest) {
 	return func(r *ClusterPutSettingsRequest) {
 		r.FlatSettings = &v

--- a/esapi/api.cluster.state.go
+++ b/esapi/api.cluster.state.go
@@ -61,7 +61,7 @@ type ClusterStateRequest struct {
 	IgnoreUnavailable      *bool
 	Local                  *bool
 	MasterTimeout          time.Duration
-	WaitForMetadataVersion *int
+	WaitForMetadataVersion *int64
 	WaitForTimeout         time.Duration
 
 	Pretty     bool
@@ -143,7 +143,7 @@ func (r ClusterStateRequest) Do(providedCtx context.Context, transport Transport
 	}
 
 	if r.WaitForMetadataVersion != nil {
-		params["wait_for_metadata_version"] = strconv.FormatInt(int64(*r.WaitForMetadataVersion), 10)
+		params["wait_for_metadata_version"] = strconv.FormatInt(*r.WaitForMetadataVersion, 10)
 	}
 
 	if r.WaitForTimeout != 0 {
@@ -285,7 +285,7 @@ func (f ClusterState) WithMasterTimeout(v time.Duration) func(*ClusterStateReque
 }
 
 // WithWaitForMetadataVersion - wait for the metadata version to be equal or greater than the specified metadata version.
-func (f ClusterState) WithWaitForMetadataVersion(v int) func(*ClusterStateRequest) {
+func (f ClusterState) WithWaitForMetadataVersion(v int64) func(*ClusterStateRequest) {
 	return func(r *ClusterStateRequest) {
 		r.WaitForMetadataVersion = &v
 	}

--- a/esapi/api.connector.sync_job_list.go
+++ b/esapi/api.connector.sync_job_list.go
@@ -221,7 +221,7 @@ func (f ConnectorSyncJobList) WithSize(v int) func(*ConnectorSyncJobListRequest)
 	}
 }
 
-// WithStatus - sync job status, which sync jobs are fetched for.
+// WithStatus - a sync job status to fetch connector sync jobs for.
 func (f ConnectorSyncJobList) WithStatus(v string) func(*ConnectorSyncJobListRequest) {
 	return func(r *ConnectorSyncJobListRequest) {
 		r.Status = v

--- a/esapi/api.count.go
+++ b/esapi/api.count.go
@@ -70,7 +70,7 @@ type CountRequest struct {
 	ProjectRouting    string
 	Query             string
 	Routing           []string
-	TerminateAfter    *int
+	TerminateAfter    *int64
 
 	Pretty     bool
 	Human      bool
@@ -174,7 +174,7 @@ func (r CountRequest) Do(providedCtx context.Context, transport Transport) (*Res
 	}
 
 	if r.TerminateAfter != nil {
-		params["terminate_after"] = strconv.FormatInt(int64(*r.TerminateAfter), 10)
+		params["terminate_after"] = strconv.FormatInt(*r.TerminateAfter, 10)
 	}
 
 	if r.Pretty {
@@ -375,7 +375,7 @@ func (f Count) WithRouting(v ...string) func(*CountRequest) {
 }
 
 // WithTerminateAfter - the maximum count for each shard, upon reaching which the query execution will terminate early.
-func (f Count) WithTerminateAfter(v int) func(*CountRequest) {
+func (f Count) WithTerminateAfter(v int64) func(*CountRequest) {
 	return func(r *CountRequest) {
 		r.TerminateAfter = &v
 	}

--- a/esapi/api.create.go
+++ b/esapi/api.create.go
@@ -64,7 +64,7 @@ type CreateRequest struct {
 	RequireDataStream    *bool
 	Routing              string
 	Timeout              time.Duration
-	Version              *int
+	Version              *int64
 	VersionType          string
 	WaitForActiveShards  string
 
@@ -145,7 +145,7 @@ func (r CreateRequest) Do(providedCtx context.Context, transport Transport) (*Re
 	}
 
 	if r.Version != nil {
-		params["version"] = strconv.FormatInt(int64(*r.Version), 10)
+		params["version"] = strconv.FormatInt(*r.Version, 10)
 	}
 
 	if r.VersionType != "" {
@@ -291,7 +291,7 @@ func (f Create) WithTimeout(v time.Duration) func(*CreateRequest) {
 }
 
 // WithVersion - explicit version number for concurrency control.
-func (f Create) WithVersion(v int) func(*CreateRequest) {
+func (f Create) WithVersion(v int64) func(*CreateRequest) {
 	return func(r *CreateRequest) {
 		r.Version = &v
 	}

--- a/esapi/api.delete.go
+++ b/esapi/api.delete.go
@@ -54,12 +54,12 @@ type DeleteRequest struct {
 	Index      string
 	DocumentID string
 
-	IfPrimaryTerm       *int
-	IfSeqNo             *int
+	IfPrimaryTerm       *int64
+	IfSeqNo             *int64
 	Refresh             string
 	Routing             string
 	Timeout             time.Duration
-	Version             *int
+	Version             *int64
 	VersionType         string
 	WaitForActiveShards string
 
@@ -112,11 +112,11 @@ func (r DeleteRequest) Do(providedCtx context.Context, transport Transport) (*Re
 	params = make(map[string]string)
 
 	if r.IfPrimaryTerm != nil {
-		params["if_primary_term"] = strconv.FormatInt(int64(*r.IfPrimaryTerm), 10)
+		params["if_primary_term"] = strconv.FormatInt(*r.IfPrimaryTerm, 10)
 	}
 
 	if r.IfSeqNo != nil {
-		params["if_seq_no"] = strconv.FormatInt(int64(*r.IfSeqNo), 10)
+		params["if_seq_no"] = strconv.FormatInt(*r.IfSeqNo, 10)
 	}
 
 	if r.Refresh != "" {
@@ -132,7 +132,7 @@ func (r DeleteRequest) Do(providedCtx context.Context, transport Transport) (*Re
 	}
 
 	if r.Version != nil {
-		params["version"] = strconv.FormatInt(int64(*r.Version), 10)
+		params["version"] = strconv.FormatInt(*r.Version, 10)
 	}
 
 	if r.VersionType != "" {
@@ -222,14 +222,14 @@ func (f Delete) WithContext(v context.Context) func(*DeleteRequest) {
 }
 
 // WithIfPrimaryTerm - only perform the delete operation if the last operation that has changed the document has the specified primary term.
-func (f Delete) WithIfPrimaryTerm(v int) func(*DeleteRequest) {
+func (f Delete) WithIfPrimaryTerm(v int64) func(*DeleteRequest) {
 	return func(r *DeleteRequest) {
 		r.IfPrimaryTerm = &v
 	}
 }
 
 // WithIfSeqNo - only perform the delete operation if the last operation that has changed the document has the specified sequence number.
-func (f Delete) WithIfSeqNo(v int) func(*DeleteRequest) {
+func (f Delete) WithIfSeqNo(v int64) func(*DeleteRequest) {
 	return func(r *DeleteRequest) {
 		r.IfSeqNo = &v
 	}
@@ -257,7 +257,7 @@ func (f Delete) WithTimeout(v time.Duration) func(*DeleteRequest) {
 }
 
 // WithVersion - explicit version number for concurrency control.
-func (f Delete) WithVersion(v int) func(*DeleteRequest) {
+func (f Delete) WithVersion(v int64) func(*DeleteRequest) {
 	return func(r *DeleteRequest) {
 		r.Version = &v
 	}

--- a/esapi/api.delete_by_query.go
+++ b/esapi/api.delete_by_query.go
@@ -65,10 +65,10 @@ type DeleteByQueryRequest struct {
 	DefaultOperator     string
 	Df                  string
 	ExpandWildcards     string
-	From                *int
+	From                *int64
 	IgnoreUnavailable   *bool
 	Lenient             *bool
-	MaxDocs             *int
+	MaxDocs             *int64
 	Preference          string
 	Query               string
 	Refresh             *bool
@@ -76,13 +76,13 @@ type DeleteByQueryRequest struct {
 	RequestsPerSecond   *int
 	Routing             []string
 	Scroll              time.Duration
-	ScrollSize          *int
+	ScrollSize          *int64
 	SearchTimeout       time.Duration
 	SearchType          string
 	Slices              interface{}
 	Sort                []string
 	Stats               []string
-	TerminateAfter      *int
+	TerminateAfter      *int64
 	Timeout             time.Duration
 	Version             *bool
 	WaitForActiveShards string
@@ -164,7 +164,7 @@ func (r DeleteByQueryRequest) Do(providedCtx context.Context, transport Transpor
 	}
 
 	if r.From != nil {
-		params["from"] = strconv.FormatInt(int64(*r.From), 10)
+		params["from"] = strconv.FormatInt(*r.From, 10)
 	}
 
 	if r.IgnoreUnavailable != nil {
@@ -176,7 +176,7 @@ func (r DeleteByQueryRequest) Do(providedCtx context.Context, transport Transpor
 	}
 
 	if r.MaxDocs != nil {
-		params["max_docs"] = strconv.FormatInt(int64(*r.MaxDocs), 10)
+		params["max_docs"] = strconv.FormatInt(*r.MaxDocs, 10)
 	}
 
 	if r.Preference != "" {
@@ -208,7 +208,7 @@ func (r DeleteByQueryRequest) Do(providedCtx context.Context, transport Transpor
 	}
 
 	if r.ScrollSize != nil {
-		params["scroll_size"] = strconv.FormatInt(int64(*r.ScrollSize), 10)
+		params["scroll_size"] = strconv.FormatInt(*r.ScrollSize, 10)
 	}
 
 	if r.SearchTimeout != 0 {
@@ -232,7 +232,7 @@ func (r DeleteByQueryRequest) Do(providedCtx context.Context, transport Transpor
 	}
 
 	if r.TerminateAfter != nil {
-		params["terminate_after"] = strconv.FormatInt(int64(*r.TerminateAfter), 10)
+		params["terminate_after"] = strconv.FormatInt(*r.TerminateAfter, 10)
 	}
 
 	if r.Timeout != 0 {
@@ -386,7 +386,7 @@ func (f DeleteByQuery) WithExpandWildcards(v string) func(*DeleteByQueryRequest)
 }
 
 // WithFrom - starting offset (default: 0).
-func (f DeleteByQuery) WithFrom(v int) func(*DeleteByQueryRequest) {
+func (f DeleteByQuery) WithFrom(v int64) func(*DeleteByQueryRequest) {
 	return func(r *DeleteByQueryRequest) {
 		r.From = &v
 	}
@@ -407,7 +407,7 @@ func (f DeleteByQuery) WithLenient(v bool) func(*DeleteByQueryRequest) {
 }
 
 // WithMaxDocs - maximum number of documents to process (default: all documents).
-func (f DeleteByQuery) WithMaxDocs(v int) func(*DeleteByQueryRequest) {
+func (f DeleteByQuery) WithMaxDocs(v int64) func(*DeleteByQueryRequest) {
 	return func(r *DeleteByQueryRequest) {
 		r.MaxDocs = &v
 	}
@@ -463,7 +463,7 @@ func (f DeleteByQuery) WithScroll(v time.Duration) func(*DeleteByQueryRequest) {
 }
 
 // WithScrollSize - size on the scroll request powering the delete by query.
-func (f DeleteByQuery) WithScrollSize(v int) func(*DeleteByQueryRequest) {
+func (f DeleteByQuery) WithScrollSize(v int64) func(*DeleteByQueryRequest) {
 	return func(r *DeleteByQueryRequest) {
 		r.ScrollSize = &v
 	}
@@ -505,7 +505,7 @@ func (f DeleteByQuery) WithStats(v ...string) func(*DeleteByQueryRequest) {
 }
 
 // WithTerminateAfter - the maximum number of documents to collect for each shard, upon reaching which the query execution will terminate early..
-func (f DeleteByQuery) WithTerminateAfter(v int) func(*DeleteByQueryRequest) {
+func (f DeleteByQuery) WithTerminateAfter(v int64) func(*DeleteByQueryRequest) {
 	return func(r *DeleteByQueryRequest) {
 		r.TerminateAfter = &v
 	}

--- a/esapi/api.exists.go
+++ b/esapi/api.exists.go
@@ -61,7 +61,7 @@ type ExistsRequest struct {
 	SourceExcludes []string
 	SourceIncludes []string
 	StoredFields   []string
-	Version        *int
+	Version        *int64
 	VersionType    string
 
 	Pretty     bool
@@ -145,7 +145,7 @@ func (r ExistsRequest) Do(providedCtx context.Context, transport Transport) (*Re
 	}
 
 	if r.Version != nil {
-		params["version"] = strconv.FormatInt(int64(*r.Version), 10)
+		params["version"] = strconv.FormatInt(*r.Version, 10)
 	}
 
 	if r.VersionType != "" {
@@ -287,7 +287,7 @@ func (f Exists) WithStoredFields(v ...string) func(*ExistsRequest) {
 }
 
 // WithVersion - explicit version number for concurrency control.
-func (f Exists) WithVersion(v int) func(*ExistsRequest) {
+func (f Exists) WithVersion(v int64) func(*ExistsRequest) {
 	return func(r *ExistsRequest) {
 		r.Version = &v
 	}

--- a/esapi/api.exists_source.go
+++ b/esapi/api.exists_source.go
@@ -60,7 +60,7 @@ type ExistsSourceRequest struct {
 	Source         []string
 	SourceExcludes []string
 	SourceIncludes []string
-	Version        *int
+	Version        *int64
 	VersionType    string
 
 	Pretty     bool
@@ -140,7 +140,7 @@ func (r ExistsSourceRequest) Do(providedCtx context.Context, transport Transport
 	}
 
 	if r.Version != nil {
-		params["version"] = strconv.FormatInt(int64(*r.Version), 10)
+		params["version"] = strconv.FormatInt(*r.Version, 10)
 	}
 
 	if r.VersionType != "" {
@@ -275,7 +275,7 @@ func (f ExistsSource) WithSourceIncludes(v ...string) func(*ExistsSourceRequest)
 }
 
 // WithVersion - explicit version number for concurrency control.
-func (f ExistsSource) WithVersion(v int) func(*ExistsSourceRequest) {
+func (f ExistsSource) WithVersion(v int64) func(*ExistsSourceRequest) {
 	return func(r *ExistsSourceRequest) {
 		r.Version = &v
 	}

--- a/esapi/api.get.go
+++ b/esapi/api.get.go
@@ -63,7 +63,7 @@ type GetRequest struct {
 	SourceExcludes       []string
 	SourceIncludes       []string
 	StoredFields         []string
-	Version              *int
+	Version              *int64
 	VersionType          string
 
 	Pretty     bool
@@ -155,7 +155,7 @@ func (r GetRequest) Do(providedCtx context.Context, transport Transport) (*Respo
 	}
 
 	if r.Version != nil {
-		params["version"] = strconv.FormatInt(int64(*r.Version), 10)
+		params["version"] = strconv.FormatInt(*r.Version, 10)
 	}
 
 	if r.VersionType != "" {
@@ -311,7 +311,7 @@ func (f Get) WithStoredFields(v ...string) func(*GetRequest) {
 }
 
 // WithVersion - explicit version number for concurrency control.
-func (f Get) WithVersion(v int) func(*GetRequest) {
+func (f Get) WithVersion(v int64) func(*GetRequest) {
 	return func(r *GetRequest) {
 		r.Version = &v
 	}

--- a/esapi/api.get_source.go
+++ b/esapi/api.get_source.go
@@ -60,7 +60,7 @@ type GetSourceRequest struct {
 	Source         []string
 	SourceExcludes []string
 	SourceIncludes []string
-	Version        *int
+	Version        *int64
 	VersionType    string
 
 	Pretty     bool
@@ -140,7 +140,7 @@ func (r GetSourceRequest) Do(providedCtx context.Context, transport Transport) (
 	}
 
 	if r.Version != nil {
-		params["version"] = strconv.FormatInt(int64(*r.Version), 10)
+		params["version"] = strconv.FormatInt(*r.Version, 10)
 	}
 
 	if r.VersionType != "" {
@@ -275,7 +275,7 @@ func (f GetSource) WithSourceIncludes(v ...string) func(*GetSourceRequest) {
 }
 
 // WithVersion - explicit version number for concurrency control.
-func (f GetSource) WithVersion(v int) func(*GetSourceRequest) {
+func (f GetSource) WithVersion(v int64) func(*GetSourceRequest) {
 	return func(r *GetSourceRequest) {
 		r.Version = &v
 	}

--- a/esapi/api.health_report.go
+++ b/esapi/api.health_report.go
@@ -51,7 +51,7 @@ type HealthReport func(o ...func(*HealthReportRequest)) (*Response, error)
 
 // HealthReportRequest configures the Health Report API request.
 type HealthReportRequest struct {
-	Feature string
+	Feature []string
 
 	Size    *int
 	Timeout time.Duration
@@ -88,15 +88,15 @@ func (r HealthReportRequest) Do(providedCtx context.Context, transport Transport
 
 	method = "GET"
 
-	path.Grow(7 + 1 + len("_health_report") + 1 + len(r.Feature))
+	path.Grow(7 + 1 + len("_health_report") + 1 + len(strings.Join(r.Feature, ",")))
 	path.WriteString("http://")
 	path.WriteString("/")
 	path.WriteString("_health_report")
-	if r.Feature != "" {
+	if len(r.Feature) > 0 {
 		path.WriteString("/")
-		path.WriteString(r.Feature)
+		path.WriteString(strings.Join(r.Feature, ","))
 		if instrument, ok := r.Instrument.(Instrumentation); ok {
-			instrument.RecordPathPart(ctx, "feature", r.Feature)
+			instrument.RecordPathPart(ctx, "feature", strings.Join(r.Feature, ","))
 		}
 	}
 
@@ -192,8 +192,8 @@ func (f HealthReport) WithContext(v context.Context) func(*HealthReportRequest) 
 	}
 }
 
-// WithFeature - a feature of the cluster, as returned by the top-level health api.
-func (f HealthReport) WithFeature(v string) func(*HealthReportRequest) {
+// WithFeature - comma-separated list of cluster features, as returned by the top-level health report api..
+func (f HealthReport) WithFeature(v ...string) func(*HealthReportRequest) {
 	return func(r *HealthReportRequest) {
 		r.Feature = v
 	}

--- a/esapi/api.index.go
+++ b/esapi/api.index.go
@@ -57,8 +57,8 @@ type IndexRequest struct {
 
 	Body io.Reader
 
-	IfPrimaryTerm        *int
-	IfSeqNo              *int
+	IfPrimaryTerm        *int64
+	IfSeqNo              *int64
 	IncludeSourceOnError *bool
 	OpType               string
 	Pipeline             string
@@ -67,7 +67,7 @@ type IndexRequest struct {
 	RequireDataStream    *bool
 	Routing              string
 	Timeout              time.Duration
-	Version              *int
+	Version              *int64
 	VersionType          string
 	WaitForActiveShards  string
 
@@ -126,11 +126,11 @@ func (r IndexRequest) Do(providedCtx context.Context, transport Transport) (*Res
 	params = make(map[string]string)
 
 	if r.IfPrimaryTerm != nil {
-		params["if_primary_term"] = strconv.FormatInt(int64(*r.IfPrimaryTerm), 10)
+		params["if_primary_term"] = strconv.FormatInt(*r.IfPrimaryTerm, 10)
 	}
 
 	if r.IfSeqNo != nil {
-		params["if_seq_no"] = strconv.FormatInt(int64(*r.IfSeqNo), 10)
+		params["if_seq_no"] = strconv.FormatInt(*r.IfSeqNo, 10)
 	}
 
 	if r.IncludeSourceOnError != nil {
@@ -166,7 +166,7 @@ func (r IndexRequest) Do(providedCtx context.Context, transport Transport) (*Res
 	}
 
 	if r.Version != nil {
-		params["version"] = strconv.FormatInt(int64(*r.Version), 10)
+		params["version"] = strconv.FormatInt(*r.Version, 10)
 	}
 
 	if r.VersionType != "" {
@@ -270,14 +270,14 @@ func (f Index) WithDocumentID(v string) func(*IndexRequest) {
 }
 
 // WithIfPrimaryTerm - only perform the index operation if the last operation that has changed the document has the specified primary term.
-func (f Index) WithIfPrimaryTerm(v int) func(*IndexRequest) {
+func (f Index) WithIfPrimaryTerm(v int64) func(*IndexRequest) {
 	return func(r *IndexRequest) {
 		r.IfPrimaryTerm = &v
 	}
 }
 
 // WithIfSeqNo - only perform the index operation if the last operation that has changed the document has the specified sequence number.
-func (f Index) WithIfSeqNo(v int) func(*IndexRequest) {
+func (f Index) WithIfSeqNo(v int64) func(*IndexRequest) {
 	return func(r *IndexRequest) {
 		r.IfSeqNo = &v
 	}
@@ -340,7 +340,7 @@ func (f Index) WithTimeout(v time.Duration) func(*IndexRequest) {
 }
 
 // WithVersion - explicit version number for concurrency control.
-func (f Index) WithVersion(v int) func(*IndexRequest) {
+func (f Index) WithVersion(v int64) func(*IndexRequest) {
 	return func(r *IndexRequest) {
 		r.Version = &v
 	}

--- a/esapi/api.indices.cancel_migrate_reindex.go
+++ b/esapi/api.indices.cancel_migrate_reindex.go
@@ -21,12 +21,13 @@ package esapi
 
 import (
 	"context"
+	"errors"
 	"net/http"
 	"strings"
 )
 
 func newIndicesCancelMigrateReindexFunc(t Transport) IndicesCancelMigrateReindex {
-	return func(index string, o ...func(*IndicesCancelMigrateReindexRequest)) (*Response, error) {
+	return func(index []string, o ...func(*IndicesCancelMigrateReindexRequest)) (*Response, error) {
 		var r = IndicesCancelMigrateReindexRequest{Index: index}
 		for _, f := range o {
 			f(&r)
@@ -45,11 +46,11 @@ func newIndicesCancelMigrateReindexFunc(t Transport) IndicesCancelMigrateReindex
 // IndicesCancelMigrateReindex cancel a migration reindex operation
 //
 // See full documentation at https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-indices-cancel-migrate-reindex.
-type IndicesCancelMigrateReindex func(index string, o ...func(*IndicesCancelMigrateReindexRequest)) (*Response, error)
+type IndicesCancelMigrateReindex func(index []string, o ...func(*IndicesCancelMigrateReindexRequest)) (*Response, error)
 
 // IndicesCancelMigrateReindexRequest configures the Indices Cancel Migrate Reindex API request.
 type IndicesCancelMigrateReindexRequest struct {
-	Index string
+	Index []string
 
 	Pretty     bool
 	Human      bool
@@ -82,16 +83,20 @@ func (r IndicesCancelMigrateReindexRequest) Do(providedCtx context.Context, tran
 
 	method = "POST"
 
-	path.Grow(7 + 1 + len("_migration") + 1 + len("reindex") + 1 + len(r.Index) + 1 + len("_cancel"))
+	if len(r.Index) == 0 {
+		return nil, errors.New("index is required and cannot be nil or empty")
+	}
+
+	path.Grow(7 + 1 + len("_migration") + 1 + len("reindex") + 1 + len(strings.Join(r.Index, ",")) + 1 + len("_cancel"))
 	path.WriteString("http://")
 	path.WriteString("/")
 	path.WriteString("_migration")
 	path.WriteString("/")
 	path.WriteString("reindex")
 	path.WriteString("/")
-	path.WriteString(r.Index)
+	path.WriteString(strings.Join(r.Index, ","))
 	if instrument, ok := r.Instrument.(Instrumentation); ok {
-		instrument.RecordPathPart(ctx, "index", r.Index)
+		instrument.RecordPathPart(ctx, "index", strings.Join(r.Index, ","))
 	}
 	path.WriteString("/")
 	path.WriteString("_cancel")

--- a/esapi/api.indices.delete_index_template.go
+++ b/esapi/api.indices.delete_index_template.go
@@ -21,13 +21,14 @@ package esapi
 
 import (
 	"context"
+	"errors"
 	"net/http"
 	"strings"
 	"time"
 )
 
 func newIndicesDeleteIndexTemplateFunc(t Transport) IndicesDeleteIndexTemplate {
-	return func(name string, o ...func(*IndicesDeleteIndexTemplateRequest)) (*Response, error) {
+	return func(name []string, o ...func(*IndicesDeleteIndexTemplateRequest)) (*Response, error) {
 		var r = IndicesDeleteIndexTemplateRequest{Name: name}
 		for _, f := range o {
 			f(&r)
@@ -46,11 +47,11 @@ func newIndicesDeleteIndexTemplateFunc(t Transport) IndicesDeleteIndexTemplate {
 // IndicesDeleteIndexTemplate delete an index template
 //
 // See full documentation at https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-indices-delete-index-template.
-type IndicesDeleteIndexTemplate func(name string, o ...func(*IndicesDeleteIndexTemplateRequest)) (*Response, error)
+type IndicesDeleteIndexTemplate func(name []string, o ...func(*IndicesDeleteIndexTemplateRequest)) (*Response, error)
 
 // IndicesDeleteIndexTemplateRequest configures the Indices Delete Index Template API request.
 type IndicesDeleteIndexTemplateRequest struct {
-	Name string
+	Name []string
 
 	MasterTimeout time.Duration
 	Timeout       time.Duration
@@ -86,14 +87,18 @@ func (r IndicesDeleteIndexTemplateRequest) Do(providedCtx context.Context, trans
 
 	method = "DELETE"
 
-	path.Grow(7 + 1 + len("_index_template") + 1 + len(r.Name))
+	if len(r.Name) == 0 {
+		return nil, errors.New("name is required and cannot be nil or empty")
+	}
+
+	path.Grow(7 + 1 + len("_index_template") + 1 + len(strings.Join(r.Name, ",")))
 	path.WriteString("http://")
 	path.WriteString("/")
 	path.WriteString("_index_template")
 	path.WriteString("/")
-	path.WriteString(r.Name)
+	path.WriteString(strings.Join(r.Name, ","))
 	if instrument, ok := r.Instrument.(Instrumentation); ok {
-		instrument.RecordPathPart(ctx, "name", r.Name)
+		instrument.RecordPathPart(ctx, "name", strings.Join(r.Name, ","))
 	}
 
 	params = make(map[string]string)

--- a/esapi/api.indices.disk_usage.go
+++ b/esapi/api.indices.disk_usage.go
@@ -21,13 +21,14 @@ package esapi
 
 import (
 	"context"
+	"errors"
 	"net/http"
 	"strconv"
 	"strings"
 )
 
 func newIndicesDiskUsageFunc(t Transport) IndicesDiskUsage {
-	return func(index string, o ...func(*IndicesDiskUsageRequest)) (*Response, error) {
+	return func(index []string, o ...func(*IndicesDiskUsageRequest)) (*Response, error) {
 		var r = IndicesDiskUsageRequest{Index: index}
 		for _, f := range o {
 			f(&r)
@@ -48,11 +49,11 @@ func newIndicesDiskUsageFunc(t Transport) IndicesDiskUsage {
 // This API is experimental.
 //
 // See full documentation at https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-indices-disk-usage.
-type IndicesDiskUsage func(index string, o ...func(*IndicesDiskUsageRequest)) (*Response, error)
+type IndicesDiskUsage func(index []string, o ...func(*IndicesDiskUsageRequest)) (*Response, error)
 
 // IndicesDiskUsageRequest configures the Indices Disk Usage API request.
 type IndicesDiskUsageRequest struct {
-	Index string
+	Index []string
 
 	AllowNoIndices    *bool
 	ExpandWildcards   string
@@ -91,12 +92,16 @@ func (r IndicesDiskUsageRequest) Do(providedCtx context.Context, transport Trans
 
 	method = "POST"
 
-	path.Grow(7 + 1 + len(r.Index) + 1 + len("_disk_usage"))
+	if len(r.Index) == 0 {
+		return nil, errors.New("index is required and cannot be nil or empty")
+	}
+
+	path.Grow(7 + 1 + len(strings.Join(r.Index, ",")) + 1 + len("_disk_usage"))
 	path.WriteString("http://")
 	path.WriteString("/")
-	path.WriteString(r.Index)
+	path.WriteString(strings.Join(r.Index, ","))
 	if instrument, ok := r.Instrument.(Instrumentation); ok {
-		instrument.RecordPathPart(ctx, "index", r.Index)
+		instrument.RecordPathPart(ctx, "index", strings.Join(r.Index, ","))
 	}
 	path.WriteString("/")
 	path.WriteString("_disk_usage")

--- a/esapi/api.indices.explain_data_lifecycle.go
+++ b/esapi/api.indices.explain_data_lifecycle.go
@@ -21,6 +21,7 @@ package esapi
 
 import (
 	"context"
+	"errors"
 	"net/http"
 	"strconv"
 	"strings"
@@ -28,7 +29,7 @@ import (
 )
 
 func newIndicesExplainDataLifecycleFunc(t Transport) IndicesExplainDataLifecycle {
-	return func(index string, o ...func(*IndicesExplainDataLifecycleRequest)) (*Response, error) {
+	return func(index []string, o ...func(*IndicesExplainDataLifecycleRequest)) (*Response, error) {
 		var r = IndicesExplainDataLifecycleRequest{Index: index}
 		for _, f := range o {
 			f(&r)
@@ -47,11 +48,11 @@ func newIndicesExplainDataLifecycleFunc(t Transport) IndicesExplainDataLifecycle
 // IndicesExplainDataLifecycle get the status for a data stream lifecycle
 //
 // See full documentation at https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-indices-explain-data-lifecycle.
-type IndicesExplainDataLifecycle func(index string, o ...func(*IndicesExplainDataLifecycleRequest)) (*Response, error)
+type IndicesExplainDataLifecycle func(index []string, o ...func(*IndicesExplainDataLifecycleRequest)) (*Response, error)
 
 // IndicesExplainDataLifecycleRequest configures the Indices Explain Data Lifecycle API request.
 type IndicesExplainDataLifecycleRequest struct {
-	Index string
+	Index []string
 
 	IncludeDefaults *bool
 	MasterTimeout   time.Duration
@@ -87,12 +88,16 @@ func (r IndicesExplainDataLifecycleRequest) Do(providedCtx context.Context, tran
 
 	method = "GET"
 
-	path.Grow(7 + 1 + len(r.Index) + 1 + len("_lifecycle") + 1 + len("explain"))
+	if len(r.Index) == 0 {
+		return nil, errors.New("index is required and cannot be nil or empty")
+	}
+
+	path.Grow(7 + 1 + len(strings.Join(r.Index, ",")) + 1 + len("_lifecycle") + 1 + len("explain"))
 	path.WriteString("http://")
 	path.WriteString("/")
-	path.WriteString(r.Index)
+	path.WriteString(strings.Join(r.Index, ","))
 	if instrument, ok := r.Instrument.(Instrumentation); ok {
-		instrument.RecordPathPart(ctx, "index", r.Index)
+		instrument.RecordPathPart(ctx, "index", strings.Join(r.Index, ","))
 	}
 	path.WriteString("/")
 	path.WriteString("_lifecycle")

--- a/esapi/api.indices.field_usage_stats.go
+++ b/esapi/api.indices.field_usage_stats.go
@@ -21,13 +21,14 @@ package esapi
 
 import (
 	"context"
+	"errors"
 	"net/http"
 	"strconv"
 	"strings"
 )
 
 func newIndicesFieldUsageStatsFunc(t Transport) IndicesFieldUsageStats {
-	return func(index string, o ...func(*IndicesFieldUsageStatsRequest)) (*Response, error) {
+	return func(index []string, o ...func(*IndicesFieldUsageStatsRequest)) (*Response, error) {
 		var r = IndicesFieldUsageStatsRequest{Index: index}
 		for _, f := range o {
 			f(&r)
@@ -48,11 +49,11 @@ func newIndicesFieldUsageStatsFunc(t Transport) IndicesFieldUsageStats {
 // This API is experimental.
 //
 // See full documentation at https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-indices-field-usage-stats.
-type IndicesFieldUsageStats func(index string, o ...func(*IndicesFieldUsageStatsRequest)) (*Response, error)
+type IndicesFieldUsageStats func(index []string, o ...func(*IndicesFieldUsageStatsRequest)) (*Response, error)
 
 // IndicesFieldUsageStatsRequest configures the Indices Field Usage Stats API request.
 type IndicesFieldUsageStatsRequest struct {
-	Index string
+	Index []string
 
 	AllowNoIndices    *bool
 	ExpandWildcards   string
@@ -90,12 +91,16 @@ func (r IndicesFieldUsageStatsRequest) Do(providedCtx context.Context, transport
 
 	method = "GET"
 
-	path.Grow(7 + 1 + len(r.Index) + 1 + len("_field_usage_stats"))
+	if len(r.Index) == 0 {
+		return nil, errors.New("index is required and cannot be nil or empty")
+	}
+
+	path.Grow(7 + 1 + len(strings.Join(r.Index, ",")) + 1 + len("_field_usage_stats"))
 	path.WriteString("http://")
 	path.WriteString("/")
-	path.WriteString(r.Index)
+	path.WriteString(strings.Join(r.Index, ","))
 	if instrument, ok := r.Instrument.(Instrumentation); ok {
-		instrument.RecordPathPart(ctx, "index", r.Index)
+		instrument.RecordPathPart(ctx, "index", strings.Join(r.Index, ","))
 	}
 	path.WriteString("/")
 	path.WriteString("_field_usage_stats")

--- a/esapi/api.indices.forcemerge.go
+++ b/esapi/api.indices.forcemerge.go
@@ -56,7 +56,7 @@ type IndicesForcemergeRequest struct {
 	ExpandWildcards    string
 	Flush              *bool
 	IgnoreUnavailable  *bool
-	MaxNumSegments     *int
+	MaxNumSegments     *int64
 	OnlyExpungeDeletes *bool
 	WaitForCompletion  *bool
 
@@ -122,7 +122,7 @@ func (r IndicesForcemergeRequest) Do(providedCtx context.Context, transport Tran
 	}
 
 	if r.MaxNumSegments != nil {
-		params["max_num_segments"] = strconv.FormatInt(int64(*r.MaxNumSegments), 10)
+		params["max_num_segments"] = strconv.FormatInt(*r.MaxNumSegments, 10)
 	}
 
 	if r.OnlyExpungeDeletes != nil {
@@ -247,7 +247,7 @@ func (f IndicesForcemerge) WithIgnoreUnavailable(v bool) func(*IndicesForcemerge
 }
 
 // WithMaxNumSegments - the number of segments the index should be merged into (default: dynamic).
-func (f IndicesForcemerge) WithMaxNumSegments(v int) func(*IndicesForcemergeRequest) {
+func (f IndicesForcemerge) WithMaxNumSegments(v int64) func(*IndicesForcemergeRequest) {
 	return func(r *IndicesForcemergeRequest) {
 		r.MaxNumSegments = &v
 	}

--- a/esapi/api.indices.get_migrate_reindex_status.go
+++ b/esapi/api.indices.get_migrate_reindex_status.go
@@ -21,12 +21,13 @@ package esapi
 
 import (
 	"context"
+	"errors"
 	"net/http"
 	"strings"
 )
 
 func newIndicesGetMigrateReindexStatusFunc(t Transport) IndicesGetMigrateReindexStatus {
-	return func(index string, o ...func(*IndicesGetMigrateReindexStatusRequest)) (*Response, error) {
+	return func(index []string, o ...func(*IndicesGetMigrateReindexStatusRequest)) (*Response, error) {
 		var r = IndicesGetMigrateReindexStatusRequest{Index: index}
 		for _, f := range o {
 			f(&r)
@@ -45,11 +46,11 @@ func newIndicesGetMigrateReindexStatusFunc(t Transport) IndicesGetMigrateReindex
 // IndicesGetMigrateReindexStatus get the migration reindexing status
 //
 // See full documentation at https://www.elastic.co/docs/api/doc/elasticsearch/group/endpoint-migration.
-type IndicesGetMigrateReindexStatus func(index string, o ...func(*IndicesGetMigrateReindexStatusRequest)) (*Response, error)
+type IndicesGetMigrateReindexStatus func(index []string, o ...func(*IndicesGetMigrateReindexStatusRequest)) (*Response, error)
 
 // IndicesGetMigrateReindexStatusRequest configures the Indices Get Migrate Reindex Status API request.
 type IndicesGetMigrateReindexStatusRequest struct {
-	Index string
+	Index []string
 
 	Pretty     bool
 	Human      bool
@@ -82,16 +83,20 @@ func (r IndicesGetMigrateReindexStatusRequest) Do(providedCtx context.Context, t
 
 	method = "GET"
 
-	path.Grow(7 + 1 + len("_migration") + 1 + len("reindex") + 1 + len(r.Index) + 1 + len("_status"))
+	if len(r.Index) == 0 {
+		return nil, errors.New("index is required and cannot be nil or empty")
+	}
+
+	path.Grow(7 + 1 + len("_migration") + 1 + len("reindex") + 1 + len(strings.Join(r.Index, ",")) + 1 + len("_status"))
 	path.WriteString("http://")
 	path.WriteString("/")
 	path.WriteString("_migration")
 	path.WriteString("/")
 	path.WriteString("reindex")
 	path.WriteString("/")
-	path.WriteString(r.Index)
+	path.WriteString(strings.Join(r.Index, ","))
 	if instrument, ok := r.Instrument.(Instrumentation); ok {
-		instrument.RecordPathPart(ctx, "index", r.Index)
+		instrument.RecordPathPart(ctx, "index", strings.Join(r.Index, ","))
 	}
 	path.WriteString("/")
 	path.WriteString("_status")

--- a/esapi/api.indices.put_data_stream_mappings.go
+++ b/esapi/api.indices.put_data_stream_mappings.go
@@ -21,6 +21,7 @@ package esapi
 
 import (
 	"context"
+	"errors"
 	"io"
 	"net/http"
 	"strconv"
@@ -29,7 +30,7 @@ import (
 )
 
 func newIndicesPutDataStreamMappingsFunc(t Transport) IndicesPutDataStreamMappings {
-	return func(name string, body io.Reader, o ...func(*IndicesPutDataStreamMappingsRequest)) (*Response, error) {
+	return func(name []string, body io.Reader, o ...func(*IndicesPutDataStreamMappingsRequest)) (*Response, error) {
 		var r = IndicesPutDataStreamMappingsRequest{Name: name, Body: body}
 		for _, f := range o {
 			f(&r)
@@ -48,13 +49,13 @@ func newIndicesPutDataStreamMappingsFunc(t Transport) IndicesPutDataStreamMappin
 // IndicesPutDataStreamMappings update data stream mappings
 //
 // See full documentation at https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-indices-put-data-stream-mappings.
-type IndicesPutDataStreamMappings func(name string, body io.Reader, o ...func(*IndicesPutDataStreamMappingsRequest)) (*Response, error)
+type IndicesPutDataStreamMappings func(name []string, body io.Reader, o ...func(*IndicesPutDataStreamMappingsRequest)) (*Response, error)
 
 // IndicesPutDataStreamMappingsRequest configures the Indices Put Data Stream Mappings API request.
 type IndicesPutDataStreamMappingsRequest struct {
 	Body io.Reader
 
-	Name string
+	Name []string
 
 	DryRun        *bool
 	MasterTimeout time.Duration
@@ -91,14 +92,18 @@ func (r IndicesPutDataStreamMappingsRequest) Do(providedCtx context.Context, tra
 
 	method = "PUT"
 
-	path.Grow(7 + 1 + len("_data_stream") + 1 + len(r.Name) + 1 + len("_mappings"))
+	if len(r.Name) == 0 {
+		return nil, errors.New("name is required and cannot be nil or empty")
+	}
+
+	path.Grow(7 + 1 + len("_data_stream") + 1 + len(strings.Join(r.Name, ",")) + 1 + len("_mappings"))
 	path.WriteString("http://")
 	path.WriteString("/")
 	path.WriteString("_data_stream")
 	path.WriteString("/")
-	path.WriteString(r.Name)
+	path.WriteString(strings.Join(r.Name, ","))
 	if instrument, ok := r.Instrument.(Instrumentation); ok {
-		instrument.RecordPathPart(ctx, "name", r.Name)
+		instrument.RecordPathPart(ctx, "name", strings.Join(r.Name, ","))
 	}
 	path.WriteString("/")
 	path.WriteString("_mappings")

--- a/esapi/api.indices.put_data_stream_settings.go
+++ b/esapi/api.indices.put_data_stream_settings.go
@@ -21,6 +21,7 @@ package esapi
 
 import (
 	"context"
+	"errors"
 	"io"
 	"net/http"
 	"strconv"
@@ -29,7 +30,7 @@ import (
 )
 
 func newIndicesPutDataStreamSettingsFunc(t Transport) IndicesPutDataStreamSettings {
-	return func(name string, body io.Reader, o ...func(*IndicesPutDataStreamSettingsRequest)) (*Response, error) {
+	return func(name []string, body io.Reader, o ...func(*IndicesPutDataStreamSettingsRequest)) (*Response, error) {
 		var r = IndicesPutDataStreamSettingsRequest{Name: name, Body: body}
 		for _, f := range o {
 			f(&r)
@@ -48,13 +49,13 @@ func newIndicesPutDataStreamSettingsFunc(t Transport) IndicesPutDataStreamSettin
 // IndicesPutDataStreamSettings update data stream settings
 //
 // See full documentation at https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-indices-put-data-stream-settings.
-type IndicesPutDataStreamSettings func(name string, body io.Reader, o ...func(*IndicesPutDataStreamSettingsRequest)) (*Response, error)
+type IndicesPutDataStreamSettings func(name []string, body io.Reader, o ...func(*IndicesPutDataStreamSettingsRequest)) (*Response, error)
 
 // IndicesPutDataStreamSettingsRequest configures the Indices Put Data Stream Settings API request.
 type IndicesPutDataStreamSettingsRequest struct {
 	Body io.Reader
 
-	Name string
+	Name []string
 
 	DryRun        *bool
 	MasterTimeout time.Duration
@@ -91,14 +92,18 @@ func (r IndicesPutDataStreamSettingsRequest) Do(providedCtx context.Context, tra
 
 	method = "PUT"
 
-	path.Grow(7 + 1 + len("_data_stream") + 1 + len(r.Name) + 1 + len("_settings"))
+	if len(r.Name) == 0 {
+		return nil, errors.New("name is required and cannot be nil or empty")
+	}
+
+	path.Grow(7 + 1 + len("_data_stream") + 1 + len(strings.Join(r.Name, ",")) + 1 + len("_settings"))
 	path.WriteString("http://")
 	path.WriteString("/")
 	path.WriteString("_data_stream")
 	path.WriteString("/")
-	path.WriteString(r.Name)
+	path.WriteString(strings.Join(r.Name, ","))
 	if instrument, ok := r.Instrument.(Instrumentation); ok {
-		instrument.RecordPathPart(ctx, "name", r.Name)
+		instrument.RecordPathPart(ctx, "name", strings.Join(r.Name, ","))
 	}
 	path.WriteString("/")
 	path.WriteString("_settings")

--- a/esapi/api.indices.resolve_index.go
+++ b/esapi/api.indices.resolve_index.go
@@ -56,7 +56,7 @@ type IndicesResolveIndexRequest struct {
 	AllowNoIndices    *bool
 	ExpandWildcards   string
 	IgnoreUnavailable *bool
-	Mode              string
+	Mode              []string
 	ProjectRouting    string
 
 	Pretty     bool
@@ -120,8 +120,8 @@ func (r IndicesResolveIndexRequest) Do(providedCtx context.Context, transport Tr
 		params["ignore_unavailable"] = strconv.FormatBool(*r.IgnoreUnavailable)
 	}
 
-	if r.Mode != "" {
-		params["mode"] = r.Mode
+	if len(r.Mode) > 0 {
+		params["mode"] = strings.Join(r.Mode, ",")
 	}
 
 	if r.ProjectRouting != "" {
@@ -228,7 +228,7 @@ func (f IndicesResolveIndex) WithIgnoreUnavailable(v bool) func(*IndicesResolveI
 }
 
 // WithMode - filter indices by index mode. comma-separated list of indexmode. empty means no filter..
-func (f IndicesResolveIndex) WithMode(v string) func(*IndicesResolveIndexRequest) {
+func (f IndicesResolveIndex) WithMode(v ...string) func(*IndicesResolveIndexRequest) {
 	return func(r *IndicesResolveIndexRequest) {
 		r.Mode = v
 	}

--- a/esapi/api.inference.chat_completion_unified.go
+++ b/esapi/api.inference.chat_completion_unified.go
@@ -24,6 +24,7 @@ import (
 	"io"
 	"net/http"
 	"strings"
+	"time"
 )
 
 func newInferenceChatCompletionUnifiedFunc(t Transport) InferenceChatCompletionUnified {
@@ -53,6 +54,8 @@ type InferenceChatCompletionUnifiedRequest struct {
 	Body io.Reader
 
 	InferenceID string
+
+	Timeout time.Duration
 
 	Pretty     bool
 	Human      bool
@@ -100,6 +103,10 @@ func (r InferenceChatCompletionUnifiedRequest) Do(providedCtx context.Context, t
 	path.WriteString("_stream")
 
 	params = make(map[string]string)
+
+	if r.Timeout != 0 {
+		params["timeout"] = formatDuration(r.Timeout)
+	}
 
 	if r.Pretty {
 		params["pretty"] = "true"
@@ -183,6 +190,13 @@ func (r InferenceChatCompletionUnifiedRequest) Do(providedCtx context.Context, t
 func (f InferenceChatCompletionUnified) WithContext(v context.Context) func(*InferenceChatCompletionUnifiedRequest) {
 	return func(r *InferenceChatCompletionUnifiedRequest) {
 		r.ctx = v
+	}
+}
+
+// WithTimeout - specifies the amount of time to wait for the inference request to complete..
+func (f InferenceChatCompletionUnified) WithTimeout(v time.Duration) func(*InferenceChatCompletionUnifiedRequest) {
+	return func(r *InferenceChatCompletionUnifiedRequest) {
+		r.Timeout = v
 	}
 }
 

--- a/esapi/api.inference.completion.go
+++ b/esapi/api.inference.completion.go
@@ -24,6 +24,7 @@ import (
 	"io"
 	"net/http"
 	"strings"
+	"time"
 )
 
 func newInferenceCompletionFunc(t Transport) InferenceCompletion {
@@ -53,6 +54,8 @@ type InferenceCompletionRequest struct {
 	Body io.Reader
 
 	InferenceID string
+
+	Timeout time.Duration
 
 	Pretty     bool
 	Human      bool
@@ -98,6 +101,10 @@ func (r InferenceCompletionRequest) Do(providedCtx context.Context, transport Tr
 	}
 
 	params = make(map[string]string)
+
+	if r.Timeout != 0 {
+		params["timeout"] = formatDuration(r.Timeout)
+	}
 
 	if r.Pretty {
 		params["pretty"] = "true"
@@ -181,6 +188,13 @@ func (r InferenceCompletionRequest) Do(providedCtx context.Context, transport Tr
 func (f InferenceCompletion) WithContext(v context.Context) func(*InferenceCompletionRequest) {
 	return func(r *InferenceCompletionRequest) {
 		r.ctx = v
+	}
+}
+
+// WithTimeout - specifies the amount of time to wait for the inference request to complete..
+func (f InferenceCompletion) WithTimeout(v time.Duration) func(*InferenceCompletionRequest) {
+	return func(r *InferenceCompletionRequest) {
+		r.Timeout = v
 	}
 }
 

--- a/esapi/api.inference.inference.go
+++ b/esapi/api.inference.inference.go
@@ -24,6 +24,7 @@ import (
 	"io"
 	"net/http"
 	"strings"
+	"time"
 )
 
 func newInferenceInferenceFunc(t Transport) InferenceInference {
@@ -54,6 +55,8 @@ type InferenceInferenceRequest struct {
 
 	InferenceID string
 	TaskType    string
+
+	Timeout time.Duration
 
 	Pretty     bool
 	Human      bool
@@ -104,6 +107,10 @@ func (r InferenceInferenceRequest) Do(providedCtx context.Context, transport Tra
 	}
 
 	params = make(map[string]string)
+
+	if r.Timeout != 0 {
+		params["timeout"] = formatDuration(r.Timeout)
+	}
 
 	if r.Pretty {
 		params["pretty"] = "true"
@@ -194,6 +201,13 @@ func (f InferenceInference) WithContext(v context.Context) func(*InferenceInfere
 func (f InferenceInference) WithTaskType(v string) func(*InferenceInferenceRequest) {
 	return func(r *InferenceInferenceRequest) {
 		r.TaskType = v
+	}
+}
+
+// WithTimeout - the amount of time to wait for the inference request to complete..
+func (f InferenceInference) WithTimeout(v time.Duration) func(*InferenceInferenceRequest) {
+	return func(r *InferenceInferenceRequest) {
+		r.Timeout = v
 	}
 }
 

--- a/esapi/api.inference.put.go
+++ b/esapi/api.inference.put.go
@@ -24,6 +24,7 @@ import (
 	"io"
 	"net/http"
 	"strings"
+	"time"
 )
 
 func newInferencePutFunc(t Transport) InferencePut {
@@ -54,6 +55,8 @@ type InferencePutRequest struct {
 
 	InferenceID string
 	TaskType    string
+
+	Timeout time.Duration
 
 	Pretty     bool
 	Human      bool
@@ -104,6 +107,10 @@ func (r InferencePutRequest) Do(providedCtx context.Context, transport Transport
 	}
 
 	params = make(map[string]string)
+
+	if r.Timeout != 0 {
+		params["timeout"] = formatDuration(r.Timeout)
+	}
 
 	if r.Pretty {
 		params["pretty"] = "true"
@@ -194,6 +201,13 @@ func (f InferencePut) WithContext(v context.Context) func(*InferencePutRequest) 
 func (f InferencePut) WithTaskType(v string) func(*InferencePutRequest) {
 	return func(r *InferencePutRequest) {
 		r.TaskType = v
+	}
+}
+
+// WithTimeout - specifies the amount of time to wait for the inference endpoint to be created..
+func (f InferencePut) WithTimeout(v time.Duration) func(*InferencePutRequest) {
+	return func(r *InferencePutRequest) {
+		r.Timeout = v
 	}
 }
 

--- a/esapi/api.inference.put_ai21.go
+++ b/esapi/api.inference.put_ai21.go
@@ -24,6 +24,7 @@ import (
 	"io"
 	"net/http"
 	"strings"
+	"time"
 )
 
 func newInferencePutAi21Func(t Transport) InferencePutAi21 {
@@ -54,6 +55,8 @@ type InferencePutAi21Request struct {
 
 	Ai21InferenceID string
 	TaskType        string
+
+	Timeout time.Duration
 
 	Pretty     bool
 	Human      bool
@@ -102,6 +105,10 @@ func (r InferencePutAi21Request) Do(providedCtx context.Context, transport Trans
 	}
 
 	params = make(map[string]string)
+
+	if r.Timeout != 0 {
+		params["timeout"] = formatDuration(r.Timeout)
+	}
 
 	if r.Pretty {
 		params["pretty"] = "true"
@@ -185,6 +192,13 @@ func (r InferencePutAi21Request) Do(providedCtx context.Context, transport Trans
 func (f InferencePutAi21) WithContext(v context.Context) func(*InferencePutAi21Request) {
 	return func(r *InferencePutAi21Request) {
 		r.ctx = v
+	}
+}
+
+// WithTimeout - specifies the amount of time to wait for the inference endpoint to be created..
+func (f InferencePutAi21) WithTimeout(v time.Duration) func(*InferencePutAi21Request) {
+	return func(r *InferencePutAi21Request) {
+		r.Timeout = v
 	}
 }
 

--- a/esapi/api.inference.put_alibabacloud.go
+++ b/esapi/api.inference.put_alibabacloud.go
@@ -24,6 +24,7 @@ import (
 	"io"
 	"net/http"
 	"strings"
+	"time"
 )
 
 func newInferencePutAlibabacloudFunc(t Transport) InferencePutAlibabacloud {
@@ -54,6 +55,8 @@ type InferencePutAlibabacloudRequest struct {
 
 	AlibabacloudInferenceID string
 	TaskType                string
+
+	Timeout time.Duration
 
 	Pretty     bool
 	Human      bool
@@ -102,6 +105,10 @@ func (r InferencePutAlibabacloudRequest) Do(providedCtx context.Context, transpo
 	}
 
 	params = make(map[string]string)
+
+	if r.Timeout != 0 {
+		params["timeout"] = formatDuration(r.Timeout)
+	}
 
 	if r.Pretty {
 		params["pretty"] = "true"
@@ -185,6 +192,13 @@ func (r InferencePutAlibabacloudRequest) Do(providedCtx context.Context, transpo
 func (f InferencePutAlibabacloud) WithContext(v context.Context) func(*InferencePutAlibabacloudRequest) {
 	return func(r *InferencePutAlibabacloudRequest) {
 		r.ctx = v
+	}
+}
+
+// WithTimeout - specifies the amount of time to wait for the inference endpoint to be created..
+func (f InferencePutAlibabacloud) WithTimeout(v time.Duration) func(*InferencePutAlibabacloudRequest) {
+	return func(r *InferencePutAlibabacloudRequest) {
+		r.Timeout = v
 	}
 }
 

--- a/esapi/api.inference.put_amazonbedrock.go
+++ b/esapi/api.inference.put_amazonbedrock.go
@@ -24,6 +24,7 @@ import (
 	"io"
 	"net/http"
 	"strings"
+	"time"
 )
 
 func newInferencePutAmazonbedrockFunc(t Transport) InferencePutAmazonbedrock {
@@ -54,6 +55,8 @@ type InferencePutAmazonbedrockRequest struct {
 
 	AmazonbedrockInferenceID string
 	TaskType                 string
+
+	Timeout time.Duration
 
 	Pretty     bool
 	Human      bool
@@ -102,6 +105,10 @@ func (r InferencePutAmazonbedrockRequest) Do(providedCtx context.Context, transp
 	}
 
 	params = make(map[string]string)
+
+	if r.Timeout != 0 {
+		params["timeout"] = formatDuration(r.Timeout)
+	}
 
 	if r.Pretty {
 		params["pretty"] = "true"
@@ -185,6 +192,13 @@ func (r InferencePutAmazonbedrockRequest) Do(providedCtx context.Context, transp
 func (f InferencePutAmazonbedrock) WithContext(v context.Context) func(*InferencePutAmazonbedrockRequest) {
 	return func(r *InferencePutAmazonbedrockRequest) {
 		r.ctx = v
+	}
+}
+
+// WithTimeout - specifies the amount of time to wait for the inference endpoint to be created..
+func (f InferencePutAmazonbedrock) WithTimeout(v time.Duration) func(*InferencePutAmazonbedrockRequest) {
+	return func(r *InferencePutAmazonbedrockRequest) {
+		r.Timeout = v
 	}
 }
 

--- a/esapi/api.inference.put_amazonsagemaker.go
+++ b/esapi/api.inference.put_amazonsagemaker.go
@@ -24,6 +24,7 @@ import (
 	"io"
 	"net/http"
 	"strings"
+	"time"
 )
 
 func newInferencePutAmazonsagemakerFunc(t Transport) InferencePutAmazonsagemaker {
@@ -54,6 +55,8 @@ type InferencePutAmazonsagemakerRequest struct {
 
 	AmazonsagemakerInferenceID string
 	TaskType                   string
+
+	Timeout time.Duration
 
 	Pretty     bool
 	Human      bool
@@ -102,6 +105,10 @@ func (r InferencePutAmazonsagemakerRequest) Do(providedCtx context.Context, tran
 	}
 
 	params = make(map[string]string)
+
+	if r.Timeout != 0 {
+		params["timeout"] = formatDuration(r.Timeout)
+	}
 
 	if r.Pretty {
 		params["pretty"] = "true"
@@ -185,6 +192,13 @@ func (r InferencePutAmazonsagemakerRequest) Do(providedCtx context.Context, tran
 func (f InferencePutAmazonsagemaker) WithContext(v context.Context) func(*InferencePutAmazonsagemakerRequest) {
 	return func(r *InferencePutAmazonsagemakerRequest) {
 		r.ctx = v
+	}
+}
+
+// WithTimeout - specifies the amount of time to wait for the inference endpoint to be created..
+func (f InferencePutAmazonsagemaker) WithTimeout(v time.Duration) func(*InferencePutAmazonsagemakerRequest) {
+	return func(r *InferencePutAmazonsagemakerRequest) {
+		r.Timeout = v
 	}
 }
 

--- a/esapi/api.inference.put_anthropic.go
+++ b/esapi/api.inference.put_anthropic.go
@@ -24,6 +24,7 @@ import (
 	"io"
 	"net/http"
 	"strings"
+	"time"
 )
 
 func newInferencePutAnthropicFunc(t Transport) InferencePutAnthropic {
@@ -54,6 +55,8 @@ type InferencePutAnthropicRequest struct {
 
 	AnthropicInferenceID string
 	TaskType             string
+
+	Timeout time.Duration
 
 	Pretty     bool
 	Human      bool
@@ -102,6 +105,10 @@ func (r InferencePutAnthropicRequest) Do(providedCtx context.Context, transport 
 	}
 
 	params = make(map[string]string)
+
+	if r.Timeout != 0 {
+		params["timeout"] = formatDuration(r.Timeout)
+	}
 
 	if r.Pretty {
 		params["pretty"] = "true"
@@ -185,6 +192,13 @@ func (r InferencePutAnthropicRequest) Do(providedCtx context.Context, transport 
 func (f InferencePutAnthropic) WithContext(v context.Context) func(*InferencePutAnthropicRequest) {
 	return func(r *InferencePutAnthropicRequest) {
 		r.ctx = v
+	}
+}
+
+// WithTimeout - specifies the amount of time to wait for the inference endpoint to be created..
+func (f InferencePutAnthropic) WithTimeout(v time.Duration) func(*InferencePutAnthropicRequest) {
+	return func(r *InferencePutAnthropicRequest) {
+		r.Timeout = v
 	}
 }
 

--- a/esapi/api.inference.put_azureaistudio.go
+++ b/esapi/api.inference.put_azureaistudio.go
@@ -24,6 +24,7 @@ import (
 	"io"
 	"net/http"
 	"strings"
+	"time"
 )
 
 func newInferencePutAzureaistudioFunc(t Transport) InferencePutAzureaistudio {
@@ -54,6 +55,8 @@ type InferencePutAzureaistudioRequest struct {
 
 	AzureaistudioInferenceID string
 	TaskType                 string
+
+	Timeout time.Duration
 
 	Pretty     bool
 	Human      bool
@@ -102,6 +105,10 @@ func (r InferencePutAzureaistudioRequest) Do(providedCtx context.Context, transp
 	}
 
 	params = make(map[string]string)
+
+	if r.Timeout != 0 {
+		params["timeout"] = formatDuration(r.Timeout)
+	}
 
 	if r.Pretty {
 		params["pretty"] = "true"
@@ -185,6 +192,13 @@ func (r InferencePutAzureaistudioRequest) Do(providedCtx context.Context, transp
 func (f InferencePutAzureaistudio) WithContext(v context.Context) func(*InferencePutAzureaistudioRequest) {
 	return func(r *InferencePutAzureaistudioRequest) {
 		r.ctx = v
+	}
+}
+
+// WithTimeout - specifies the amount of time to wait for the inference endpoint to be created..
+func (f InferencePutAzureaistudio) WithTimeout(v time.Duration) func(*InferencePutAzureaistudioRequest) {
+	return func(r *InferencePutAzureaistudioRequest) {
+		r.Timeout = v
 	}
 }
 

--- a/esapi/api.inference.put_azureopenai.go
+++ b/esapi/api.inference.put_azureopenai.go
@@ -24,6 +24,7 @@ import (
 	"io"
 	"net/http"
 	"strings"
+	"time"
 )
 
 func newInferencePutAzureopenaiFunc(t Transport) InferencePutAzureopenai {
@@ -54,6 +55,8 @@ type InferencePutAzureopenaiRequest struct {
 
 	AzureopenaiInferenceID string
 	TaskType               string
+
+	Timeout time.Duration
 
 	Pretty     bool
 	Human      bool
@@ -102,6 +105,10 @@ func (r InferencePutAzureopenaiRequest) Do(providedCtx context.Context, transpor
 	}
 
 	params = make(map[string]string)
+
+	if r.Timeout != 0 {
+		params["timeout"] = formatDuration(r.Timeout)
+	}
 
 	if r.Pretty {
 		params["pretty"] = "true"
@@ -185,6 +192,13 @@ func (r InferencePutAzureopenaiRequest) Do(providedCtx context.Context, transpor
 func (f InferencePutAzureopenai) WithContext(v context.Context) func(*InferencePutAzureopenaiRequest) {
 	return func(r *InferencePutAzureopenaiRequest) {
 		r.ctx = v
+	}
+}
+
+// WithTimeout - specifies the amount of time to wait for the inference endpoint to be created..
+func (f InferencePutAzureopenai) WithTimeout(v time.Duration) func(*InferencePutAzureopenaiRequest) {
+	return func(r *InferencePutAzureopenaiRequest) {
+		r.Timeout = v
 	}
 }
 

--- a/esapi/api.inference.put_cohere.go
+++ b/esapi/api.inference.put_cohere.go
@@ -24,6 +24,7 @@ import (
 	"io"
 	"net/http"
 	"strings"
+	"time"
 )
 
 func newInferencePutCohereFunc(t Transport) InferencePutCohere {
@@ -54,6 +55,8 @@ type InferencePutCohereRequest struct {
 
 	CohereInferenceID string
 	TaskType          string
+
+	Timeout time.Duration
 
 	Pretty     bool
 	Human      bool
@@ -102,6 +105,10 @@ func (r InferencePutCohereRequest) Do(providedCtx context.Context, transport Tra
 	}
 
 	params = make(map[string]string)
+
+	if r.Timeout != 0 {
+		params["timeout"] = formatDuration(r.Timeout)
+	}
 
 	if r.Pretty {
 		params["pretty"] = "true"
@@ -185,6 +192,13 @@ func (r InferencePutCohereRequest) Do(providedCtx context.Context, transport Tra
 func (f InferencePutCohere) WithContext(v context.Context) func(*InferencePutCohereRequest) {
 	return func(r *InferencePutCohereRequest) {
 		r.ctx = v
+	}
+}
+
+// WithTimeout - specifies the amount of time to wait for the inference endpoint to be created..
+func (f InferencePutCohere) WithTimeout(v time.Duration) func(*InferencePutCohereRequest) {
+	return func(r *InferencePutCohereRequest) {
+		r.Timeout = v
 	}
 }
 

--- a/esapi/api.inference.put_contextualai.go
+++ b/esapi/api.inference.put_contextualai.go
@@ -24,6 +24,7 @@ import (
 	"io"
 	"net/http"
 	"strings"
+	"time"
 )
 
 func newInferencePutContextualaiFunc(t Transport) InferencePutContextualai {
@@ -54,6 +55,8 @@ type InferencePutContextualaiRequest struct {
 
 	ContextualaiInferenceID string
 	TaskType                string
+
+	Timeout time.Duration
 
 	Pretty     bool
 	Human      bool
@@ -102,6 +105,10 @@ func (r InferencePutContextualaiRequest) Do(providedCtx context.Context, transpo
 	}
 
 	params = make(map[string]string)
+
+	if r.Timeout != 0 {
+		params["timeout"] = formatDuration(r.Timeout)
+	}
 
 	if r.Pretty {
 		params["pretty"] = "true"
@@ -185,6 +192,13 @@ func (r InferencePutContextualaiRequest) Do(providedCtx context.Context, transpo
 func (f InferencePutContextualai) WithContext(v context.Context) func(*InferencePutContextualaiRequest) {
 	return func(r *InferencePutContextualaiRequest) {
 		r.ctx = v
+	}
+}
+
+// WithTimeout - specifies the amount of time to wait for the inference endpoint to be created..
+func (f InferencePutContextualai) WithTimeout(v time.Duration) func(*InferencePutContextualaiRequest) {
+	return func(r *InferencePutContextualaiRequest) {
+		r.Timeout = v
 	}
 }
 

--- a/esapi/api.inference.put_deepseek.go
+++ b/esapi/api.inference.put_deepseek.go
@@ -24,6 +24,7 @@ import (
 	"io"
 	"net/http"
 	"strings"
+	"time"
 )
 
 func newInferencePutDeepseekFunc(t Transport) InferencePutDeepseek {
@@ -54,6 +55,8 @@ type InferencePutDeepseekRequest struct {
 
 	DeepseekInferenceID string
 	TaskType            string
+
+	Timeout time.Duration
 
 	Pretty     bool
 	Human      bool
@@ -102,6 +105,10 @@ func (r InferencePutDeepseekRequest) Do(providedCtx context.Context, transport T
 	}
 
 	params = make(map[string]string)
+
+	if r.Timeout != 0 {
+		params["timeout"] = formatDuration(r.Timeout)
+	}
 
 	if r.Pretty {
 		params["pretty"] = "true"
@@ -185,6 +192,13 @@ func (r InferencePutDeepseekRequest) Do(providedCtx context.Context, transport T
 func (f InferencePutDeepseek) WithContext(v context.Context) func(*InferencePutDeepseekRequest) {
 	return func(r *InferencePutDeepseekRequest) {
 		r.ctx = v
+	}
+}
+
+// WithTimeout - specifies the amount of time to wait for the inference endpoint to be created..
+func (f InferencePutDeepseek) WithTimeout(v time.Duration) func(*InferencePutDeepseekRequest) {
+	return func(r *InferencePutDeepseekRequest) {
+		r.Timeout = v
 	}
 }
 

--- a/esapi/api.inference.put_elasticsearch.go
+++ b/esapi/api.inference.put_elasticsearch.go
@@ -24,6 +24,7 @@ import (
 	"io"
 	"net/http"
 	"strings"
+	"time"
 )
 
 func newInferencePutElasticsearchFunc(t Transport) InferencePutElasticsearch {
@@ -54,6 +55,8 @@ type InferencePutElasticsearchRequest struct {
 
 	ElasticsearchInferenceID string
 	TaskType                 string
+
+	Timeout time.Duration
 
 	Pretty     bool
 	Human      bool
@@ -102,6 +105,10 @@ func (r InferencePutElasticsearchRequest) Do(providedCtx context.Context, transp
 	}
 
 	params = make(map[string]string)
+
+	if r.Timeout != 0 {
+		params["timeout"] = formatDuration(r.Timeout)
+	}
 
 	if r.Pretty {
 		params["pretty"] = "true"
@@ -185,6 +192,13 @@ func (r InferencePutElasticsearchRequest) Do(providedCtx context.Context, transp
 func (f InferencePutElasticsearch) WithContext(v context.Context) func(*InferencePutElasticsearchRequest) {
 	return func(r *InferencePutElasticsearchRequest) {
 		r.ctx = v
+	}
+}
+
+// WithTimeout - specifies the amount of time to wait for the inference endpoint to be created..
+func (f InferencePutElasticsearch) WithTimeout(v time.Duration) func(*InferencePutElasticsearchRequest) {
+	return func(r *InferencePutElasticsearchRequest) {
+		r.Timeout = v
 	}
 }
 

--- a/esapi/api.inference.put_elser.go
+++ b/esapi/api.inference.put_elser.go
@@ -24,6 +24,7 @@ import (
 	"io"
 	"net/http"
 	"strings"
+	"time"
 )
 
 func newInferencePutElserFunc(t Transport) InferencePutElser {
@@ -54,6 +55,8 @@ type InferencePutElserRequest struct {
 
 	ElserInferenceID string
 	TaskType         string
+
+	Timeout time.Duration
 
 	Pretty     bool
 	Human      bool
@@ -102,6 +105,10 @@ func (r InferencePutElserRequest) Do(providedCtx context.Context, transport Tran
 	}
 
 	params = make(map[string]string)
+
+	if r.Timeout != 0 {
+		params["timeout"] = formatDuration(r.Timeout)
+	}
 
 	if r.Pretty {
 		params["pretty"] = "true"
@@ -185,6 +192,13 @@ func (r InferencePutElserRequest) Do(providedCtx context.Context, transport Tran
 func (f InferencePutElser) WithContext(v context.Context) func(*InferencePutElserRequest) {
 	return func(r *InferencePutElserRequest) {
 		r.ctx = v
+	}
+}
+
+// WithTimeout - specifies the amount of time to wait for the inference endpoint to be created..
+func (f InferencePutElser) WithTimeout(v time.Duration) func(*InferencePutElserRequest) {
+	return func(r *InferencePutElserRequest) {
+		r.Timeout = v
 	}
 }
 

--- a/esapi/api.inference.put_googleaistudio.go
+++ b/esapi/api.inference.put_googleaistudio.go
@@ -24,6 +24,7 @@ import (
 	"io"
 	"net/http"
 	"strings"
+	"time"
 )
 
 func newInferencePutGoogleaistudioFunc(t Transport) InferencePutGoogleaistudio {
@@ -54,6 +55,8 @@ type InferencePutGoogleaistudioRequest struct {
 
 	GoogleaistudioInferenceID string
 	TaskType                  string
+
+	Timeout time.Duration
 
 	Pretty     bool
 	Human      bool
@@ -102,6 +105,10 @@ func (r InferencePutGoogleaistudioRequest) Do(providedCtx context.Context, trans
 	}
 
 	params = make(map[string]string)
+
+	if r.Timeout != 0 {
+		params["timeout"] = formatDuration(r.Timeout)
+	}
 
 	if r.Pretty {
 		params["pretty"] = "true"
@@ -185,6 +192,13 @@ func (r InferencePutGoogleaistudioRequest) Do(providedCtx context.Context, trans
 func (f InferencePutGoogleaistudio) WithContext(v context.Context) func(*InferencePutGoogleaistudioRequest) {
 	return func(r *InferencePutGoogleaistudioRequest) {
 		r.ctx = v
+	}
+}
+
+// WithTimeout - specifies the amount of time to wait for the inference endpoint to be created..
+func (f InferencePutGoogleaistudio) WithTimeout(v time.Duration) func(*InferencePutGoogleaistudioRequest) {
+	return func(r *InferencePutGoogleaistudioRequest) {
+		r.Timeout = v
 	}
 }
 

--- a/esapi/api.inference.put_googlevertexai.go
+++ b/esapi/api.inference.put_googlevertexai.go
@@ -24,6 +24,7 @@ import (
 	"io"
 	"net/http"
 	"strings"
+	"time"
 )
 
 func newInferencePutGooglevertexaiFunc(t Transport) InferencePutGooglevertexai {
@@ -54,6 +55,8 @@ type InferencePutGooglevertexaiRequest struct {
 
 	GooglevertexaiInferenceID string
 	TaskType                  string
+
+	Timeout time.Duration
 
 	Pretty     bool
 	Human      bool
@@ -102,6 +105,10 @@ func (r InferencePutGooglevertexaiRequest) Do(providedCtx context.Context, trans
 	}
 
 	params = make(map[string]string)
+
+	if r.Timeout != 0 {
+		params["timeout"] = formatDuration(r.Timeout)
+	}
 
 	if r.Pretty {
 		params["pretty"] = "true"
@@ -185,6 +192,13 @@ func (r InferencePutGooglevertexaiRequest) Do(providedCtx context.Context, trans
 func (f InferencePutGooglevertexai) WithContext(v context.Context) func(*InferencePutGooglevertexaiRequest) {
 	return func(r *InferencePutGooglevertexaiRequest) {
 		r.ctx = v
+	}
+}
+
+// WithTimeout - specifies the amount of time to wait for the inference endpoint to be created..
+func (f InferencePutGooglevertexai) WithTimeout(v time.Duration) func(*InferencePutGooglevertexaiRequest) {
+	return func(r *InferencePutGooglevertexaiRequest) {
+		r.Timeout = v
 	}
 }
 

--- a/esapi/api.inference.put_hugging_face.go
+++ b/esapi/api.inference.put_hugging_face.go
@@ -24,6 +24,7 @@ import (
 	"io"
 	"net/http"
 	"strings"
+	"time"
 )
 
 func newInferencePutHuggingFaceFunc(t Transport) InferencePutHuggingFace {
@@ -54,6 +55,8 @@ type InferencePutHuggingFaceRequest struct {
 
 	HuggingfaceInferenceID string
 	TaskType               string
+
+	Timeout time.Duration
 
 	Pretty     bool
 	Human      bool
@@ -102,6 +105,10 @@ func (r InferencePutHuggingFaceRequest) Do(providedCtx context.Context, transpor
 	}
 
 	params = make(map[string]string)
+
+	if r.Timeout != 0 {
+		params["timeout"] = formatDuration(r.Timeout)
+	}
 
 	if r.Pretty {
 		params["pretty"] = "true"
@@ -185,6 +192,13 @@ func (r InferencePutHuggingFaceRequest) Do(providedCtx context.Context, transpor
 func (f InferencePutHuggingFace) WithContext(v context.Context) func(*InferencePutHuggingFaceRequest) {
 	return func(r *InferencePutHuggingFaceRequest) {
 		r.ctx = v
+	}
+}
+
+// WithTimeout - specifies the amount of time to wait for the inference endpoint to be created..
+func (f InferencePutHuggingFace) WithTimeout(v time.Duration) func(*InferencePutHuggingFaceRequest) {
+	return func(r *InferencePutHuggingFaceRequest) {
+		r.Timeout = v
 	}
 }
 

--- a/esapi/api.inference.put_jinaai.go
+++ b/esapi/api.inference.put_jinaai.go
@@ -24,6 +24,7 @@ import (
 	"io"
 	"net/http"
 	"strings"
+	"time"
 )
 
 func newInferencePutJinaaiFunc(t Transport) InferencePutJinaai {
@@ -54,6 +55,8 @@ type InferencePutJinaaiRequest struct {
 
 	JinaaiInferenceID string
 	TaskType          string
+
+	Timeout time.Duration
 
 	Pretty     bool
 	Human      bool
@@ -102,6 +105,10 @@ func (r InferencePutJinaaiRequest) Do(providedCtx context.Context, transport Tra
 	}
 
 	params = make(map[string]string)
+
+	if r.Timeout != 0 {
+		params["timeout"] = formatDuration(r.Timeout)
+	}
 
 	if r.Pretty {
 		params["pretty"] = "true"
@@ -185,6 +192,13 @@ func (r InferencePutJinaaiRequest) Do(providedCtx context.Context, transport Tra
 func (f InferencePutJinaai) WithContext(v context.Context) func(*InferencePutJinaaiRequest) {
 	return func(r *InferencePutJinaaiRequest) {
 		r.ctx = v
+	}
+}
+
+// WithTimeout - specifies the amount of time to wait for the inference endpoint to be created..
+func (f InferencePutJinaai) WithTimeout(v time.Duration) func(*InferencePutJinaaiRequest) {
+	return func(r *InferencePutJinaaiRequest) {
+		r.Timeout = v
 	}
 }
 

--- a/esapi/api.inference.put_llama.go
+++ b/esapi/api.inference.put_llama.go
@@ -24,6 +24,7 @@ import (
 	"io"
 	"net/http"
 	"strings"
+	"time"
 )
 
 func newInferencePutLlamaFunc(t Transport) InferencePutLlama {
@@ -54,6 +55,8 @@ type InferencePutLlamaRequest struct {
 
 	LlamaInferenceID string
 	TaskType         string
+
+	Timeout time.Duration
 
 	Pretty     bool
 	Human      bool
@@ -102,6 +105,10 @@ func (r InferencePutLlamaRequest) Do(providedCtx context.Context, transport Tran
 	}
 
 	params = make(map[string]string)
+
+	if r.Timeout != 0 {
+		params["timeout"] = formatDuration(r.Timeout)
+	}
 
 	if r.Pretty {
 		params["pretty"] = "true"
@@ -185,6 +192,13 @@ func (r InferencePutLlamaRequest) Do(providedCtx context.Context, transport Tran
 func (f InferencePutLlama) WithContext(v context.Context) func(*InferencePutLlamaRequest) {
 	return func(r *InferencePutLlamaRequest) {
 		r.ctx = v
+	}
+}
+
+// WithTimeout - specifies the amount of time to wait for the inference endpoint to be created..
+func (f InferencePutLlama) WithTimeout(v time.Duration) func(*InferencePutLlamaRequest) {
+	return func(r *InferencePutLlamaRequest) {
+		r.Timeout = v
 	}
 }
 

--- a/esapi/api.inference.put_mistral.go
+++ b/esapi/api.inference.put_mistral.go
@@ -24,6 +24,7 @@ import (
 	"io"
 	"net/http"
 	"strings"
+	"time"
 )
 
 func newInferencePutMistralFunc(t Transport) InferencePutMistral {
@@ -54,6 +55,8 @@ type InferencePutMistralRequest struct {
 
 	MistralInferenceID string
 	TaskType           string
+
+	Timeout time.Duration
 
 	Pretty     bool
 	Human      bool
@@ -102,6 +105,10 @@ func (r InferencePutMistralRequest) Do(providedCtx context.Context, transport Tr
 	}
 
 	params = make(map[string]string)
+
+	if r.Timeout != 0 {
+		params["timeout"] = formatDuration(r.Timeout)
+	}
 
 	if r.Pretty {
 		params["pretty"] = "true"
@@ -185,6 +192,13 @@ func (r InferencePutMistralRequest) Do(providedCtx context.Context, transport Tr
 func (f InferencePutMistral) WithContext(v context.Context) func(*InferencePutMistralRequest) {
 	return func(r *InferencePutMistralRequest) {
 		r.ctx = v
+	}
+}
+
+// WithTimeout - specifies the amount of time to wait for the inference endpoint to be created..
+func (f InferencePutMistral) WithTimeout(v time.Duration) func(*InferencePutMistralRequest) {
+	return func(r *InferencePutMistralRequest) {
+		r.Timeout = v
 	}
 }
 

--- a/esapi/api.inference.put_openai.go
+++ b/esapi/api.inference.put_openai.go
@@ -24,6 +24,7 @@ import (
 	"io"
 	"net/http"
 	"strings"
+	"time"
 )
 
 func newInferencePutOpenaiFunc(t Transport) InferencePutOpenai {
@@ -54,6 +55,8 @@ type InferencePutOpenaiRequest struct {
 
 	OpenaiInferenceID string
 	TaskType          string
+
+	Timeout time.Duration
 
 	Pretty     bool
 	Human      bool
@@ -102,6 +105,10 @@ func (r InferencePutOpenaiRequest) Do(providedCtx context.Context, transport Tra
 	}
 
 	params = make(map[string]string)
+
+	if r.Timeout != 0 {
+		params["timeout"] = formatDuration(r.Timeout)
+	}
 
 	if r.Pretty {
 		params["pretty"] = "true"
@@ -185,6 +192,13 @@ func (r InferencePutOpenaiRequest) Do(providedCtx context.Context, transport Tra
 func (f InferencePutOpenai) WithContext(v context.Context) func(*InferencePutOpenaiRequest) {
 	return func(r *InferencePutOpenaiRequest) {
 		r.ctx = v
+	}
+}
+
+// WithTimeout - specifies the amount of time to wait for the inference endpoint to be created..
+func (f InferencePutOpenai) WithTimeout(v time.Duration) func(*InferencePutOpenaiRequest) {
+	return func(r *InferencePutOpenaiRequest) {
+		r.Timeout = v
 	}
 }
 

--- a/esapi/api.inference.put_voyageai.go
+++ b/esapi/api.inference.put_voyageai.go
@@ -24,6 +24,7 @@ import (
 	"io"
 	"net/http"
 	"strings"
+	"time"
 )
 
 func newInferencePutVoyageaiFunc(t Transport) InferencePutVoyageai {
@@ -54,6 +55,8 @@ type InferencePutVoyageaiRequest struct {
 
 	TaskType            string
 	VoyageaiInferenceID string
+
+	Timeout time.Duration
 
 	Pretty     bool
 	Human      bool
@@ -102,6 +105,10 @@ func (r InferencePutVoyageaiRequest) Do(providedCtx context.Context, transport T
 	}
 
 	params = make(map[string]string)
+
+	if r.Timeout != 0 {
+		params["timeout"] = formatDuration(r.Timeout)
+	}
 
 	if r.Pretty {
 		params["pretty"] = "true"
@@ -185,6 +192,13 @@ func (r InferencePutVoyageaiRequest) Do(providedCtx context.Context, transport T
 func (f InferencePutVoyageai) WithContext(v context.Context) func(*InferencePutVoyageaiRequest) {
 	return func(r *InferencePutVoyageaiRequest) {
 		r.ctx = v
+	}
+}
+
+// WithTimeout - specifies the amount of time to wait for the inference endpoint to be created..
+func (f InferencePutVoyageai) WithTimeout(v time.Duration) func(*InferencePutVoyageaiRequest) {
+	return func(r *InferencePutVoyageaiRequest) {
+		r.Timeout = v
 	}
 }
 

--- a/esapi/api.inference.put_watsonx.go
+++ b/esapi/api.inference.put_watsonx.go
@@ -24,6 +24,7 @@ import (
 	"io"
 	"net/http"
 	"strings"
+	"time"
 )
 
 func newInferencePutWatsonxFunc(t Transport) InferencePutWatsonx {
@@ -54,6 +55,8 @@ type InferencePutWatsonxRequest struct {
 
 	TaskType           string
 	WatsonxInferenceID string
+
+	Timeout time.Duration
 
 	Pretty     bool
 	Human      bool
@@ -102,6 +105,10 @@ func (r InferencePutWatsonxRequest) Do(providedCtx context.Context, transport Tr
 	}
 
 	params = make(map[string]string)
+
+	if r.Timeout != 0 {
+		params["timeout"] = formatDuration(r.Timeout)
+	}
 
 	if r.Pretty {
 		params["pretty"] = "true"
@@ -185,6 +192,13 @@ func (r InferencePutWatsonxRequest) Do(providedCtx context.Context, transport Tr
 func (f InferencePutWatsonx) WithContext(v context.Context) func(*InferencePutWatsonxRequest) {
 	return func(r *InferencePutWatsonxRequest) {
 		r.ctx = v
+	}
+}
+
+// WithTimeout - specifies the amount of time to wait for the inference endpoint to be created..
+func (f InferencePutWatsonx) WithTimeout(v time.Duration) func(*InferencePutWatsonxRequest) {
+	return func(r *InferencePutWatsonxRequest) {
+		r.Timeout = v
 	}
 }
 

--- a/esapi/api.inference.rerank.go
+++ b/esapi/api.inference.rerank.go
@@ -24,6 +24,7 @@ import (
 	"io"
 	"net/http"
 	"strings"
+	"time"
 )
 
 func newInferenceRerankFunc(t Transport) InferenceRerank {
@@ -53,6 +54,8 @@ type InferenceRerankRequest struct {
 	Body io.Reader
 
 	InferenceID string
+
+	Timeout time.Duration
 
 	Pretty     bool
 	Human      bool
@@ -98,6 +101,10 @@ func (r InferenceRerankRequest) Do(providedCtx context.Context, transport Transp
 	}
 
 	params = make(map[string]string)
+
+	if r.Timeout != 0 {
+		params["timeout"] = formatDuration(r.Timeout)
+	}
 
 	if r.Pretty {
 		params["pretty"] = "true"
@@ -181,6 +188,13 @@ func (r InferenceRerankRequest) Do(providedCtx context.Context, transport Transp
 func (f InferenceRerank) WithContext(v context.Context) func(*InferenceRerankRequest) {
 	return func(r *InferenceRerankRequest) {
 		r.ctx = v
+	}
+}
+
+// WithTimeout - the amount of time to wait for the inference request to complete..
+func (f InferenceRerank) WithTimeout(v time.Duration) func(*InferenceRerankRequest) {
+	return func(r *InferenceRerankRequest) {
+		r.Timeout = v
 	}
 }
 

--- a/esapi/api.inference.sparse_embedding.go
+++ b/esapi/api.inference.sparse_embedding.go
@@ -24,6 +24,7 @@ import (
 	"io"
 	"net/http"
 	"strings"
+	"time"
 )
 
 func newInferenceSparseEmbeddingFunc(t Transport) InferenceSparseEmbedding {
@@ -53,6 +54,8 @@ type InferenceSparseEmbeddingRequest struct {
 	Body io.Reader
 
 	InferenceID string
+
+	Timeout time.Duration
 
 	Pretty     bool
 	Human      bool
@@ -98,6 +101,10 @@ func (r InferenceSparseEmbeddingRequest) Do(providedCtx context.Context, transpo
 	}
 
 	params = make(map[string]string)
+
+	if r.Timeout != 0 {
+		params["timeout"] = formatDuration(r.Timeout)
+	}
 
 	if r.Pretty {
 		params["pretty"] = "true"
@@ -181,6 +188,13 @@ func (r InferenceSparseEmbeddingRequest) Do(providedCtx context.Context, transpo
 func (f InferenceSparseEmbedding) WithContext(v context.Context) func(*InferenceSparseEmbeddingRequest) {
 	return func(r *InferenceSparseEmbeddingRequest) {
 		r.ctx = v
+	}
+}
+
+// WithTimeout - specifies the amount of time to wait for the inference request to complete..
+func (f InferenceSparseEmbedding) WithTimeout(v time.Duration) func(*InferenceSparseEmbeddingRequest) {
+	return func(r *InferenceSparseEmbeddingRequest) {
+		r.Timeout = v
 	}
 }
 

--- a/esapi/api.inference.stream_completion.go
+++ b/esapi/api.inference.stream_completion.go
@@ -24,6 +24,7 @@ import (
 	"io"
 	"net/http"
 	"strings"
+	"time"
 )
 
 func newInferenceStreamCompletionFunc(t Transport) InferenceStreamCompletion {
@@ -53,6 +54,8 @@ type InferenceStreamCompletionRequest struct {
 	Body io.Reader
 
 	InferenceID string
+
+	Timeout time.Duration
 
 	Pretty     bool
 	Human      bool
@@ -100,6 +103,10 @@ func (r InferenceStreamCompletionRequest) Do(providedCtx context.Context, transp
 	path.WriteString("_stream")
 
 	params = make(map[string]string)
+
+	if r.Timeout != 0 {
+		params["timeout"] = formatDuration(r.Timeout)
+	}
 
 	if r.Pretty {
 		params["pretty"] = "true"
@@ -183,6 +190,13 @@ func (r InferenceStreamCompletionRequest) Do(providedCtx context.Context, transp
 func (f InferenceStreamCompletion) WithContext(v context.Context) func(*InferenceStreamCompletionRequest) {
 	return func(r *InferenceStreamCompletionRequest) {
 		r.ctx = v
+	}
+}
+
+// WithTimeout - the amount of time to wait for the inference request to complete..
+func (f InferenceStreamCompletion) WithTimeout(v time.Duration) func(*InferenceStreamCompletionRequest) {
+	return func(r *InferenceStreamCompletionRequest) {
+		r.Timeout = v
 	}
 }
 

--- a/esapi/api.inference.text_embedding.go
+++ b/esapi/api.inference.text_embedding.go
@@ -24,6 +24,7 @@ import (
 	"io"
 	"net/http"
 	"strings"
+	"time"
 )
 
 func newInferenceTextEmbeddingFunc(t Transport) InferenceTextEmbedding {
@@ -53,6 +54,8 @@ type InferenceTextEmbeddingRequest struct {
 	Body io.Reader
 
 	InferenceID string
+
+	Timeout time.Duration
 
 	Pretty     bool
 	Human      bool
@@ -98,6 +101,10 @@ func (r InferenceTextEmbeddingRequest) Do(providedCtx context.Context, transport
 	}
 
 	params = make(map[string]string)
+
+	if r.Timeout != 0 {
+		params["timeout"] = formatDuration(r.Timeout)
+	}
 
 	if r.Pretty {
 		params["pretty"] = "true"
@@ -181,6 +188,13 @@ func (r InferenceTextEmbeddingRequest) Do(providedCtx context.Context, transport
 func (f InferenceTextEmbedding) WithContext(v context.Context) func(*InferenceTextEmbeddingRequest) {
 	return func(r *InferenceTextEmbeddingRequest) {
 		r.ctx = v
+	}
+}
+
+// WithTimeout - specifies the amount of time to wait for the inference request to complete..
+func (f InferenceTextEmbedding) WithTimeout(v time.Duration) func(*InferenceTextEmbeddingRequest) {
+	return func(r *InferenceTextEmbeddingRequest) {
+		r.Timeout = v
 	}
 }
 

--- a/esapi/api.msearch.go
+++ b/esapi/api.msearch.go
@@ -63,7 +63,7 @@ type MsearchRequest struct {
 	IncludeNamedQueriesScore   *bool
 	MaxConcurrentSearches      *int
 	MaxConcurrentShardRequests *int
-	PreFilterShardSize         *int
+	PreFilterShardSize         *int64
 	ProjectRouting             string
 	RestTotalHitsAsInt         *bool
 	Routing                    []string
@@ -152,7 +152,7 @@ func (r MsearchRequest) Do(providedCtx context.Context, transport Transport) (*R
 	}
 
 	if r.PreFilterShardSize != nil {
-		params["pre_filter_shard_size"] = strconv.FormatInt(int64(*r.PreFilterShardSize), 10)
+		params["pre_filter_shard_size"] = strconv.FormatInt(*r.PreFilterShardSize, 10)
 	}
 
 	if r.ProjectRouting != "" {
@@ -324,7 +324,7 @@ func (f Msearch) WithMaxConcurrentShardRequests(v int) func(*MsearchRequest) {
 }
 
 // WithPreFilterShardSize - a threshold that enforces a pre-filter roundtrip to prefilter search shards based on query rewriting if the number of shards the search request expands to exceeds the threshold. this filter roundtrip can limit the number of shards significantly if for instance a shard can not match any documents based on its rewrite method ie. if date filters are mandatory to match but the shard bounds and the query are disjoint..
-func (f Msearch) WithPreFilterShardSize(v int) func(*MsearchRequest) {
+func (f Msearch) WithPreFilterShardSize(v int64) func(*MsearchRequest) {
 	return func(r *MsearchRequest) {
 		r.PreFilterShardSize = &v
 	}

--- a/esapi/api.msearch_template.go
+++ b/esapi/api.msearch_template.go
@@ -56,7 +56,7 @@ type MsearchTemplateRequest struct {
 	Body io.Reader
 
 	CcsMinimizeRoundtrips *bool
-	MaxConcurrentSearches *int
+	MaxConcurrentSearches *int64
 	ProjectRouting        string
 	RestTotalHitsAsInt    *bool
 	SearchType            string
@@ -114,7 +114,7 @@ func (r MsearchTemplateRequest) Do(providedCtx context.Context, transport Transp
 	}
 
 	if r.MaxConcurrentSearches != nil {
-		params["max_concurrent_searches"] = strconv.FormatInt(int64(*r.MaxConcurrentSearches), 10)
+		params["max_concurrent_searches"] = strconv.FormatInt(*r.MaxConcurrentSearches, 10)
 	}
 
 	if r.ProjectRouting != "" {
@@ -233,7 +233,7 @@ func (f MsearchTemplate) WithCcsMinimizeRoundtrips(v bool) func(*MsearchTemplate
 }
 
 // WithMaxConcurrentSearches - controls the maximum number of concurrent searches the multi search api will execute.
-func (f MsearchTemplate) WithMaxConcurrentSearches(v int) func(*MsearchTemplateRequest) {
+func (f MsearchTemplate) WithMaxConcurrentSearches(v int64) func(*MsearchTemplateRequest) {
 	return func(r *MsearchTemplateRequest) {
 		r.MaxConcurrentSearches = &v
 	}

--- a/esapi/api.mtermvectors.go
+++ b/esapi/api.mtermvectors.go
@@ -65,7 +65,7 @@ type MtermvectorsRequest struct {
 	Realtime        *bool
 	Routing         string
 	TermStatistics  *bool
-	Version         *int
+	Version         *int64
 	VersionType     string
 
 	Pretty     bool
@@ -154,7 +154,7 @@ func (r MtermvectorsRequest) Do(providedCtx context.Context, transport Transport
 	}
 
 	if r.Version != nil {
-		params["version"] = strconv.FormatInt(int64(*r.Version), 10)
+		params["version"] = strconv.FormatInt(*r.Version, 10)
 	}
 
 	if r.VersionType != "" {
@@ -331,7 +331,7 @@ func (f Mtermvectors) WithTermStatistics(v bool) func(*MtermvectorsRequest) {
 }
 
 // WithVersion - explicit version number for concurrency control.
-func (f Mtermvectors) WithVersion(v int) func(*MtermvectorsRequest) {
+func (f Mtermvectors) WithVersion(v int64) func(*MtermvectorsRequest) {
 	return func(r *MtermvectorsRequest) {
 		r.Version = &v
 	}

--- a/esapi/api.nodes.clear_repositories_metering_archive.go
+++ b/esapi/api.nodes.clear_repositories_metering_archive.go
@@ -28,7 +28,7 @@ import (
 )
 
 func newNodesClearRepositoriesMeteringArchiveFunc(t Transport) NodesClearRepositoriesMeteringArchive {
-	return func(max_archive_version *int, node_id []string, o ...func(*NodesClearRepositoriesMeteringArchiveRequest)) (*Response, error) {
+	return func(max_archive_version *int64, node_id []string, o ...func(*NodesClearRepositoriesMeteringArchiveRequest)) (*Response, error) {
 		var r = NodesClearRepositoriesMeteringArchiveRequest{MaxArchiveVersion: max_archive_version, NodeID: node_id}
 		for _, f := range o {
 			f(&r)
@@ -49,11 +49,11 @@ func newNodesClearRepositoriesMeteringArchiveFunc(t Transport) NodesClearReposit
 // This API is experimental.
 //
 // See full documentation at https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-nodes-clear-repositories-metering-archive.
-type NodesClearRepositoriesMeteringArchive func(max_archive_version *int, node_id []string, o ...func(*NodesClearRepositoriesMeteringArchiveRequest)) (*Response, error)
+type NodesClearRepositoriesMeteringArchive func(max_archive_version *int64, node_id []string, o ...func(*NodesClearRepositoriesMeteringArchiveRequest)) (*Response, error)
 
 // NodesClearRepositoriesMeteringArchiveRequest configures the Nodes Clear Repositories Metering Archive API request.
 type NodesClearRepositoriesMeteringArchiveRequest struct {
-	MaxArchiveVersion *int
+	MaxArchiveVersion *int64
 	NodeID            []string
 
 	Pretty     bool
@@ -94,7 +94,7 @@ func (r NodesClearRepositoriesMeteringArchiveRequest) Do(providedCtx context.Con
 		return nil, errors.New("max_archive_version is required and cannot be nil")
 	}
 
-	path.Grow(7 + 1 + len("_nodes") + 1 + len(strings.Join(r.NodeID, ",")) + 1 + len("_repositories_metering") + 1 + len(strconv.Itoa(*r.MaxArchiveVersion)))
+	path.Grow(7 + 1 + len("_nodes") + 1 + len(strings.Join(r.NodeID, ",")) + 1 + len("_repositories_metering") + 1 + len(strconv.FormatInt(*r.MaxArchiveVersion, 10)))
 	path.WriteString("http://")
 	path.WriteString("/")
 	path.WriteString("_nodes")
@@ -106,9 +106,9 @@ func (r NodesClearRepositoriesMeteringArchiveRequest) Do(providedCtx context.Con
 	path.WriteString("/")
 	path.WriteString("_repositories_metering")
 	path.WriteString("/")
-	path.WriteString(strconv.Itoa(*r.MaxArchiveVersion))
+	path.WriteString(strconv.FormatInt(*r.MaxArchiveVersion, 10))
 	if instrument, ok := r.Instrument.(Instrumentation); ok {
-		instrument.RecordPathPart(ctx, "max_archive_version", strconv.Itoa(*r.MaxArchiveVersion))
+		instrument.RecordPathPart(ctx, "max_archive_version", strconv.FormatInt(*r.MaxArchiveVersion, 10))
 	}
 
 	params = make(map[string]string)

--- a/esapi/api.nodes.hot_threads.go
+++ b/esapi/api.nodes.hot_threads.go
@@ -55,9 +55,9 @@ type NodesHotThreadsRequest struct {
 
 	IgnoreIdleThreads *bool
 	Interval          time.Duration
-	Snapshots         *int
+	Snapshots         *int64
 	Sort              string
-	Threads           *int
+	Threads           *int64
 	Timeout           time.Duration
 	DocumentType      string
 
@@ -117,7 +117,7 @@ func (r NodesHotThreadsRequest) Do(providedCtx context.Context, transport Transp
 	}
 
 	if r.Snapshots != nil {
-		params["snapshots"] = strconv.FormatInt(int64(*r.Snapshots), 10)
+		params["snapshots"] = strconv.FormatInt(*r.Snapshots, 10)
 	}
 
 	if r.Sort != "" {
@@ -125,7 +125,7 @@ func (r NodesHotThreadsRequest) Do(providedCtx context.Context, transport Transp
 	}
 
 	if r.Threads != nil {
-		params["threads"] = strconv.FormatInt(int64(*r.Threads), 10)
+		params["threads"] = strconv.FormatInt(*r.Threads, 10)
 	}
 
 	if r.Timeout != 0 {
@@ -236,7 +236,7 @@ func (f NodesHotThreads) WithInterval(v time.Duration) func(*NodesHotThreadsRequ
 }
 
 // WithSnapshots - number of samples of thread stacktrace (default: 10).
-func (f NodesHotThreads) WithSnapshots(v int) func(*NodesHotThreadsRequest) {
+func (f NodesHotThreads) WithSnapshots(v int64) func(*NodesHotThreadsRequest) {
 	return func(r *NodesHotThreadsRequest) {
 		r.Snapshots = &v
 	}
@@ -250,7 +250,7 @@ func (f NodesHotThreads) WithSort(v string) func(*NodesHotThreadsRequest) {
 }
 
 // WithThreads - specify the number of threads to provide information for (default: 3).
-func (f NodesHotThreads) WithThreads(v int) func(*NodesHotThreadsRequest) {
+func (f NodesHotThreads) WithThreads(v int64) func(*NodesHotThreadsRequest) {
 	return func(r *NodesHotThreadsRequest) {
 		r.Threads = &v
 	}

--- a/esapi/api.project.tags.go
+++ b/esapi/api.project.tags.go
@@ -44,7 +44,7 @@ func newProjectTagsFunc(t Transport) ProjectTags {
 
 // ProjectTags return tags defined for the project
 //
-// This API is experimental.
+// See full documentation at https://www.elastic.co/docs/api/doc/elasticsearch-serverless/operation/operation-project-tags.
 type ProjectTags func(o ...func(*ProjectTagsRequest)) (*Response, error)
 
 // ProjectTagsRequest configures the Project Tags API request.

--- a/esapi/api.search.go
+++ b/esapi/api.search.go
@@ -61,7 +61,7 @@ type SearchRequest struct {
 	AllowPartialSearchResults  *bool
 	Analyzer                   string
 	AnalyzeWildcard            *bool
-	BatchedReduceSize          *int
+	BatchedReduceSize          *int64
 	CcsMinimizeRoundtrips      *bool
 	DefaultOperator            string
 	Df                         string
@@ -76,7 +76,7 @@ type SearchRequest struct {
 	Lenient                    *bool
 	MaxConcurrentShardRequests *int
 	Preference                 string
-	PreFilterShardSize         *int
+	PreFilterShardSize         *int64
 	ProjectRouting             string
 	Query                      string
 	RequestCache               *bool
@@ -95,9 +95,9 @@ type SearchRequest struct {
 	StoredFields               []string
 	SuggestField               string
 	SuggestMode                string
-	SuggestSize                *int
+	SuggestSize                *int64
 	SuggestText                string
-	TerminateAfter             *int
+	TerminateAfter             *int64
 	Timeout                    time.Duration
 	TrackScores                *bool
 	TrackTotalHits             interface{}
@@ -166,7 +166,7 @@ func (r SearchRequest) Do(providedCtx context.Context, transport Transport) (*Re
 	}
 
 	if r.BatchedReduceSize != nil {
-		params["batched_reduce_size"] = strconv.FormatInt(int64(*r.BatchedReduceSize), 10)
+		params["batched_reduce_size"] = strconv.FormatInt(*r.BatchedReduceSize, 10)
 	}
 
 	if r.CcsMinimizeRoundtrips != nil {
@@ -226,7 +226,7 @@ func (r SearchRequest) Do(providedCtx context.Context, transport Transport) (*Re
 	}
 
 	if r.PreFilterShardSize != nil {
-		params["pre_filter_shard_size"] = strconv.FormatInt(int64(*r.PreFilterShardSize), 10)
+		params["pre_filter_shard_size"] = strconv.FormatInt(*r.PreFilterShardSize, 10)
 	}
 
 	if r.ProjectRouting != "" {
@@ -302,7 +302,7 @@ func (r SearchRequest) Do(providedCtx context.Context, transport Transport) (*Re
 	}
 
 	if r.SuggestSize != nil {
-		params["suggest_size"] = strconv.FormatInt(int64(*r.SuggestSize), 10)
+		params["suggest_size"] = strconv.FormatInt(*r.SuggestSize, 10)
 	}
 
 	if r.SuggestText != "" {
@@ -310,7 +310,7 @@ func (r SearchRequest) Do(providedCtx context.Context, transport Transport) (*Re
 	}
 
 	if r.TerminateAfter != nil {
-		params["terminate_after"] = strconv.FormatInt(int64(*r.TerminateAfter), 10)
+		params["terminate_after"] = strconv.FormatInt(*r.TerminateAfter, 10)
 	}
 
 	if r.Timeout != 0 {
@@ -461,7 +461,7 @@ func (f Search) WithAnalyzeWildcard(v bool) func(*SearchRequest) {
 }
 
 // WithBatchedReduceSize - the number of shard results that should be reduced at once on the coordinating node. this value should be used as a protection mechanism to reduce the memory overhead per search request if the potential number of shards in the request can be large..
-func (f Search) WithBatchedReduceSize(v int) func(*SearchRequest) {
+func (f Search) WithBatchedReduceSize(v int64) func(*SearchRequest) {
 	return func(r *SearchRequest) {
 		r.BatchedReduceSize = &v
 	}
@@ -566,7 +566,7 @@ func (f Search) WithPreference(v string) func(*SearchRequest) {
 }
 
 // WithPreFilterShardSize - a threshold that enforces a pre-filter roundtrip to prefilter search shards based on query rewriting if the number of shards the search request expands to exceeds the threshold. this filter roundtrip can limit the number of shards significantly if for instance a shard can not match any documents based on its rewrite method ie. if date filters are mandatory to match but the shard bounds and the query are disjoint..
-func (f Search) WithPreFilterShardSize(v int) func(*SearchRequest) {
+func (f Search) WithPreFilterShardSize(v int64) func(*SearchRequest) {
 	return func(r *SearchRequest) {
 		r.PreFilterShardSize = &v
 	}
@@ -699,7 +699,7 @@ func (f Search) WithSuggestMode(v string) func(*SearchRequest) {
 }
 
 // WithSuggestSize - how many suggestions to return in response.
-func (f Search) WithSuggestSize(v int) func(*SearchRequest) {
+func (f Search) WithSuggestSize(v int64) func(*SearchRequest) {
 	return func(r *SearchRequest) {
 		r.SuggestSize = &v
 	}
@@ -713,7 +713,7 @@ func (f Search) WithSuggestText(v string) func(*SearchRequest) {
 }
 
 // WithTerminateAfter - the maximum number of documents to collect for each shard, upon reaching which the query execution will terminate early..
-func (f Search) WithTerminateAfter(v int) func(*SearchRequest) {
+func (f Search) WithTerminateAfter(v int64) func(*SearchRequest) {
 	return func(r *SearchRequest) {
 		r.TerminateAfter = &v
 	}

--- a/esapi/api.shutdown.get_node.go
+++ b/esapi/api.shutdown.get_node.go
@@ -50,7 +50,7 @@ type ShutdownGetNode func(o ...func(*ShutdownGetNodeRequest)) (*Response, error)
 
 // ShutdownGetNodeRequest configures the Shutdown Get Node API request.
 type ShutdownGetNodeRequest struct {
-	NodeID string
+	NodeID []string
 
 	MasterTimeout time.Duration
 
@@ -85,15 +85,15 @@ func (r ShutdownGetNodeRequest) Do(providedCtx context.Context, transport Transp
 
 	method = "GET"
 
-	path.Grow(7 + 1 + len("_nodes") + 1 + len(r.NodeID) + 1 + len("shutdown"))
+	path.Grow(7 + 1 + len("_nodes") + 1 + len(strings.Join(r.NodeID, ",")) + 1 + len("shutdown"))
 	path.WriteString("http://")
 	path.WriteString("/")
 	path.WriteString("_nodes")
-	if r.NodeID != "" {
+	if len(r.NodeID) > 0 {
 		path.WriteString("/")
-		path.WriteString(r.NodeID)
+		path.WriteString(strings.Join(r.NodeID, ","))
 		if instrument, ok := r.Instrument.(Instrumentation); ok {
-			instrument.RecordPathPart(ctx, "node_id", r.NodeID)
+			instrument.RecordPathPart(ctx, "node_id", strings.Join(r.NodeID, ","))
 		}
 	}
 	path.WriteString("/")
@@ -183,8 +183,8 @@ func (f ShutdownGetNode) WithContext(v context.Context) func(*ShutdownGetNodeReq
 	}
 }
 
-// WithNodeID - which node for which to retrieve the shutdown status.
-func (f ShutdownGetNode) WithNodeID(v string) func(*ShutdownGetNodeRequest) {
+// WithNodeID - comma-separated list of nodes for which to retrieve the shutdown status.
+func (f ShutdownGetNode) WithNodeID(v ...string) func(*ShutdownGetNodeRequest) {
 	return func(r *ShutdownGetNodeRequest) {
 		r.NodeID = v
 	}

--- a/esapi/api.simulate.ingest.go
+++ b/esapi/api.simulate.ingest.go
@@ -206,7 +206,7 @@ func (f SimulateIngest) WithIndex(v string) func(*SimulateIngestRequest) {
 	}
 }
 
-// WithMergeType - the mapping merge type if mapping overrides are being provided in mapping_addition. the allowed values are one of index or template. the index option merges mappings the way they would be merged into an existing index. the template option merges mappings the way they would be merged into a template..
+// WithMergeType - the mapping merge type if mapping overrides are being provided in mapping_addition.the allowed values are one of index or template.the index option merges mappings the way they would be merged into an existing index.the template option merges mappings the way they would be merged into a template..
 func (f SimulateIngest) WithMergeType(v string) func(*SimulateIngestRequest) {
 	return func(r *SimulateIngestRequest) {
 		r.MergeType = v

--- a/esapi/api.snapshot.repository_verify_integrity.go
+++ b/esapi/api.snapshot.repository_verify_integrity.go
@@ -21,13 +21,14 @@ package esapi
 
 import (
 	"context"
+	"errors"
 	"net/http"
 	"strconv"
 	"strings"
 )
 
 func newSnapshotRepositoryVerifyIntegrityFunc(t Transport) SnapshotRepositoryVerifyIntegrity {
-	return func(repository string, o ...func(*SnapshotRepositoryVerifyIntegrityRequest)) (*Response, error) {
+	return func(repository []string, o ...func(*SnapshotRepositoryVerifyIntegrityRequest)) (*Response, error) {
 		var r = SnapshotRepositoryVerifyIntegrityRequest{Repository: repository}
 		for _, f := range o {
 			f(&r)
@@ -48,11 +49,11 @@ func newSnapshotRepositoryVerifyIntegrityFunc(t Transport) SnapshotRepositoryVer
 // This API is experimental.
 //
 // See full documentation at https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-snapshot-repository-verify-integrity.
-type SnapshotRepositoryVerifyIntegrity func(repository string, o ...func(*SnapshotRepositoryVerifyIntegrityRequest)) (*Response, error)
+type SnapshotRepositoryVerifyIntegrity func(repository []string, o ...func(*SnapshotRepositoryVerifyIntegrityRequest)) (*Response, error)
 
 // SnapshotRepositoryVerifyIntegrityRequest configures the Snapshot Repository Verify Integrity API request.
 type SnapshotRepositoryVerifyIntegrityRequest struct {
-	Repository string
+	Repository []string
 
 	BlobThreadPoolConcurrency            *int
 	IndexSnapshotVerificationConcurrency *int
@@ -94,14 +95,18 @@ func (r SnapshotRepositoryVerifyIntegrityRequest) Do(providedCtx context.Context
 
 	method = "POST"
 
-	path.Grow(7 + 1 + len("_snapshot") + 1 + len(r.Repository) + 1 + len("_verify_integrity"))
+	if len(r.Repository) == 0 {
+		return nil, errors.New("repository is required and cannot be nil or empty")
+	}
+
+	path.Grow(7 + 1 + len("_snapshot") + 1 + len(strings.Join(r.Repository, ",")) + 1 + len("_verify_integrity"))
 	path.WriteString("http://")
 	path.WriteString("/")
 	path.WriteString("_snapshot")
 	path.WriteString("/")
-	path.WriteString(r.Repository)
+	path.WriteString(strings.Join(r.Repository, ","))
 	if instrument, ok := r.Instrument.(Instrumentation); ok {
-		instrument.RecordPathPart(ctx, "repository", r.Repository)
+		instrument.RecordPathPart(ctx, "repository", strings.Join(r.Repository, ","))
 	}
 	path.WriteString("/")
 	path.WriteString("_verify_integrity")

--- a/esapi/api.streams.logs_disable.go
+++ b/esapi/api.streams.logs_disable.go
@@ -45,7 +45,9 @@ func newStreamsLogsDisableFunc(t Transport) StreamsLogsDisable {
 
 // StreamsLogsDisable disable the Logs Streams feature for this cluster
 //
-// See full documentation at https://www.elastic.co/guide/en/elasticsearch/reference/master/streams-logs-disable.html.
+// This API is experimental.
+//
+// See full documentation at https://www.elastic.co/docs/api/doc/elasticsearch#TODO.
 type StreamsLogsDisable func(o ...func(*StreamsLogsDisableRequest)) (*Response, error)
 
 // StreamsLogsDisableRequest configures the Streams Logs Disable API request.

--- a/esapi/api.streams.logs_enable.go
+++ b/esapi/api.streams.logs_enable.go
@@ -45,7 +45,9 @@ func newStreamsLogsEnableFunc(t Transport) StreamsLogsEnable {
 
 // StreamsLogsEnable enable the Logs Streams feature for this cluster
 //
-// See full documentation at https://www.elastic.co/guide/en/elasticsearch/reference/master/streams-logs-enable.html.
+// This API is experimental.
+//
+// See full documentation at https://www.elastic.co/docs/api/doc/elasticsearch#TODO.
 type StreamsLogsEnable func(o ...func(*StreamsLogsEnableRequest)) (*Response, error)
 
 // StreamsLogsEnableRequest configures the Streams Logs Enable API request.

--- a/esapi/api.streams.status.go
+++ b/esapi/api.streams.status.go
@@ -45,7 +45,9 @@ func newStreamsStatusFunc(t Transport) StreamsStatus {
 
 // StreamsStatus return the current status of the streams feature for each streams type
 //
-// See full documentation at https://www.elastic.co/guide/en/elasticsearch/reference/master/streams-status.html.
+// This API is experimental.
+//
+// See full documentation at https://www.elastic.co/docs/api/doc/elasticsearch#TODO.
 type StreamsStatus func(o ...func(*StreamsStatusRequest)) (*Response, error)
 
 // StreamsStatusRequest configures the Streams Status API request.

--- a/esapi/api.termvectors.go
+++ b/esapi/api.termvectors.go
@@ -65,7 +65,7 @@ type TermvectorsRequest struct {
 	Realtime        *bool
 	Routing         string
 	TermStatistics  *bool
-	Version         *int
+	Version         *int64
 	VersionType     string
 
 	Pretty     bool
@@ -155,7 +155,7 @@ func (r TermvectorsRequest) Do(providedCtx context.Context, transport Transport)
 	}
 
 	if r.Version != nil {
-		params["version"] = strconv.FormatInt(int64(*r.Version), 10)
+		params["version"] = strconv.FormatInt(*r.Version, 10)
 	}
 
 	if r.VersionType != "" {
@@ -325,7 +325,7 @@ func (f Termvectors) WithTermStatistics(v bool) func(*TermvectorsRequest) {
 }
 
 // WithVersion - explicit version number for concurrency control.
-func (f Termvectors) WithVersion(v int) func(*TermvectorsRequest) {
+func (f Termvectors) WithVersion(v int64) func(*TermvectorsRequest) {
 	return func(r *TermvectorsRequest) {
 		r.Version = &v
 	}

--- a/esapi/api.update.go
+++ b/esapi/api.update.go
@@ -57,8 +57,8 @@ type UpdateRequest struct {
 
 	Body io.Reader
 
-	IfPrimaryTerm        *int
-	IfSeqNo              *int
+	IfPrimaryTerm        *int64
+	IfSeqNo              *int64
 	IncludeSourceOnError *bool
 	Lang                 string
 	Refresh              string
@@ -120,11 +120,11 @@ func (r UpdateRequest) Do(providedCtx context.Context, transport Transport) (*Re
 	params = make(map[string]string)
 
 	if r.IfPrimaryTerm != nil {
-		params["if_primary_term"] = strconv.FormatInt(int64(*r.IfPrimaryTerm), 10)
+		params["if_primary_term"] = strconv.FormatInt(*r.IfPrimaryTerm, 10)
 	}
 
 	if r.IfSeqNo != nil {
-		params["if_seq_no"] = strconv.FormatInt(int64(*r.IfSeqNo), 10)
+		params["if_seq_no"] = strconv.FormatInt(*r.IfSeqNo, 10)
 	}
 
 	if r.IncludeSourceOnError != nil {
@@ -257,14 +257,14 @@ func (f Update) WithContext(v context.Context) func(*UpdateRequest) {
 }
 
 // WithIfPrimaryTerm - only perform the update operation if the last operation that has changed the document has the specified primary term.
-func (f Update) WithIfPrimaryTerm(v int) func(*UpdateRequest) {
+func (f Update) WithIfPrimaryTerm(v int64) func(*UpdateRequest) {
 	return func(r *UpdateRequest) {
 		r.IfPrimaryTerm = &v
 	}
 }
 
 // WithIfSeqNo - only perform the update operation if the last operation that has changed the document has the specified sequence number.
-func (f Update) WithIfSeqNo(v int) func(*UpdateRequest) {
+func (f Update) WithIfSeqNo(v int64) func(*UpdateRequest) {
 	return func(r *UpdateRequest) {
 		r.IfSeqNo = &v
 	}

--- a/esapi/api.update_by_query.go
+++ b/esapi/api.update_by_query.go
@@ -65,10 +65,10 @@ type UpdateByQueryRequest struct {
 	DefaultOperator     string
 	Df                  string
 	ExpandWildcards     string
-	From                *int
+	From                *int64
 	IgnoreUnavailable   *bool
 	Lenient             *bool
-	MaxDocs             *int
+	MaxDocs             *int64
 	Pipeline            string
 	Preference          string
 	Query               string
@@ -77,13 +77,13 @@ type UpdateByQueryRequest struct {
 	RequestsPerSecond   *int
 	Routing             []string
 	Scroll              time.Duration
-	ScrollSize          *int
+	ScrollSize          *int64
 	SearchTimeout       time.Duration
 	SearchType          string
 	Slices              interface{}
 	Sort                []string
 	Stats               []string
-	TerminateAfter      *int
+	TerminateAfter      *int64
 	Timeout             time.Duration
 	Version             *bool
 	VersionType         *bool
@@ -166,7 +166,7 @@ func (r UpdateByQueryRequest) Do(providedCtx context.Context, transport Transpor
 	}
 
 	if r.From != nil {
-		params["from"] = strconv.FormatInt(int64(*r.From), 10)
+		params["from"] = strconv.FormatInt(*r.From, 10)
 	}
 
 	if r.IgnoreUnavailable != nil {
@@ -178,7 +178,7 @@ func (r UpdateByQueryRequest) Do(providedCtx context.Context, transport Transpor
 	}
 
 	if r.MaxDocs != nil {
-		params["max_docs"] = strconv.FormatInt(int64(*r.MaxDocs), 10)
+		params["max_docs"] = strconv.FormatInt(*r.MaxDocs, 10)
 	}
 
 	if r.Pipeline != "" {
@@ -214,7 +214,7 @@ func (r UpdateByQueryRequest) Do(providedCtx context.Context, transport Transpor
 	}
 
 	if r.ScrollSize != nil {
-		params["scroll_size"] = strconv.FormatInt(int64(*r.ScrollSize), 10)
+		params["scroll_size"] = strconv.FormatInt(*r.ScrollSize, 10)
 	}
 
 	if r.SearchTimeout != 0 {
@@ -238,7 +238,7 @@ func (r UpdateByQueryRequest) Do(providedCtx context.Context, transport Transpor
 	}
 
 	if r.TerminateAfter != nil {
-		params["terminate_after"] = strconv.FormatInt(int64(*r.TerminateAfter), 10)
+		params["terminate_after"] = strconv.FormatInt(*r.TerminateAfter, 10)
 	}
 
 	if r.Timeout != 0 {
@@ -403,7 +403,7 @@ func (f UpdateByQuery) WithExpandWildcards(v string) func(*UpdateByQueryRequest)
 }
 
 // WithFrom - starting offset (default: 0).
-func (f UpdateByQuery) WithFrom(v int) func(*UpdateByQueryRequest) {
+func (f UpdateByQuery) WithFrom(v int64) func(*UpdateByQueryRequest) {
 	return func(r *UpdateByQueryRequest) {
 		r.From = &v
 	}
@@ -424,7 +424,7 @@ func (f UpdateByQuery) WithLenient(v bool) func(*UpdateByQueryRequest) {
 }
 
 // WithMaxDocs - maximum number of documents to process (default: all documents).
-func (f UpdateByQuery) WithMaxDocs(v int) func(*UpdateByQueryRequest) {
+func (f UpdateByQuery) WithMaxDocs(v int64) func(*UpdateByQueryRequest) {
 	return func(r *UpdateByQueryRequest) {
 		r.MaxDocs = &v
 	}
@@ -487,7 +487,7 @@ func (f UpdateByQuery) WithScroll(v time.Duration) func(*UpdateByQueryRequest) {
 }
 
 // WithScrollSize - size on the scroll request powering the update by query.
-func (f UpdateByQuery) WithScrollSize(v int) func(*UpdateByQueryRequest) {
+func (f UpdateByQuery) WithScrollSize(v int64) func(*UpdateByQueryRequest) {
 	return func(r *UpdateByQueryRequest) {
 		r.ScrollSize = &v
 	}
@@ -529,7 +529,7 @@ func (f UpdateByQuery) WithStats(v ...string) func(*UpdateByQueryRequest) {
 }
 
 // WithTerminateAfter - the maximum number of documents to collect for each shard, upon reaching which the query execution will terminate early..
-func (f UpdateByQuery) WithTerminateAfter(v int) func(*UpdateByQueryRequest) {
+func (f UpdateByQuery) WithTerminateAfter(v int64) func(*UpdateByQueryRequest) {
 	return func(r *UpdateByQueryRequest) {
 		r.TerminateAfter = &v
 	}

--- a/esapi/api.xpack.async_search.submit.go
+++ b/esapi/api.xpack.async_search.submit.go
@@ -61,7 +61,7 @@ type AsyncSearchSubmitRequest struct {
 	AllowPartialSearchResults  *bool
 	Analyzer                   string
 	AnalyzeWildcard            *bool
-	BatchedReduceSize          *int
+	BatchedReduceSize          *int64
 	CcsMinimizeRoundtrips      *bool
 	DefaultOperator            string
 	Df                         string
@@ -92,9 +92,9 @@ type AsyncSearchSubmitRequest struct {
 	StoredFields               []string
 	SuggestField               string
 	SuggestMode                string
-	SuggestSize                *int
+	SuggestSize                *int64
 	SuggestText                string
-	TerminateAfter             *int
+	TerminateAfter             *int64
 	Timeout                    time.Duration
 	TrackScores                *bool
 	TrackTotalHits             interface{}
@@ -164,7 +164,7 @@ func (r AsyncSearchSubmitRequest) Do(providedCtx context.Context, transport Tran
 	}
 
 	if r.BatchedReduceSize != nil {
-		params["batched_reduce_size"] = strconv.FormatInt(int64(*r.BatchedReduceSize), 10)
+		params["batched_reduce_size"] = strconv.FormatInt(*r.BatchedReduceSize, 10)
 	}
 
 	if r.CcsMinimizeRoundtrips != nil {
@@ -288,7 +288,7 @@ func (r AsyncSearchSubmitRequest) Do(providedCtx context.Context, transport Tran
 	}
 
 	if r.SuggestSize != nil {
-		params["suggest_size"] = strconv.FormatInt(int64(*r.SuggestSize), 10)
+		params["suggest_size"] = strconv.FormatInt(*r.SuggestSize, 10)
 	}
 
 	if r.SuggestText != "" {
@@ -296,7 +296,7 @@ func (r AsyncSearchSubmitRequest) Do(providedCtx context.Context, transport Tran
 	}
 
 	if r.TerminateAfter != nil {
-		params["terminate_after"] = strconv.FormatInt(int64(*r.TerminateAfter), 10)
+		params["terminate_after"] = strconv.FormatInt(*r.TerminateAfter, 10)
 	}
 
 	if r.Timeout != 0 {
@@ -451,7 +451,7 @@ func (f AsyncSearchSubmit) WithAnalyzeWildcard(v bool) func(*AsyncSearchSubmitRe
 }
 
 // WithBatchedReduceSize - the number of shard results that should be reduced at once on the coordinating node. this value should be used as the granularity at which progress results will be made available..
-func (f AsyncSearchSubmit) WithBatchedReduceSize(v int) func(*AsyncSearchSubmitRequest) {
+func (f AsyncSearchSubmit) WithBatchedReduceSize(v int64) func(*AsyncSearchSubmitRequest) {
 	return func(r *AsyncSearchSubmitRequest) {
 		r.BatchedReduceSize = &v
 	}
@@ -499,7 +499,7 @@ func (f AsyncSearchSubmit) WithExplain(v bool) func(*AsyncSearchSubmitRequest) {
 	}
 }
 
-// WithFrom - starting offset (default: 0).
+// WithFrom - starting offset.
 func (f AsyncSearchSubmit) WithFrom(v int) func(*AsyncSearchSubmitRequest) {
 	return func(r *AsyncSearchSubmitRequest) {
 		r.From = &v
@@ -604,7 +604,7 @@ func (f AsyncSearchSubmit) WithSeqNoPrimaryTerm(v bool) func(*AsyncSearchSubmitR
 	}
 }
 
-// WithSize - number of hits to return (default: 10).
+// WithSize - number of hits to return.
 func (f AsyncSearchSubmit) WithSize(v int) func(*AsyncSearchSubmitRequest) {
 	return func(r *AsyncSearchSubmitRequest) {
 		r.Size = &v
@@ -668,7 +668,7 @@ func (f AsyncSearchSubmit) WithSuggestMode(v string) func(*AsyncSearchSubmitRequ
 }
 
 // WithSuggestSize - how many suggestions to return in response.
-func (f AsyncSearchSubmit) WithSuggestSize(v int) func(*AsyncSearchSubmitRequest) {
+func (f AsyncSearchSubmit) WithSuggestSize(v int64) func(*AsyncSearchSubmitRequest) {
 	return func(r *AsyncSearchSubmitRequest) {
 		r.SuggestSize = &v
 	}
@@ -682,7 +682,7 @@ func (f AsyncSearchSubmit) WithSuggestText(v string) func(*AsyncSearchSubmitRequ
 }
 
 // WithTerminateAfter - the maximum number of documents to collect for each shard, upon reaching which the query execution will terminate early..
-func (f AsyncSearchSubmit) WithTerminateAfter(v int) func(*AsyncSearchSubmitRequest) {
+func (f AsyncSearchSubmit) WithTerminateAfter(v int64) func(*AsyncSearchSubmitRequest) {
 	return func(r *AsyncSearchSubmitRequest) {
 		r.TerminateAfter = &v
 	}

--- a/esapi/api.xpack.eql.search.go
+++ b/esapi/api.xpack.eql.search.go
@@ -21,6 +21,7 @@ package esapi
 
 import (
 	"context"
+	"errors"
 	"io"
 	"net/http"
 	"strconv"
@@ -29,7 +30,7 @@ import (
 )
 
 func newEqlSearchFunc(t Transport) EqlSearch {
-	return func(index string, body io.Reader, o ...func(*EqlSearchRequest)) (*Response, error) {
+	return func(index []string, body io.Reader, o ...func(*EqlSearchRequest)) (*Response, error) {
 		var r = EqlSearchRequest{Index: index, Body: body}
 		for _, f := range o {
 			f(&r)
@@ -48,11 +49,11 @@ func newEqlSearchFunc(t Transport) EqlSearch {
 // EqlSearch - Get EQL search results
 //
 // See full documentation at https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-eql-search.
-type EqlSearch func(index string, body io.Reader, o ...func(*EqlSearchRequest)) (*Response, error)
+type EqlSearch func(index []string, body io.Reader, o ...func(*EqlSearchRequest)) (*Response, error)
 
 // EqlSearchRequest configures the Eql Search API request.
 type EqlSearchRequest struct {
-	Index string
+	Index []string
 
 	Body io.Reader
 
@@ -98,12 +99,16 @@ func (r EqlSearchRequest) Do(providedCtx context.Context, transport Transport) (
 
 	method = "POST"
 
-	path.Grow(7 + 1 + len(r.Index) + 1 + len("_eql") + 1 + len("search"))
+	if len(r.Index) == 0 {
+		return nil, errors.New("index is required and cannot be nil or empty")
+	}
+
+	path.Grow(7 + 1 + len(strings.Join(r.Index, ",")) + 1 + len("_eql") + 1 + len("search"))
 	path.WriteString("http://")
 	path.WriteString("/")
-	path.WriteString(r.Index)
+	path.WriteString(strings.Join(r.Index, ","))
 	if instrument, ok := r.Instrument.(Instrumentation); ok {
-		instrument.RecordPathPart(ctx, "index", r.Index)
+		instrument.RecordPathPart(ctx, "index", strings.Join(r.Index, ","))
 	}
 	path.WriteString("/")
 	path.WriteString("_eql")

--- a/esapi/api.xpack.esql.async_query.go
+++ b/esapi/api.xpack.esql.async_query.go
@@ -217,7 +217,7 @@ func (f EsqlAsyncQuery) WithDropNullColumns(v bool) func(*EsqlAsyncQueryRequest)
 	}
 }
 
-// WithFormat - a short version of the accept header, e.g. json, yaml.
+// WithFormat - a short version of the accept header, e.g. json, yaml.`csv`, `tsv`, and `txt` formats will return results in a tabular format, excluding other metadata fields from the response.for async requests, nothing will be returned if the async query doesn't finish within the timeout.the query ID and running status are available in the `x-elasticsearch-async-ID` and `x-elasticsearch-async-is-running` http headers of the response, respectively..
 func (f EsqlAsyncQuery) WithFormat(v string) func(*EsqlAsyncQueryRequest) {
 	return func(r *EsqlAsyncQueryRequest) {
 		r.Format = v

--- a/esapi/api.xpack.esql.async_query_get.go
+++ b/esapi/api.xpack.esql.async_query_get.go
@@ -204,7 +204,7 @@ func (f EsqlAsyncQueryGet) WithDropNullColumns(v bool) func(*EsqlAsyncQueryGetRe
 	}
 }
 
-// WithFormat - a short version of the accept header, e.g. json, yaml.
+// WithFormat - a short version of the accept header, for example `json` or `yaml`..
 func (f EsqlAsyncQueryGet) WithFormat(v string) func(*EsqlAsyncQueryGetRequest) {
 	return func(r *EsqlAsyncQueryGetRequest) {
 		r.Format = v

--- a/esapi/api.xpack.esql.get_query.go
+++ b/esapi/api.xpack.esql.get_query.go
@@ -45,6 +45,8 @@ func newEsqlGetQueryFunc(t Transport) EsqlGetQuery {
 // EsqlGetQuery - Get a specific running ES|QL query information
 //
 // This API is experimental.
+//
+// See full documentation at https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-esql-get-query.
 type EsqlGetQuery func(id string, o ...func(*EsqlGetQueryRequest)) (*Response, error)
 
 // EsqlGetQueryRequest configures the Esql Get Query API request.

--- a/esapi/api.xpack.esql.list_queries.go
+++ b/esapi/api.xpack.esql.list_queries.go
@@ -45,6 +45,8 @@ func newEsqlListQueriesFunc(t Transport) EsqlListQueries {
 // EsqlListQueries - Get running ES|QL queries information
 //
 // This API is experimental.
+//
+// See full documentation at https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-esql-list-queries.
 type EsqlListQueries func(o ...func(*EsqlListQueriesRequest)) (*Response, error)
 
 // EsqlListQueriesRequest configures the Esql List Queries API request.

--- a/esapi/api.xpack.esql.query.go
+++ b/esapi/api.xpack.esql.query.go
@@ -217,7 +217,7 @@ func (f EsqlQuery) WithDropNullColumns(v bool) func(*EsqlQueryRequest) {
 	}
 }
 
-// WithFormat - a short version of the accept header, e.g. json, yaml.
+// WithFormat - a short version of the accept header, e.g. json, yaml.`csv`, `tsv`, and `txt` formats will return results in a tabular format, excluding other metadata fields from the response..
 func (f EsqlQuery) WithFormat(v string) func(*EsqlQueryRequest) {
 	return func(r *EsqlQueryRequest) {
 		r.Format = v

--- a/esapi/api.xpack.indices.data_streams_stats.go
+++ b/esapi/api.xpack.indices.data_streams_stats.go
@@ -51,6 +51,8 @@ type IndicesDataStreamsStats func(o ...func(*IndicesDataStreamsStatsRequest)) (*
 type IndicesDataStreamsStatsRequest struct {
 	Name []string
 
+	ExpandWildcards []string
+
 	Pretty     bool
 	Human      bool
 	ErrorTrace bool
@@ -97,6 +99,10 @@ func (r IndicesDataStreamsStatsRequest) Do(providedCtx context.Context, transpor
 	path.WriteString("_stats")
 
 	params = make(map[string]string)
+
+	if len(r.ExpandWildcards) > 0 {
+		params["expand_wildcards"] = strings.Join(r.ExpandWildcards, ",")
+	}
 
 	if r.Pretty {
 		params["pretty"] = "true"
@@ -180,6 +186,13 @@ func (f IndicesDataStreamsStats) WithContext(v context.Context) func(*IndicesDat
 func (f IndicesDataStreamsStats) WithName(v ...string) func(*IndicesDataStreamsStatsRequest) {
 	return func(r *IndicesDataStreamsStatsRequest) {
 		r.Name = v
+	}
+}
+
+// WithExpandWildcards - whether to expand wildcard expressions to concrete data stream names that are open, closed or both..
+func (f IndicesDataStreamsStats) WithExpandWildcards(v ...string) func(*IndicesDataStreamsStatsRequest) {
+	return func(r *IndicesDataStreamsStatsRequest) {
+		r.ExpandWildcards = v
 	}
 }
 

--- a/esapi/api.xpack.indices.get_data_stream_mappings.go
+++ b/esapi/api.xpack.indices.get_data_stream_mappings.go
@@ -21,13 +21,14 @@ package esapi
 
 import (
 	"context"
+	"errors"
 	"net/http"
 	"strings"
 	"time"
 )
 
 func newIndicesGetDataStreamMappingsFunc(t Transport) IndicesGetDataStreamMappings {
-	return func(name string, o ...func(*IndicesGetDataStreamMappingsRequest)) (*Response, error) {
+	return func(name []string, o ...func(*IndicesGetDataStreamMappingsRequest)) (*Response, error) {
 		var r = IndicesGetDataStreamMappingsRequest{Name: name}
 		for _, f := range o {
 			f(&r)
@@ -46,11 +47,11 @@ func newIndicesGetDataStreamMappingsFunc(t Transport) IndicesGetDataStreamMappin
 // IndicesGetDataStreamMappings - Get data stream mappings
 //
 // See full documentation at https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-indices-get-data-stream-mappings.
-type IndicesGetDataStreamMappings func(name string, o ...func(*IndicesGetDataStreamMappingsRequest)) (*Response, error)
+type IndicesGetDataStreamMappings func(name []string, o ...func(*IndicesGetDataStreamMappingsRequest)) (*Response, error)
 
 // IndicesGetDataStreamMappingsRequest configures the Indices Get Data Stream Mappings API request.
 type IndicesGetDataStreamMappingsRequest struct {
-	Name string
+	Name []string
 
 	MasterTimeout time.Duration
 
@@ -85,14 +86,18 @@ func (r IndicesGetDataStreamMappingsRequest) Do(providedCtx context.Context, tra
 
 	method = "GET"
 
-	path.Grow(7 + 1 + len("_data_stream") + 1 + len(r.Name) + 1 + len("_mappings"))
+	if len(r.Name) == 0 {
+		return nil, errors.New("name is required and cannot be nil or empty")
+	}
+
+	path.Grow(7 + 1 + len("_data_stream") + 1 + len(strings.Join(r.Name, ",")) + 1 + len("_mappings"))
 	path.WriteString("http://")
 	path.WriteString("/")
 	path.WriteString("_data_stream")
 	path.WriteString("/")
-	path.WriteString(r.Name)
+	path.WriteString(strings.Join(r.Name, ","))
 	if instrument, ok := r.Instrument.(Instrumentation); ok {
-		instrument.RecordPathPart(ctx, "name", r.Name)
+		instrument.RecordPathPart(ctx, "name", strings.Join(r.Name, ","))
 	}
 	path.WriteString("/")
 	path.WriteString("_mappings")

--- a/esapi/api.xpack.indices.get_data_stream_settings.go
+++ b/esapi/api.xpack.indices.get_data_stream_settings.go
@@ -21,13 +21,14 @@ package esapi
 
 import (
 	"context"
+	"errors"
 	"net/http"
 	"strings"
 	"time"
 )
 
 func newIndicesGetDataStreamSettingsFunc(t Transport) IndicesGetDataStreamSettings {
-	return func(name string, o ...func(*IndicesGetDataStreamSettingsRequest)) (*Response, error) {
+	return func(name []string, o ...func(*IndicesGetDataStreamSettingsRequest)) (*Response, error) {
 		var r = IndicesGetDataStreamSettingsRequest{Name: name}
 		for _, f := range o {
 			f(&r)
@@ -46,11 +47,11 @@ func newIndicesGetDataStreamSettingsFunc(t Transport) IndicesGetDataStreamSettin
 // IndicesGetDataStreamSettings - Get data stream settings
 //
 // See full documentation at https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-indices-get-data-stream-settings.
-type IndicesGetDataStreamSettings func(name string, o ...func(*IndicesGetDataStreamSettingsRequest)) (*Response, error)
+type IndicesGetDataStreamSettings func(name []string, o ...func(*IndicesGetDataStreamSettingsRequest)) (*Response, error)
 
 // IndicesGetDataStreamSettingsRequest configures the Indices Get Data Stream Settings API request.
 type IndicesGetDataStreamSettingsRequest struct {
-	Name string
+	Name []string
 
 	MasterTimeout time.Duration
 
@@ -85,14 +86,18 @@ func (r IndicesGetDataStreamSettingsRequest) Do(providedCtx context.Context, tra
 
 	method = "GET"
 
-	path.Grow(7 + 1 + len("_data_stream") + 1 + len(r.Name) + 1 + len("_settings"))
+	if len(r.Name) == 0 {
+		return nil, errors.New("name is required and cannot be nil or empty")
+	}
+
+	path.Grow(7 + 1 + len("_data_stream") + 1 + len(strings.Join(r.Name, ",")) + 1 + len("_settings"))
 	path.WriteString("http://")
 	path.WriteString("/")
 	path.WriteString("_data_stream")
 	path.WriteString("/")
-	path.WriteString(r.Name)
+	path.WriteString(strings.Join(r.Name, ","))
 	if instrument, ok := r.Instrument.(Instrumentation); ok {
-		instrument.RecordPathPart(ctx, "name", r.Name)
+		instrument.RecordPathPart(ctx, "name", strings.Join(r.Name, ","))
 	}
 	path.WriteString("/")
 	path.WriteString("_settings")

--- a/esapi/api.xpack.logstash.get_pipeline.go
+++ b/esapi/api.xpack.logstash.get_pipeline.go
@@ -49,7 +49,7 @@ type LogstashGetPipeline func(o ...func(*LogstashGetPipelineRequest)) (*Response
 
 // LogstashGetPipelineRequest configures the Logstash Get Pipeline API request.
 type LogstashGetPipelineRequest struct {
-	DocumentID string
+	DocumentID []string
 
 	Pretty     bool
 	Human      bool
@@ -82,17 +82,17 @@ func (r LogstashGetPipelineRequest) Do(providedCtx context.Context, transport Tr
 
 	method = "GET"
 
-	path.Grow(7 + 1 + len("_logstash") + 1 + len("pipeline") + 1 + len(r.DocumentID))
+	path.Grow(7 + 1 + len("_logstash") + 1 + len("pipeline") + 1 + len(strings.Join(r.DocumentID, ",")))
 	path.WriteString("http://")
 	path.WriteString("/")
 	path.WriteString("_logstash")
 	path.WriteString("/")
 	path.WriteString("pipeline")
-	if r.DocumentID != "" {
+	if len(r.DocumentID) > 0 {
 		path.WriteString("/")
-		path.WriteString(r.DocumentID)
+		path.WriteString(strings.Join(r.DocumentID, ","))
 		if instrument, ok := r.Instrument.(Instrumentation); ok {
-			instrument.RecordPathPart(ctx, "id", r.DocumentID)
+			instrument.RecordPathPart(ctx, "id", strings.Join(r.DocumentID, ","))
 		}
 	}
 
@@ -176,8 +176,8 @@ func (f LogstashGetPipeline) WithContext(v context.Context) func(*LogstashGetPip
 	}
 }
 
-// WithDocumentID - a list of pipeline ids.
-func (f LogstashGetPipeline) WithDocumentID(v string) func(*LogstashGetPipelineRequest) {
+// WithDocumentID - a list of pipeline identifiers..
+func (f LogstashGetPipeline) WithDocumentID(v ...string) func(*LogstashGetPipelineRequest) {
 	return func(r *LogstashGetPipelineRequest) {
 		r.DocumentID = v
 	}

--- a/esapi/api.xpack.ml.delete_calendar_job.go
+++ b/esapi/api.xpack.ml.delete_calendar_job.go
@@ -21,12 +21,13 @@ package esapi
 
 import (
 	"context"
+	"errors"
 	"net/http"
 	"strings"
 )
 
 func newMLDeleteCalendarJobFunc(t Transport) MLDeleteCalendarJob {
-	return func(calendar_id string, job_id string, o ...func(*MLDeleteCalendarJobRequest)) (*Response, error) {
+	return func(calendar_id string, job_id []string, o ...func(*MLDeleteCalendarJobRequest)) (*Response, error) {
 		var r = MLDeleteCalendarJobRequest{CalendarID: calendar_id, JobID: job_id}
 		for _, f := range o {
 			f(&r)
@@ -45,12 +46,12 @@ func newMLDeleteCalendarJobFunc(t Transport) MLDeleteCalendarJob {
 // MLDeleteCalendarJob - Delete anomaly jobs from a calendar
 //
 // See full documentation at https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-ml-delete-calendar-job.
-type MLDeleteCalendarJob func(calendar_id string, job_id string, o ...func(*MLDeleteCalendarJobRequest)) (*Response, error)
+type MLDeleteCalendarJob func(calendar_id string, job_id []string, o ...func(*MLDeleteCalendarJobRequest)) (*Response, error)
 
 // MLDeleteCalendarJobRequest configures the ML Delete Calendar Job API request.
 type MLDeleteCalendarJobRequest struct {
 	CalendarID string
-	JobID      string
+	JobID      []string
 
 	Pretty     bool
 	Human      bool
@@ -83,7 +84,11 @@ func (r MLDeleteCalendarJobRequest) Do(providedCtx context.Context, transport Tr
 
 	method = "DELETE"
 
-	path.Grow(7 + 1 + len("_ml") + 1 + len("calendars") + 1 + len(r.CalendarID) + 1 + len("jobs") + 1 + len(r.JobID))
+	if len(r.JobID) == 0 {
+		return nil, errors.New("job_id is required and cannot be nil or empty")
+	}
+
+	path.Grow(7 + 1 + len("_ml") + 1 + len("calendars") + 1 + len(r.CalendarID) + 1 + len("jobs") + 1 + len(strings.Join(r.JobID, ",")))
 	path.WriteString("http://")
 	path.WriteString("/")
 	path.WriteString("_ml")
@@ -97,9 +102,9 @@ func (r MLDeleteCalendarJobRequest) Do(providedCtx context.Context, transport Tr
 	path.WriteString("/")
 	path.WriteString("jobs")
 	path.WriteString("/")
-	path.WriteString(r.JobID)
+	path.WriteString(strings.Join(r.JobID, ","))
 	if instrument, ok := r.Instrument.(Instrumentation); ok {
-		instrument.RecordPathPart(ctx, "job_id", r.JobID)
+		instrument.RecordPathPart(ctx, "job_id", strings.Join(r.JobID, ","))
 	}
 
 	params = make(map[string]string)

--- a/esapi/api.xpack.ml.get_calendar_events.go
+++ b/esapi/api.xpack.ml.get_calendar_events.go
@@ -21,7 +21,6 @@ package esapi
 
 import (
 	"context"
-	"fmt"
 	"net/http"
 	"strconv"
 	"strings"
@@ -53,7 +52,7 @@ type MLGetCalendarEvents func(calendar_id string, o ...func(*MLGetCalendarEvents
 type MLGetCalendarEventsRequest struct {
 	CalendarID string
 
-	End   interface{}
+	End   string
 	From  *int
 	JobID string
 	Size  *int
@@ -106,8 +105,8 @@ func (r MLGetCalendarEventsRequest) Do(providedCtx context.Context, transport Tr
 
 	params = make(map[string]string)
 
-	if r.End != nil {
-		params["end"] = fmt.Sprintf("%v", r.End)
+	if r.End != "" {
+		params["end"] = r.End
 	}
 
 	if r.From != nil {
@@ -205,7 +204,7 @@ func (f MLGetCalendarEvents) WithContext(v context.Context) func(*MLGetCalendarE
 }
 
 // WithEnd - get events before this time.
-func (f MLGetCalendarEvents) WithEnd(v interface{}) func(*MLGetCalendarEventsRequest) {
+func (f MLGetCalendarEvents) WithEnd(v string) func(*MLGetCalendarEventsRequest) {
 	return func(r *MLGetCalendarEventsRequest) {
 		r.End = v
 	}

--- a/esapi/api.xpack.ml.get_categories.go
+++ b/esapi/api.xpack.ml.get_categories.go
@@ -53,7 +53,7 @@ type MLGetCategories func(job_id string, o ...func(*MLGetCategoriesRequest)) (*R
 type MLGetCategoriesRequest struct {
 	Body io.Reader
 
-	CategoryID *int
+	CategoryID *int64
 	JobID      string
 
 	From                *int
@@ -223,7 +223,7 @@ func (f MLGetCategories) WithBody(v io.Reader) func(*MLGetCategoriesRequest) {
 }
 
 // WithCategoryID - the identifier of the category definition of interest.
-func (f MLGetCategories) WithCategoryID(v int) func(*MLGetCategoriesRequest) {
+func (f MLGetCategories) WithCategoryID(v int64) func(*MLGetCategoriesRequest) {
 	return func(r *MLGetCategoriesRequest) {
 		r.CategoryID = &v
 	}

--- a/esapi/api.xpack.ml.get_datafeed_stats.go
+++ b/esapi/api.xpack.ml.get_datafeed_stats.go
@@ -50,7 +50,7 @@ type MLGetDatafeedStats func(o ...func(*MLGetDatafeedStatsRequest)) (*Response, 
 
 // MLGetDatafeedStatsRequest configures the ML Get Datafeed Stats API request.
 type MLGetDatafeedStatsRequest struct {
-	DatafeedID string
+	DatafeedID []string
 
 	AllowNoMatch *bool
 
@@ -85,17 +85,17 @@ func (r MLGetDatafeedStatsRequest) Do(providedCtx context.Context, transport Tra
 
 	method = "GET"
 
-	path.Grow(7 + 1 + len("_ml") + 1 + len("datafeeds") + 1 + len(r.DatafeedID) + 1 + len("_stats"))
+	path.Grow(7 + 1 + len("_ml") + 1 + len("datafeeds") + 1 + len(strings.Join(r.DatafeedID, ",")) + 1 + len("_stats"))
 	path.WriteString("http://")
 	path.WriteString("/")
 	path.WriteString("_ml")
 	path.WriteString("/")
 	path.WriteString("datafeeds")
-	if r.DatafeedID != "" {
+	if len(r.DatafeedID) > 0 {
 		path.WriteString("/")
-		path.WriteString(r.DatafeedID)
+		path.WriteString(strings.Join(r.DatafeedID, ","))
 		if instrument, ok := r.Instrument.(Instrumentation); ok {
-			instrument.RecordPathPart(ctx, "datafeed_id", r.DatafeedID)
+			instrument.RecordPathPart(ctx, "datafeed_id", strings.Join(r.DatafeedID, ","))
 		}
 	}
 	path.WriteString("/")
@@ -185,8 +185,8 @@ func (f MLGetDatafeedStats) WithContext(v context.Context) func(*MLGetDatafeedSt
 	}
 }
 
-// WithDatafeedID - the ID of the datafeeds stats to fetch.
-func (f MLGetDatafeedStats) WithDatafeedID(v string) func(*MLGetDatafeedStatsRequest) {
+// WithDatafeedID - comma-separated list of datafeed identifiers or wildcard expressions. if you do not specify one of these options, the api returns information about all datafeeds..
+func (f MLGetDatafeedStats) WithDatafeedID(v ...string) func(*MLGetDatafeedStatsRequest) {
 	return func(r *MLGetDatafeedStatsRequest) {
 		r.DatafeedID = v
 	}

--- a/esapi/api.xpack.ml.get_datafeeds.go
+++ b/esapi/api.xpack.ml.get_datafeeds.go
@@ -50,7 +50,7 @@ type MLGetDatafeeds func(o ...func(*MLGetDatafeedsRequest)) (*Response, error)
 
 // MLGetDatafeedsRequest configures the ML Get Datafeeds API request.
 type MLGetDatafeedsRequest struct {
-	DatafeedID string
+	DatafeedID []string
 
 	AllowNoMatch     *bool
 	ExcludeGenerated *bool
@@ -86,17 +86,17 @@ func (r MLGetDatafeedsRequest) Do(providedCtx context.Context, transport Transpo
 
 	method = "GET"
 
-	path.Grow(7 + 1 + len("_ml") + 1 + len("datafeeds") + 1 + len(r.DatafeedID))
+	path.Grow(7 + 1 + len("_ml") + 1 + len("datafeeds") + 1 + len(strings.Join(r.DatafeedID, ",")))
 	path.WriteString("http://")
 	path.WriteString("/")
 	path.WriteString("_ml")
 	path.WriteString("/")
 	path.WriteString("datafeeds")
-	if r.DatafeedID != "" {
+	if len(r.DatafeedID) > 0 {
 		path.WriteString("/")
-		path.WriteString(r.DatafeedID)
+		path.WriteString(strings.Join(r.DatafeedID, ","))
 		if instrument, ok := r.Instrument.(Instrumentation); ok {
-			instrument.RecordPathPart(ctx, "datafeed_id", r.DatafeedID)
+			instrument.RecordPathPart(ctx, "datafeed_id", strings.Join(r.DatafeedID, ","))
 		}
 	}
 
@@ -188,8 +188,8 @@ func (f MLGetDatafeeds) WithContext(v context.Context) func(*MLGetDatafeedsReque
 	}
 }
 
-// WithDatafeedID - the ID of the datafeeds to fetch.
-func (f MLGetDatafeeds) WithDatafeedID(v string) func(*MLGetDatafeedsRequest) {
+// WithDatafeedID - identifier for the datafeed. it can be a datafeed identifier or a wildcard expression. if you do not specify one of these options, the api returns information about all datafeeds..
+func (f MLGetDatafeeds) WithDatafeedID(v ...string) func(*MLGetDatafeedsRequest) {
 	return func(r *MLGetDatafeedsRequest) {
 		r.DatafeedID = v
 	}

--- a/esapi/api.xpack.ml.get_filters.go
+++ b/esapi/api.xpack.ml.get_filters.go
@@ -50,7 +50,7 @@ type MLGetFilters func(o ...func(*MLGetFiltersRequest)) (*Response, error)
 
 // MLGetFiltersRequest configures the ML Get Filters API request.
 type MLGetFiltersRequest struct {
-	FilterID string
+	FilterID []string
 
 	From *int
 	Size *int
@@ -86,17 +86,17 @@ func (r MLGetFiltersRequest) Do(providedCtx context.Context, transport Transport
 
 	method = "GET"
 
-	path.Grow(7 + 1 + len("_ml") + 1 + len("filters") + 1 + len(r.FilterID))
+	path.Grow(7 + 1 + len("_ml") + 1 + len("filters") + 1 + len(strings.Join(r.FilterID, ",")))
 	path.WriteString("http://")
 	path.WriteString("/")
 	path.WriteString("_ml")
 	path.WriteString("/")
 	path.WriteString("filters")
-	if r.FilterID != "" {
+	if len(r.FilterID) > 0 {
 		path.WriteString("/")
-		path.WriteString(r.FilterID)
+		path.WriteString(strings.Join(r.FilterID, ","))
 		if instrument, ok := r.Instrument.(Instrumentation); ok {
-			instrument.RecordPathPart(ctx, "filter_id", r.FilterID)
+			instrument.RecordPathPart(ctx, "filter_id", strings.Join(r.FilterID, ","))
 		}
 	}
 
@@ -188,8 +188,8 @@ func (f MLGetFilters) WithContext(v context.Context) func(*MLGetFiltersRequest) 
 	}
 }
 
-// WithFilterID - the ID of the filter to fetch.
-func (f MLGetFilters) WithFilterID(v string) func(*MLGetFiltersRequest) {
+// WithFilterID - comma-separated list of strings that uniquely identify a filter..
+func (f MLGetFilters) WithFilterID(v ...string) func(*MLGetFiltersRequest) {
 	return func(r *MLGetFiltersRequest) {
 		r.FilterID = v
 	}

--- a/esapi/api.xpack.ml.get_jobs.go
+++ b/esapi/api.xpack.ml.get_jobs.go
@@ -50,7 +50,7 @@ type MLGetJobs func(o ...func(*MLGetJobsRequest)) (*Response, error)
 
 // MLGetJobsRequest configures the ML Get Jobs API request.
 type MLGetJobsRequest struct {
-	JobID string
+	JobID []string
 
 	AllowNoMatch     *bool
 	ExcludeGenerated *bool
@@ -86,17 +86,17 @@ func (r MLGetJobsRequest) Do(providedCtx context.Context, transport Transport) (
 
 	method = "GET"
 
-	path.Grow(7 + 1 + len("_ml") + 1 + len("anomaly_detectors") + 1 + len(r.JobID))
+	path.Grow(7 + 1 + len("_ml") + 1 + len("anomaly_detectors") + 1 + len(strings.Join(r.JobID, ",")))
 	path.WriteString("http://")
 	path.WriteString("/")
 	path.WriteString("_ml")
 	path.WriteString("/")
 	path.WriteString("anomaly_detectors")
-	if r.JobID != "" {
+	if len(r.JobID) > 0 {
 		path.WriteString("/")
-		path.WriteString(r.JobID)
+		path.WriteString(strings.Join(r.JobID, ","))
 		if instrument, ok := r.Instrument.(Instrumentation); ok {
-			instrument.RecordPathPart(ctx, "job_id", r.JobID)
+			instrument.RecordPathPart(ctx, "job_id", strings.Join(r.JobID, ","))
 		}
 	}
 
@@ -188,8 +188,8 @@ func (f MLGetJobs) WithContext(v context.Context) func(*MLGetJobsRequest) {
 	}
 }
 
-// WithJobID - the ID of the jobs to fetch.
-func (f MLGetJobs) WithJobID(v string) func(*MLGetJobsRequest) {
+// WithJobID - comma-separated list of identifiers for the anomaly detection job. it can be a job identifier, a group name, or a wildcard expression. if you do not specify one of these options, the api returns information for all anomaly detection jobs..
+func (f MLGetJobs) WithJobID(v ...string) func(*MLGetJobsRequest) {
 	return func(r *MLGetJobsRequest) {
 		r.JobID = v
 	}

--- a/esapi/api.xpack.ml.get_model_snapshots.go
+++ b/esapi/api.xpack.ml.get_model_snapshots.go
@@ -21,7 +21,6 @@ package esapi
 
 import (
 	"context"
-	"fmt"
 	"io"
 	"net/http"
 	"strconv"
@@ -58,11 +57,11 @@ type MLGetModelSnapshotsRequest struct {
 	SnapshotID string
 
 	Desc  *bool
-	End   interface{}
+	End   string
 	From  *int
 	Size  *int
 	Sort  string
-	Start interface{}
+	Start string
 
 	Pretty     bool
 	Human      bool
@@ -122,8 +121,8 @@ func (r MLGetModelSnapshotsRequest) Do(providedCtx context.Context, transport Tr
 		params["desc"] = strconv.FormatBool(*r.Desc)
 	}
 
-	if r.End != nil {
-		params["end"] = fmt.Sprintf("%v", r.End)
+	if r.End != "" {
+		params["end"] = r.End
 	}
 
 	if r.From != nil {
@@ -138,8 +137,8 @@ func (r MLGetModelSnapshotsRequest) Do(providedCtx context.Context, transport Tr
 		params["sort"] = r.Sort
 	}
 
-	if r.Start != nil {
-		params["start"] = fmt.Sprintf("%v", r.Start)
+	if r.Start != "" {
+		params["start"] = r.Start
 	}
 
 	if r.Pretty {
@@ -249,7 +248,7 @@ func (f MLGetModelSnapshots) WithDesc(v bool) func(*MLGetModelSnapshotsRequest) 
 }
 
 // WithEnd - the filter 'end' query parameter.
-func (f MLGetModelSnapshots) WithEnd(v interface{}) func(*MLGetModelSnapshotsRequest) {
+func (f MLGetModelSnapshots) WithEnd(v string) func(*MLGetModelSnapshotsRequest) {
 	return func(r *MLGetModelSnapshotsRequest) {
 		r.End = v
 	}
@@ -277,7 +276,7 @@ func (f MLGetModelSnapshots) WithSort(v string) func(*MLGetModelSnapshotsRequest
 }
 
 // WithStart - the filter 'start' query parameter.
-func (f MLGetModelSnapshots) WithStart(v interface{}) func(*MLGetModelSnapshotsRequest) {
+func (f MLGetModelSnapshots) WithStart(v string) func(*MLGetModelSnapshotsRequest) {
 	return func(r *MLGetModelSnapshotsRequest) {
 		r.Start = v
 	}

--- a/esapi/api.xpack.ml.get_overall_buckets.go
+++ b/esapi/api.xpack.ml.get_overall_buckets.go
@@ -26,6 +26,7 @@ import (
 	"net/http"
 	"strconv"
 	"strings"
+	"time"
 )
 
 func newMLGetOverallBucketsFunc(t Transport) MLGetOverallBuckets {
@@ -57,7 +58,7 @@ type MLGetOverallBucketsRequest struct {
 	JobID string
 
 	AllowNoMatch   *bool
-	BucketSpan     string
+	BucketSpan     time.Duration
 	End            string
 	ExcludeInterim *bool
 	OverallScore   interface{}
@@ -117,8 +118,8 @@ func (r MLGetOverallBucketsRequest) Do(providedCtx context.Context, transport Tr
 		params["allow_no_match"] = strconv.FormatBool(*r.AllowNoMatch)
 	}
 
-	if r.BucketSpan != "" {
-		params["bucket_span"] = r.BucketSpan
+	if r.BucketSpan != 0 {
+		params["bucket_span"] = formatDuration(r.BucketSpan)
 	}
 
 	if r.End != "" {
@@ -241,7 +242,7 @@ func (f MLGetOverallBuckets) WithAllowNoMatch(v bool) func(*MLGetOverallBucketsR
 }
 
 // WithBucketSpan - the span of the overall buckets. defaults to the longest job bucket_span.
-func (f MLGetOverallBuckets) WithBucketSpan(v string) func(*MLGetOverallBucketsRequest) {
+func (f MLGetOverallBuckets) WithBucketSpan(v time.Duration) func(*MLGetOverallBucketsRequest) {
 	return func(r *MLGetOverallBucketsRequest) {
 		r.BucketSpan = v
 	}

--- a/esapi/api.xpack.ml.get_trained_models.go
+++ b/esapi/api.xpack.ml.get_trained_models.go
@@ -50,7 +50,7 @@ type MLGetTrainedModels func(o ...func(*MLGetTrainedModelsRequest)) (*Response, 
 
 // MLGetTrainedModelsRequest configures the ML Get Trained Models API request.
 type MLGetTrainedModelsRequest struct {
-	ModelID string
+	ModelID []string
 
 	AllowNoMatch         *bool
 	DecompressDefinition *bool
@@ -91,17 +91,17 @@ func (r MLGetTrainedModelsRequest) Do(providedCtx context.Context, transport Tra
 
 	method = "GET"
 
-	path.Grow(7 + 1 + len("_ml") + 1 + len("trained_models") + 1 + len(r.ModelID))
+	path.Grow(7 + 1 + len("_ml") + 1 + len("trained_models") + 1 + len(strings.Join(r.ModelID, ",")))
 	path.WriteString("http://")
 	path.WriteString("/")
 	path.WriteString("_ml")
 	path.WriteString("/")
 	path.WriteString("trained_models")
-	if r.ModelID != "" {
+	if len(r.ModelID) > 0 {
 		path.WriteString("/")
-		path.WriteString(r.ModelID)
+		path.WriteString(strings.Join(r.ModelID, ","))
 		if instrument, ok := r.Instrument.(Instrumentation); ok {
-			instrument.RecordPathPart(ctx, "model_id", r.ModelID)
+			instrument.RecordPathPart(ctx, "model_id", strings.Join(r.ModelID, ","))
 		}
 	}
 
@@ -213,8 +213,8 @@ func (f MLGetTrainedModels) WithContext(v context.Context) func(*MLGetTrainedMod
 	}
 }
 
-// WithModelID - the ID of the trained models to fetch.
-func (f MLGetTrainedModels) WithModelID(v string) func(*MLGetTrainedModelsRequest) {
+// WithModelID - the unique identifier of the trained model or a model alias.  you can get information for multiple trained models in a single api request by using a list of model ids or a wildcard expression..
+func (f MLGetTrainedModels) WithModelID(v ...string) func(*MLGetTrainedModelsRequest) {
 	return func(r *MLGetTrainedModelsRequest) {
 		r.ModelID = v
 	}
@@ -248,7 +248,7 @@ func (f MLGetTrainedModels) WithFrom(v int) func(*MLGetTrainedModelsRequest) {
 	}
 }
 
-// WithInclude - a comma-separate list of fields to optionally include. valid options are 'definition' and 'total_feature_importance'. default is none..
+// WithInclude - a comma delimited string of optional fields to include in the responsebody..
 func (f MLGetTrainedModels) WithInclude(v string) func(*MLGetTrainedModelsRequest) {
 	return func(r *MLGetTrainedModelsRequest) {
 		r.Include = v

--- a/esapi/api.xpack.ml.get_trained_models_stats.go
+++ b/esapi/api.xpack.ml.get_trained_models_stats.go
@@ -50,7 +50,7 @@ type MLGetTrainedModelsStats func(o ...func(*MLGetTrainedModelsStatsRequest)) (*
 
 // MLGetTrainedModelsStatsRequest configures the ML Get Trained Models Stats API request.
 type MLGetTrainedModelsStatsRequest struct {
-	ModelID string
+	ModelID []string
 
 	AllowNoMatch *bool
 	From         *int
@@ -87,17 +87,17 @@ func (r MLGetTrainedModelsStatsRequest) Do(providedCtx context.Context, transpor
 
 	method = "GET"
 
-	path.Grow(7 + 1 + len("_ml") + 1 + len("trained_models") + 1 + len(r.ModelID) + 1 + len("_stats"))
+	path.Grow(7 + 1 + len("_ml") + 1 + len("trained_models") + 1 + len(strings.Join(r.ModelID, ",")) + 1 + len("_stats"))
 	path.WriteString("http://")
 	path.WriteString("/")
 	path.WriteString("_ml")
 	path.WriteString("/")
 	path.WriteString("trained_models")
-	if r.ModelID != "" {
+	if len(r.ModelID) > 0 {
 		path.WriteString("/")
-		path.WriteString(r.ModelID)
+		path.WriteString(strings.Join(r.ModelID, ","))
 		if instrument, ok := r.Instrument.(Instrumentation); ok {
-			instrument.RecordPathPart(ctx, "model_id", r.ModelID)
+			instrument.RecordPathPart(ctx, "model_id", strings.Join(r.ModelID, ","))
 		}
 	}
 	path.WriteString("/")
@@ -195,8 +195,8 @@ func (f MLGetTrainedModelsStats) WithContext(v context.Context) func(*MLGetTrain
 	}
 }
 
-// WithModelID - the ID of the trained models stats to fetch.
-func (f MLGetTrainedModelsStats) WithModelID(v string) func(*MLGetTrainedModelsStatsRequest) {
+// WithModelID - the unique identifier of the trained model or a model alias. it can be a list or a wildcard expression..
+func (f MLGetTrainedModelsStats) WithModelID(v ...string) func(*MLGetTrainedModelsStatsRequest) {
 	return func(r *MLGetTrainedModelsStatsRequest) {
 		r.ModelID = v
 	}

--- a/esapi/api.xpack.ml.open_job.go
+++ b/esapi/api.xpack.ml.open_job.go
@@ -24,6 +24,7 @@ import (
 	"io"
 	"net/http"
 	"strings"
+	"time"
 )
 
 func newMLOpenJobFunc(t Transport) MLOpenJob {
@@ -53,6 +54,8 @@ type MLOpenJobRequest struct {
 	Body io.Reader
 
 	JobID string
+
+	Timeout time.Duration
 
 	Pretty     bool
 	Human      bool
@@ -100,6 +103,10 @@ func (r MLOpenJobRequest) Do(providedCtx context.Context, transport Transport) (
 	path.WriteString("_open")
 
 	params = make(map[string]string)
+
+	if r.Timeout != 0 {
+		params["timeout"] = formatDuration(r.Timeout)
+	}
 
 	if r.Pretty {
 		params["pretty"] = "true"
@@ -190,6 +197,13 @@ func (f MLOpenJob) WithContext(v context.Context) func(*MLOpenJobRequest) {
 func (f MLOpenJob) WithBody(v io.Reader) func(*MLOpenJobRequest) {
 	return func(r *MLOpenJobRequest) {
 		r.Body = v
+	}
+}
+
+// WithTimeout - controls the time to wait until a job has opened..
+func (f MLOpenJob) WithTimeout(v time.Duration) func(*MLOpenJobRequest) {
+	return func(r *MLOpenJobRequest) {
+		r.Timeout = v
 	}
 }
 

--- a/esapi/api.xpack.ml.put_calendar_job.go
+++ b/esapi/api.xpack.ml.put_calendar_job.go
@@ -21,12 +21,13 @@ package esapi
 
 import (
 	"context"
+	"errors"
 	"net/http"
 	"strings"
 )
 
 func newMLPutCalendarJobFunc(t Transport) MLPutCalendarJob {
-	return func(calendar_id string, job_id string, o ...func(*MLPutCalendarJobRequest)) (*Response, error) {
+	return func(calendar_id string, job_id []string, o ...func(*MLPutCalendarJobRequest)) (*Response, error) {
 		var r = MLPutCalendarJobRequest{CalendarID: calendar_id, JobID: job_id}
 		for _, f := range o {
 			f(&r)
@@ -45,12 +46,12 @@ func newMLPutCalendarJobFunc(t Transport) MLPutCalendarJob {
 // MLPutCalendarJob - Add anomaly detection job to calendar
 //
 // See full documentation at https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-ml-put-calendar-job.
-type MLPutCalendarJob func(calendar_id string, job_id string, o ...func(*MLPutCalendarJobRequest)) (*Response, error)
+type MLPutCalendarJob func(calendar_id string, job_id []string, o ...func(*MLPutCalendarJobRequest)) (*Response, error)
 
 // MLPutCalendarJobRequest configures the ML Put Calendar Job API request.
 type MLPutCalendarJobRequest struct {
 	CalendarID string
-	JobID      string
+	JobID      []string
 
 	Pretty     bool
 	Human      bool
@@ -83,7 +84,11 @@ func (r MLPutCalendarJobRequest) Do(providedCtx context.Context, transport Trans
 
 	method = "PUT"
 
-	path.Grow(7 + 1 + len("_ml") + 1 + len("calendars") + 1 + len(r.CalendarID) + 1 + len("jobs") + 1 + len(r.JobID))
+	if len(r.JobID) == 0 {
+		return nil, errors.New("job_id is required and cannot be nil or empty")
+	}
+
+	path.Grow(7 + 1 + len("_ml") + 1 + len("calendars") + 1 + len(r.CalendarID) + 1 + len("jobs") + 1 + len(strings.Join(r.JobID, ",")))
 	path.WriteString("http://")
 	path.WriteString("/")
 	path.WriteString("_ml")
@@ -97,9 +102,9 @@ func (r MLPutCalendarJobRequest) Do(providedCtx context.Context, transport Trans
 	path.WriteString("/")
 	path.WriteString("jobs")
 	path.WriteString("/")
-	path.WriteString(r.JobID)
+	path.WriteString(strings.Join(r.JobID, ","))
 	if instrument, ok := r.Instrument.(Instrumentation); ok {
-		instrument.RecordPathPart(ctx, "job_id", r.JobID)
+		instrument.RecordPathPart(ctx, "job_id", strings.Join(r.JobID, ","))
 	}
 
 	params = make(map[string]string)

--- a/esapi/api.xpack.ml.start_trained_model_deployment.go
+++ b/esapi/api.xpack.ml.start_trained_model_deployment.go
@@ -287,7 +287,7 @@ func (f MLStartTrainedModelDeployment) WithTimeout(v time.Duration) func(*MLStar
 	}
 }
 
-// WithWaitFor - the allocation status for which to wait.
+// WithWaitFor - specifies the allocation status to wait for before returning..
 func (f MLStartTrainedModelDeployment) WithWaitFor(v string) func(*MLStartTrainedModelDeploymentRequest) {
 	return func(r *MLStartTrainedModelDeploymentRequest) {
 		r.WaitFor = v

--- a/esapi/api.xpack.ml.validate_detector.go
+++ b/esapi/api.xpack.ml.validate_detector.go
@@ -44,8 +44,6 @@ func newMLValidateDetectorFunc(t Transport) MLValidateDetector {
 // ----- API Definition -------------------------------------------------------
 
 // MLValidateDetector - Validate an anomaly detection job
-//
-// See full documentation at https://www.elastic.co/guide/en/machine-learning/current/ml-jobs.html.
 type MLValidateDetector func(body io.Reader, o ...func(*MLValidateDetectorRequest)) (*Response, error)
 
 // MLValidateDetectorRequest configures the ML Validate Detector API request.

--- a/esapi/api.xpack.monitoring.bulk.go
+++ b/esapi/api.xpack.monitoring.bulk.go
@@ -24,11 +24,12 @@ import (
 	"io"
 	"net/http"
 	"strings"
+	"time"
 )
 
 func newMonitoringBulkFunc(t Transport) MonitoringBulk {
-	return func(body io.Reader, o ...func(*MonitoringBulkRequest)) (*Response, error) {
-		var r = MonitoringBulkRequest{Body: body}
+	return func(body io.Reader, interval time.Duration, system_api_version string, system_id string, o ...func(*MonitoringBulkRequest)) (*Response, error) {
+		var r = MonitoringBulkRequest{Body: body, Interval: interval, SystemAPIVersion: system_api_version, SystemID: system_id}
 		for _, f := range o {
 			f(&r)
 		}
@@ -46,15 +47,13 @@ func newMonitoringBulkFunc(t Transport) MonitoringBulk {
 // MonitoringBulk - Send monitoring data
 //
 // See full documentation at https://www.elastic.co/docs/api/doc/elasticsearch.
-type MonitoringBulk func(body io.Reader, o ...func(*MonitoringBulkRequest)) (*Response, error)
+type MonitoringBulk func(body io.Reader, interval time.Duration, system_api_version string, system_id string, o ...func(*MonitoringBulkRequest)) (*Response, error)
 
 // MonitoringBulkRequest configures the Monitoring Bulk API request.
 type MonitoringBulkRequest struct {
 	Body io.Reader
 
-	DocumentType string
-
-	Interval         string
+	Interval         time.Duration
 	SystemAPIVersion string
 	SystemID         string
 
@@ -89,24 +88,14 @@ func (r MonitoringBulkRequest) Do(providedCtx context.Context, transport Transpo
 
 	method = "POST"
 
-	path.Grow(7 + 1 + len("_monitoring") + 1 + len(r.DocumentType) + 1 + len("bulk"))
+	path.Grow(7 + len("/_monitoring/bulk"))
 	path.WriteString("http://")
-	path.WriteString("/")
-	path.WriteString("_monitoring")
-	if r.DocumentType != "" {
-		path.WriteString("/")
-		path.WriteString(r.DocumentType)
-		if instrument, ok := r.Instrument.(Instrumentation); ok {
-			instrument.RecordPathPart(ctx, "type", r.DocumentType)
-		}
-	}
-	path.WriteString("/")
-	path.WriteString("bulk")
+	path.WriteString("/_monitoring/bulk")
 
 	params = make(map[string]string)
 
-	if r.Interval != "" {
-		params["interval"] = r.Interval
+	if r.Interval != 0 {
+		params["interval"] = formatDuration(r.Interval)
 	}
 
 	if r.SystemAPIVersion != "" {
@@ -202,15 +191,8 @@ func (f MonitoringBulk) WithContext(v context.Context) func(*MonitoringBulkReque
 	}
 }
 
-// WithDocumentType - default document type for items which don't provide one.
-func (f MonitoringBulk) WithDocumentType(v string) func(*MonitoringBulkRequest) {
-	return func(r *MonitoringBulkRequest) {
-		r.DocumentType = v
-	}
-}
-
 // WithInterval - collection interval (e.g., '10s' or '10000ms') of the payload.
-func (f MonitoringBulk) WithInterval(v string) func(*MonitoringBulkRequest) {
+func (f MonitoringBulk) WithInterval(v time.Duration) func(*MonitoringBulkRequest) {
 	return func(r *MonitoringBulkRequest) {
 		r.Interval = v
 	}

--- a/esapi/api.xpack.open_point_in_time.go
+++ b/esapi/api.xpack.open_point_in_time.go
@@ -26,10 +26,11 @@ import (
 	"net/http"
 	"strconv"
 	"strings"
+	"time"
 )
 
 func newOpenPointInTimeFunc(t Transport) OpenPointInTime {
-	return func(index []string, keep_alive string, o ...func(*OpenPointInTimeRequest)) (*Response, error) {
+	return func(index []string, keep_alive time.Duration, o ...func(*OpenPointInTimeRequest)) (*Response, error) {
 		var r = OpenPointInTimeRequest{Index: index, KeepAlive: keep_alive}
 		for _, f := range o {
 			f(&r)
@@ -48,7 +49,7 @@ func newOpenPointInTimeFunc(t Transport) OpenPointInTime {
 // OpenPointInTime - Open a point in time
 //
 // See full documentation at https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-open-point-in-time.
-type OpenPointInTime func(index []string, keep_alive string, o ...func(*OpenPointInTimeRequest)) (*Response, error)
+type OpenPointInTime func(index []string, keep_alive time.Duration, o ...func(*OpenPointInTimeRequest)) (*Response, error)
 
 // OpenPointInTimeRequest configures the Open Point In Time API request.
 type OpenPointInTimeRequest struct {
@@ -59,7 +60,7 @@ type OpenPointInTimeRequest struct {
 	AllowPartialSearchResults  *bool
 	ExpandWildcards            string
 	IgnoreUnavailable          *bool
-	KeepAlive                  string
+	KeepAlive                  time.Duration
 	MaxConcurrentShardRequests *int
 	Preference                 string
 	ProjectRouting             string
@@ -124,8 +125,8 @@ func (r OpenPointInTimeRequest) Do(providedCtx context.Context, transport Transp
 		params["ignore_unavailable"] = strconv.FormatBool(*r.IgnoreUnavailable)
 	}
 
-	if r.KeepAlive != "" {
-		params["keep_alive"] = r.KeepAlive
+	if r.KeepAlive != 0 {
+		params["keep_alive"] = formatDuration(r.KeepAlive)
 	}
 
 	if r.MaxConcurrentShardRequests != nil {
@@ -258,7 +259,7 @@ func (f OpenPointInTime) WithIgnoreUnavailable(v bool) func(*OpenPointInTimeRequ
 }
 
 // WithKeepAlive - specific the time to live for the point in time.
-func (f OpenPointInTime) WithKeepAlive(v string) func(*OpenPointInTimeRequest) {
+func (f OpenPointInTime) WithKeepAlive(v time.Duration) func(*OpenPointInTimeRequest) {
 	return func(r *OpenPointInTimeRequest) {
 		r.KeepAlive = v
 	}

--- a/esapi/api.xpack.rollup.get_rollup_index_caps.go
+++ b/esapi/api.xpack.rollup.get_rollup_index_caps.go
@@ -21,12 +21,13 @@ package esapi
 
 import (
 	"context"
+	"errors"
 	"net/http"
 	"strings"
 )
 
 func newRollupGetRollupIndexCapsFunc(t Transport) RollupGetRollupIndexCaps {
-	return func(index string, o ...func(*RollupGetRollupIndexCapsRequest)) (*Response, error) {
+	return func(index []string, o ...func(*RollupGetRollupIndexCapsRequest)) (*Response, error) {
 		var r = RollupGetRollupIndexCapsRequest{Index: index}
 		for _, f := range o {
 			f(&r)
@@ -47,11 +48,11 @@ func newRollupGetRollupIndexCapsFunc(t Transport) RollupGetRollupIndexCaps {
 // This API is experimental.
 //
 // See full documentation at https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-rollup-get-rollup-index-caps.
-type RollupGetRollupIndexCaps func(index string, o ...func(*RollupGetRollupIndexCapsRequest)) (*Response, error)
+type RollupGetRollupIndexCaps func(index []string, o ...func(*RollupGetRollupIndexCapsRequest)) (*Response, error)
 
 // RollupGetRollupIndexCapsRequest configures the Rollup Get Rollup Index Caps API request.
 type RollupGetRollupIndexCapsRequest struct {
-	Index string
+	Index []string
 
 	Pretty     bool
 	Human      bool
@@ -84,12 +85,16 @@ func (r RollupGetRollupIndexCapsRequest) Do(providedCtx context.Context, transpo
 
 	method = "GET"
 
-	path.Grow(7 + 1 + len(r.Index) + 1 + len("_rollup") + 1 + len("data"))
+	if len(r.Index) == 0 {
+		return nil, errors.New("index is required and cannot be nil or empty")
+	}
+
+	path.Grow(7 + 1 + len(strings.Join(r.Index, ",")) + 1 + len("_rollup") + 1 + len("data"))
 	path.WriteString("http://")
 	path.WriteString("/")
-	path.WriteString(r.Index)
+	path.WriteString(strings.Join(r.Index, ","))
 	if instrument, ok := r.Instrument.(Instrumentation); ok {
-		instrument.RecordPathPart(ctx, "index", r.Index)
+		instrument.RecordPathPart(ctx, "index", strings.Join(r.Index, ","))
 	}
 	path.WriteString("/")
 	path.WriteString("_rollup")

--- a/esapi/api.xpack.security.delete_privileges.go
+++ b/esapi/api.xpack.security.delete_privileges.go
@@ -21,12 +21,13 @@ package esapi
 
 import (
 	"context"
+	"errors"
 	"net/http"
 	"strings"
 )
 
 func newSecurityDeletePrivilegesFunc(t Transport) SecurityDeletePrivileges {
-	return func(name string, application string, o ...func(*SecurityDeletePrivilegesRequest)) (*Response, error) {
+	return func(name []string, application string, o ...func(*SecurityDeletePrivilegesRequest)) (*Response, error) {
 		var r = SecurityDeletePrivilegesRequest{Name: name, Application: application}
 		for _, f := range o {
 			f(&r)
@@ -45,12 +46,12 @@ func newSecurityDeletePrivilegesFunc(t Transport) SecurityDeletePrivileges {
 // SecurityDeletePrivileges - Delete application privileges
 //
 // See full documentation at https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-security-delete-privileges.
-type SecurityDeletePrivileges func(name string, application string, o ...func(*SecurityDeletePrivilegesRequest)) (*Response, error)
+type SecurityDeletePrivileges func(name []string, application string, o ...func(*SecurityDeletePrivilegesRequest)) (*Response, error)
 
 // SecurityDeletePrivilegesRequest configures the Security Delete Privileges API request.
 type SecurityDeletePrivilegesRequest struct {
 	Application string
-	Name        string
+	Name        []string
 
 	Refresh string
 
@@ -85,7 +86,11 @@ func (r SecurityDeletePrivilegesRequest) Do(providedCtx context.Context, transpo
 
 	method = "DELETE"
 
-	path.Grow(7 + 1 + len("_security") + 1 + len("privilege") + 1 + len(r.Application) + 1 + len(r.Name))
+	if len(r.Name) == 0 {
+		return nil, errors.New("name is required and cannot be nil or empty")
+	}
+
+	path.Grow(7 + 1 + len("_security") + 1 + len("privilege") + 1 + len(r.Application) + 1 + len(strings.Join(r.Name, ",")))
 	path.WriteString("http://")
 	path.WriteString("/")
 	path.WriteString("_security")
@@ -97,9 +102,9 @@ func (r SecurityDeletePrivilegesRequest) Do(providedCtx context.Context, transpo
 		instrument.RecordPathPart(ctx, "application", r.Application)
 	}
 	path.WriteString("/")
-	path.WriteString(r.Name)
+	path.WriteString(strings.Join(r.Name, ","))
 	if instrument, ok := r.Instrument.(Instrumentation); ok {
-		instrument.RecordPathPart(ctx, "name", r.Name)
+		instrument.RecordPathPart(ctx, "name", strings.Join(r.Name, ","))
 	}
 
 	params = make(map[string]string)

--- a/esapi/api.xpack.security.get_privileges.go
+++ b/esapi/api.xpack.security.get_privileges.go
@@ -50,7 +50,7 @@ type SecurityGetPrivileges func(o ...func(*SecurityGetPrivilegesRequest)) (*Resp
 // SecurityGetPrivilegesRequest configures the Security Get Privileges API request.
 type SecurityGetPrivilegesRequest struct {
 	Application string
-	Name        string
+	Name        []string
 
 	Pretty     bool
 	Human      bool
@@ -83,7 +83,7 @@ func (r SecurityGetPrivilegesRequest) Do(providedCtx context.Context, transport 
 
 	method = "GET"
 
-	path.Grow(7 + 1 + len("_security") + 1 + len("privilege") + 1 + len(r.Application) + 1 + len(r.Name))
+	path.Grow(7 + 1 + len("_security") + 1 + len("privilege") + 1 + len(r.Application) + 1 + len(strings.Join(r.Name, ",")))
 	path.WriteString("http://")
 	path.WriteString("/")
 	path.WriteString("_security")
@@ -96,11 +96,11 @@ func (r SecurityGetPrivilegesRequest) Do(providedCtx context.Context, transport 
 			instrument.RecordPathPart(ctx, "application", r.Application)
 		}
 	}
-	if r.Name != "" {
+	if len(r.Name) > 0 {
 		path.WriteString("/")
-		path.WriteString(r.Name)
+		path.WriteString(strings.Join(r.Name, ","))
 		if instrument, ok := r.Instrument.(Instrumentation); ok {
-			instrument.RecordPathPart(ctx, "name", r.Name)
+			instrument.RecordPathPart(ctx, "name", strings.Join(r.Name, ","))
 		}
 	}
 
@@ -191,8 +191,8 @@ func (f SecurityGetPrivileges) WithApplication(v string) func(*SecurityGetPrivil
 	}
 }
 
-// WithName - privilege name.
-func (f SecurityGetPrivileges) WithName(v string) func(*SecurityGetPrivilegesRequest) {
+// WithName - comma-separated list of privilege names. if you do not specify this parameter, the api returns information about all privileges for the requested application..
+func (f SecurityGetPrivileges) WithName(v ...string) func(*SecurityGetPrivilegesRequest) {
 	return func(r *SecurityGetPrivilegesRequest) {
 		r.Name = v
 	}

--- a/esapi/api.xpack.security.update_user_profile_data.go
+++ b/esapi/api.xpack.security.update_user_profile_data.go
@@ -55,8 +55,8 @@ type SecurityUpdateUserProfileDataRequest struct {
 
 	UID string
 
-	IfPrimaryTerm *int
-	IfSeqNo       *int
+	IfPrimaryTerm *int64
+	IfSeqNo       *int64
 	Refresh       string
 
 	Pretty     bool
@@ -107,11 +107,11 @@ func (r SecurityUpdateUserProfileDataRequest) Do(providedCtx context.Context, tr
 	params = make(map[string]string)
 
 	if r.IfPrimaryTerm != nil {
-		params["if_primary_term"] = strconv.FormatInt(int64(*r.IfPrimaryTerm), 10)
+		params["if_primary_term"] = strconv.FormatInt(*r.IfPrimaryTerm, 10)
 	}
 
 	if r.IfSeqNo != nil {
-		params["if_seq_no"] = strconv.FormatInt(int64(*r.IfSeqNo), 10)
+		params["if_seq_no"] = strconv.FormatInt(*r.IfSeqNo, 10)
 	}
 
 	if r.Refresh != "" {
@@ -204,14 +204,14 @@ func (f SecurityUpdateUserProfileData) WithContext(v context.Context) func(*Secu
 }
 
 // WithIfPrimaryTerm - only perform the update operation if the last operation that has changed the document has the specified primary term.
-func (f SecurityUpdateUserProfileData) WithIfPrimaryTerm(v int) func(*SecurityUpdateUserProfileDataRequest) {
+func (f SecurityUpdateUserProfileData) WithIfPrimaryTerm(v int64) func(*SecurityUpdateUserProfileDataRequest) {
 	return func(r *SecurityUpdateUserProfileDataRequest) {
 		r.IfPrimaryTerm = &v
 	}
 }
 
 // WithIfSeqNo - only perform the update operation if the last operation that has changed the document has the specified sequence number.
-func (f SecurityUpdateUserProfileData) WithIfSeqNo(v int) func(*SecurityUpdateUserProfileDataRequest) {
+func (f SecurityUpdateUserProfileData) WithIfSeqNo(v int64) func(*SecurityUpdateUserProfileDataRequest) {
 	return func(r *SecurityUpdateUserProfileDataRequest) {
 		r.IfSeqNo = &v
 	}

--- a/esapi/api.xpack.sql.query.go
+++ b/esapi/api.xpack.sql.query.go
@@ -185,7 +185,7 @@ func (f SQLQuery) WithContext(v context.Context) func(*SQLQueryRequest) {
 	}
 }
 
-// WithFormat - a short version of the accept header, e.g. json, yaml.
+// WithFormat - the format for the response.you can also specify a format using the `accept` http header.if you specify both this parameter and the `accept` http header, this parameter takes precedence..
 func (f SQLQuery) WithFormat(v string) func(*SQLQueryRequest) {
 	return func(r *SQLQueryRequest) {
 		r.Format = v

--- a/esapi/api.xpack.text_structure.find_field_structure.go
+++ b/esapi/api.xpack.text_structure.find_field_structure.go
@@ -28,8 +28,8 @@ import (
 )
 
 func newTextStructureFindFieldStructureFunc(t Transport) TextStructureFindFieldStructure {
-	return func(index string, field string, o ...func(*TextStructureFindFieldStructureRequest)) (*Response, error) {
-		var r = TextStructureFindFieldStructureRequest{Index: index, Field: field}
+	return func(field string, index string, o ...func(*TextStructureFindFieldStructureRequest)) (*Response, error) {
+		var r = TextStructureFindFieldStructureRequest{Field: field, Index: index}
 		for _, f := range o {
 			f(&r)
 		}
@@ -47,7 +47,7 @@ func newTextStructureFindFieldStructureFunc(t Transport) TextStructureFindFieldS
 // TextStructureFindFieldStructure - Find the structure of a text field
 //
 // See full documentation at https://www.elastic.co/docs/api/doc/elasticsearch/group/endpoint-text_structure.
-type TextStructureFindFieldStructure func(index string, field string, o ...func(*TextStructureFindFieldStructureRequest)) (*Response, error)
+type TextStructureFindFieldStructure func(field string, index string, o ...func(*TextStructureFindFieldStructureRequest)) (*Response, error)
 
 // TextStructureFindFieldStructureRequest configures the Text Structure Find Field Structure API request.
 type TextStructureFindFieldStructureRequest struct {
@@ -258,7 +258,7 @@ func (f TextStructureFindFieldStructure) WithDocumentsToSample(v int) func(*Text
 	}
 }
 
-// WithEcsCompatibility - optional parameter to specify the compatibility mode with ecs grok patterns - may be either 'v1' or 'disabled'.
+// WithEcsCompatibility - the mode of compatibility with ecs compliant grok patterns.use this parameter to specify whether to use ecs grok patterns instead of legacy ones when the structure finder creates a grok pattern.this setting primarily has an impact when a whole message grok pattern such as `%{catalinalog}` matches the input.if the structure finder identifies a common structure but has no idea of the meaning then generic field names such as `path`, `ipaddress`, `field1`, and `field2` are used in the `grok_pattern` output.the intention in that situation is that a user who knows the meanings will rename the fields before using them..
 func (f TextStructureFindFieldStructure) WithEcsCompatibility(v string) func(*TextStructureFindFieldStructureRequest) {
 	return func(r *TextStructureFindFieldStructureRequest) {
 		r.EcsCompatibility = v

--- a/esapi/api.xpack.text_structure.find_message_structure.go
+++ b/esapi/api.xpack.text_structure.find_message_structure.go
@@ -246,7 +246,7 @@ func (f TextStructureFindMessageStructure) WithDelimiter(v string) func(*TextStr
 	}
 }
 
-// WithEcsCompatibility - optional parameter to specify the compatibility mode with ecs grok patterns - may be either 'v1' or 'disabled'.
+// WithEcsCompatibility - the mode of compatibility with ecs compliant grok patterns.use this parameter to specify whether to use ecs grok patterns instead of legacy ones when the structure finder creates a grok pattern.this setting primarily has an impact when a whole message grok pattern such as `%{catalinalog}` matches the input.if the structure finder identifies a common structure but has no idea of meaning then generic field names such as `path`, `ipaddress`, `field1`, and `field2` are used in the `grok_pattern` output, with the intention that a user who knows the meanings rename these fields before using it..
 func (f TextStructureFindMessageStructure) WithEcsCompatibility(v string) func(*TextStructureFindMessageStructureRequest) {
 	return func(r *TextStructureFindMessageStructureRequest) {
 		r.EcsCompatibility = v

--- a/esapi/api.xpack.transform.get_transform.go
+++ b/esapi/api.xpack.transform.get_transform.go
@@ -50,7 +50,7 @@ type TransformGetTransform func(o ...func(*TransformGetTransformRequest)) (*Resp
 
 // TransformGetTransformRequest configures the Transform Get Transform API request.
 type TransformGetTransformRequest struct {
-	TransformID string
+	TransformID []string
 
 	AllowNoMatch     *bool
 	ExcludeGenerated *bool
@@ -88,15 +88,15 @@ func (r TransformGetTransformRequest) Do(providedCtx context.Context, transport 
 
 	method = "GET"
 
-	path.Grow(7 + 1 + len("_transform") + 1 + len(r.TransformID))
+	path.Grow(7 + 1 + len("_transform") + 1 + len(strings.Join(r.TransformID, ",")))
 	path.WriteString("http://")
 	path.WriteString("/")
 	path.WriteString("_transform")
-	if r.TransformID != "" {
+	if len(r.TransformID) > 0 {
 		path.WriteString("/")
-		path.WriteString(r.TransformID)
+		path.WriteString(strings.Join(r.TransformID, ","))
 		if instrument, ok := r.Instrument.(Instrumentation); ok {
-			instrument.RecordPathPart(ctx, "transform_id", r.TransformID)
+			instrument.RecordPathPart(ctx, "transform_id", strings.Join(r.TransformID, ","))
 		}
 	}
 
@@ -196,8 +196,8 @@ func (f TransformGetTransform) WithContext(v context.Context) func(*TransformGet
 	}
 }
 
-// WithTransformID - the ID or comma delimited list of ID expressions of the transforms to get, '_all' or '*' implies get all transforms.
-func (f TransformGetTransform) WithTransformID(v string) func(*TransformGetTransformRequest) {
+// WithTransformID - comma-separated list of transform identifiers or wildcard expressions. you can get information for all transforms by using `_all`, by specifying `*` as the `<transform_id>`, or by omitting the `<transform_id>`..
+func (f TransformGetTransform) WithTransformID(v ...string) func(*TransformGetTransformRequest) {
 	return func(r *TransformGetTransformRequest) {
 		r.TransformID = v
 	}

--- a/esapi/api.xpack.transform.get_transform_stats.go
+++ b/esapi/api.xpack.transform.get_transform_stats.go
@@ -21,6 +21,7 @@ package esapi
 
 import (
 	"context"
+	"errors"
 	"net/http"
 	"strconv"
 	"strings"
@@ -28,7 +29,7 @@ import (
 )
 
 func newTransformGetTransformStatsFunc(t Transport) TransformGetTransformStats {
-	return func(transform_id string, o ...func(*TransformGetTransformStatsRequest)) (*Response, error) {
+	return func(transform_id []string, o ...func(*TransformGetTransformStatsRequest)) (*Response, error) {
 		var r = TransformGetTransformStatsRequest{TransformID: transform_id}
 		for _, f := range o {
 			f(&r)
@@ -47,15 +48,15 @@ func newTransformGetTransformStatsFunc(t Transport) TransformGetTransformStats {
 // TransformGetTransformStats - Get transform stats
 //
 // See full documentation at https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-transform-get-transform-stats.
-type TransformGetTransformStats func(transform_id string, o ...func(*TransformGetTransformStatsRequest)) (*Response, error)
+type TransformGetTransformStats func(transform_id []string, o ...func(*TransformGetTransformStatsRequest)) (*Response, error)
 
 // TransformGetTransformStatsRequest configures the Transform Get Transform Stats API request.
 type TransformGetTransformStatsRequest struct {
-	TransformID string
+	TransformID []string
 
 	AllowNoMatch *bool
-	From         *int
-	Size         *int
+	From         *int64
+	Size         *int64
 	Timeout      time.Duration
 
 	Pretty     bool
@@ -89,14 +90,18 @@ func (r TransformGetTransformStatsRequest) Do(providedCtx context.Context, trans
 
 	method = "GET"
 
-	path.Grow(7 + 1 + len("_transform") + 1 + len(r.TransformID) + 1 + len("_stats"))
+	if len(r.TransformID) == 0 {
+		return nil, errors.New("transform_id is required and cannot be nil or empty")
+	}
+
+	path.Grow(7 + 1 + len("_transform") + 1 + len(strings.Join(r.TransformID, ",")) + 1 + len("_stats"))
 	path.WriteString("http://")
 	path.WriteString("/")
 	path.WriteString("_transform")
 	path.WriteString("/")
-	path.WriteString(r.TransformID)
+	path.WriteString(strings.Join(r.TransformID, ","))
 	if instrument, ok := r.Instrument.(Instrumentation); ok {
-		instrument.RecordPathPart(ctx, "transform_id", r.TransformID)
+		instrument.RecordPathPart(ctx, "transform_id", strings.Join(r.TransformID, ","))
 	}
 	path.WriteString("/")
 	path.WriteString("_stats")
@@ -108,11 +113,11 @@ func (r TransformGetTransformStatsRequest) Do(providedCtx context.Context, trans
 	}
 
 	if r.From != nil {
-		params["from"] = strconv.FormatInt(int64(*r.From), 10)
+		params["from"] = strconv.FormatInt(*r.From, 10)
 	}
 
 	if r.Size != nil {
-		params["size"] = strconv.FormatInt(int64(*r.Size), 10)
+		params["size"] = strconv.FormatInt(*r.Size, 10)
 	}
 
 	if r.Timeout != 0 {
@@ -205,14 +210,14 @@ func (f TransformGetTransformStats) WithAllowNoMatch(v bool) func(*TransformGetT
 }
 
 // WithFrom - skips a number of transform stats, defaults to 0.
-func (f TransformGetTransformStats) WithFrom(v int) func(*TransformGetTransformStatsRequest) {
+func (f TransformGetTransformStats) WithFrom(v int64) func(*TransformGetTransformStatsRequest) {
 	return func(r *TransformGetTransformStatsRequest) {
 		r.From = &v
 	}
 }
 
 // WithSize - specifies a max number of transform stats to get, defaults to 100.
-func (f TransformGetTransformStats) WithSize(v int) func(*TransformGetTransformStatsRequest) {
+func (f TransformGetTransformStats) WithSize(v int64) func(*TransformGetTransformStatsRequest) {
 	return func(r *TransformGetTransformStatsRequest) {
 		r.Size = &v
 	}

--- a/esapi/api.xpack.watcher.put_watch.go
+++ b/esapi/api.xpack.watcher.put_watch.go
@@ -56,9 +56,9 @@ type WatcherPutWatchRequest struct {
 	Body io.Reader
 
 	Active        *bool
-	IfPrimaryTerm *int
-	IfSeqNo       *int
-	Version       *int
+	IfPrimaryTerm *int64
+	IfSeqNo       *int64
+	Version       *int64
 
 	Pretty     bool
 	Human      bool
@@ -110,15 +110,15 @@ func (r WatcherPutWatchRequest) Do(providedCtx context.Context, transport Transp
 	}
 
 	if r.IfPrimaryTerm != nil {
-		params["if_primary_term"] = strconv.FormatInt(int64(*r.IfPrimaryTerm), 10)
+		params["if_primary_term"] = strconv.FormatInt(*r.IfPrimaryTerm, 10)
 	}
 
 	if r.IfSeqNo != nil {
-		params["if_seq_no"] = strconv.FormatInt(int64(*r.IfSeqNo), 10)
+		params["if_seq_no"] = strconv.FormatInt(*r.IfSeqNo, 10)
 	}
 
 	if r.Version != nil {
-		params["version"] = strconv.FormatInt(int64(*r.Version), 10)
+		params["version"] = strconv.FormatInt(*r.Version, 10)
 	}
 
 	if r.Pretty {
@@ -214,21 +214,21 @@ func (f WatcherPutWatch) WithActive(v bool) func(*WatcherPutWatchRequest) {
 }
 
 // WithIfPrimaryTerm - only update the watch if the last operation that has changed the watch has the specified primary term.
-func (f WatcherPutWatch) WithIfPrimaryTerm(v int) func(*WatcherPutWatchRequest) {
+func (f WatcherPutWatch) WithIfPrimaryTerm(v int64) func(*WatcherPutWatchRequest) {
 	return func(r *WatcherPutWatchRequest) {
 		r.IfPrimaryTerm = &v
 	}
 }
 
 // WithIfSeqNo - only update the watch if the last operation that has changed the watch has the specified sequence number.
-func (f WatcherPutWatch) WithIfSeqNo(v int) func(*WatcherPutWatchRequest) {
+func (f WatcherPutWatch) WithIfSeqNo(v int64) func(*WatcherPutWatchRequest) {
 	return func(r *WatcherPutWatchRequest) {
 		r.IfSeqNo = &v
 	}
 }
 
 // WithVersion - explicit version number for concurrency control.
-func (f WatcherPutWatch) WithVersion(v int) func(*WatcherPutWatchRequest) {
+func (f WatcherPutWatch) WithVersion(v int64) func(*WatcherPutWatchRequest) {
 	return func(r *WatcherPutWatchRequest) {
 		r.Version = &v
 	}


### PR DESCRIPTION
## Summary

Regenerate `esapi/` against the latest 9.2 spec. First successful regeneration on 9.2 since the generator blocker was fixed (#1415, date-type normalization). This PR realizes the `long`→`*int64` fix (#1392, part of #548) on 9.2 and catches up the spec drift that accumulated while regeneration was blocked.

## Breaking changes

Params previously typed `*int` are now `*int64` to match the spec's `long` type. Affects ~20 endpoints. Examples:

- Document versioning: `Index`, `Update`, `Delete`, `Get`, `Create`, `Exists`, `GetSource`, `ExistsSource` — `WithVersion`, `WithIfSeqNo`, `WithIfPrimaryTerm` now take `int64`
- Search paging / termination: `Search`, `Count`, `Msearch`, `MsearchTemplate`, etc. — affected `Withxxx` setters flip to `int64`

Call sites passing untyped integer literals (e.g. `WithVersion(42)`) keep compiling. Call sites passing a typed `int` variable need an `int64(...)` cast.

Fixes #548.

## Other spec-driven changes (backlog catch-up)

Because scheduled regeneration was blocked on 9.2, this diff covers 112 files. Contents include:

- Additive fields and `Withxxx` options across many endpoints
- Documentation updates, build-hash bump
- Spec-driven signature adjustments unrelated to the int64 fix

## Test plan

- [ ] CI build passes
- [ ] CI unit tests pass
- [ ] CI integration tests pass

## Related

- #548 (root issue)
- #1402, #1403, #1406, #1414 (same regeneration on 9.4, 9.3, main, 8.19)
