### PR TITLE
docs: document gen-tests-in-CI and BREAKING-CHANGE footer conventions

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -56,6 +56,13 @@ make gen-api                    # regenerate esapi/ from specs
 - All exported types and functions must have godoc comments.
 - Before finishing, always run: `make lint && make test-unit`.
 
+## Regeneration
+
+- `make gen-api` regenerates `esapi/` from the REST spec. Commit only this output in regeneration PRs.
+- `make gen-tests` regenerates the YAML-driven tests in `esapi/test/` and `internal/build/cmd/generate/commands/gentests/api_registry.gen.go`. This runs in Buildkite CI; do not commit its output locally.
+- Regenerating after a generator fix or long gap will include spec drift (new endpoints, reworded descriptions, additive fields). Mention it in the PR body alongside the motivating change.
+- `make download-specs` uses the Makefile's default version. Override with `ELASTICSEARCH_BUILD_VERSION=X.Y.Z make download-specs` when regenerating a version branch from a checkout whose default targets a different version.
+
 ## Commits and Pull Requests
 
 PRs are squash-merged into a single commit when landing on `main` or a version branch. Because of this, each PR should represent one distinct, self-contained change — a single feature, bug fix, or refactor. Mixing unrelated changes in one PR means they become inseparable in history, making reviews harder and reverts riskier (reverting one change would also revert the unrelated ones).
@@ -66,6 +73,10 @@ When planning work:
 - Keep each PR focused on a single logical change with a clear purpose.
 - Avoid bundling unrelated fixes or refactors into a feature PR — send them separately.
 - Prefer multiple small PRs over one large PR, even if they land in quick succession.
+
+### Breaking changes
+
+Commits containing breaking API changes need a `BREAKING-CHANGE:` footer (preceded by a blank line) on a `fix:` or `feat:` commit. release-please reads the footer from the squash-merged commit to flag the release accordingly. Do not mark a breaking change as `chore:` or `refactor:`.
 
 ## Architecture
 


### PR DESCRIPTION
## Summary

Document two conventions that tripped up agents during the #548 long→int64 rollout:

- `make gen-tests` runs in Buildkite CI; local regen PRs should commit only `make gen-api` output. Without this note, authors commit regenerated `esapi/test/*.go` and `api_registry.gen.go`, doubling PR size and creating merge churn.
- Breaking changes go in a `BREAKING-CHANGE:` footer on `fix:`/`feat:` commits so release-please picks them up on squash-merge.

Also small: the `ELASTICSEARCH_BUILD_VERSION` override for `make download-specs`, and a note that regenerations after a gap bundle spec drift.

## Changes

- `AGENTS.md`: add `## Regeneration` section (between "Key Rules" and "Commits and Pull Requests")
- `AGENTS.md`: add `### Breaking changes` subsection under "Commits and Pull Requests"

Nothing removed. `CLAUDE.md` is a symlink to `AGENTS.md`, so one file covers both.

## Test plan

- [x] `CLAUDE.md` still points at `AGENTS.md` (unchanged)
- [x] Manual read-through for clarity
