### PR TITLE
fix(gen): use []string for slice-typed args in test boilerplate

### DIFF
--- a/internal/build/cmd/generate/commands/gentests/generator.go
+++ b/internal/build/cmd/generate/commands/gentests/generator.go
@@ -485,7 +485,7 @@ func (g *Generator) genCommonSetup() {
 		}
 
 		{
-			res, _ = es.Indices.DeleteIndexTemplate("*")
+			res, _ = es.Indices.DeleteIndexTemplate([]string{"*"})
 			if res != nil && res.Body != nil { defer res.Body.Close() }
 		}
 


### PR DESCRIPTION
## Summary

Backport two boilerplate fixes from main to 9.2 for the test generator.

After #1421 regenerated 9.2's esapi, several cleanup helpers take `[]string` where they used to take `string`. The test generator's common-setup boilerplate still calls them with bare strings, so every regenerated `esapi/test/*_test.go` file fails to compile in Buildkite:

- `es.Indices.DeleteIndexTemplate("*")` → expected `[]string{"*"}`
- `es.Security.DeletePrivileges(k, "_all")` → expected `[]string{k}, "_all"`

## What main does

main (and 9.4, 9.3) already emit both calls in `[]string{...}` form. Both lines were updated as part of the `feat: Update APIs to 9.3.0` bump (3c657dad) — same source commit as #1415's date normalization — and never cleanly backported to 9.2. 8.19's esapi still types both methods with plain strings, so 8.19 doesn't need these changes.

## Changes

Two one-line fixes in `internal/build/cmd/generate/commands/gentests/generator.go`:

- `DeleteIndexTemplate("*")` → `DeleteIndexTemplate([]string{"*"})`
- `DeletePrivileges(k, "_all")` → `DeletePrivileges([]string{k}, "_all")`

## Test plan

- [x] Checked out `regen-esapi-long-int64-9.2`'s esapi locally, ran `make gen-tests` with these changes, regenerated `esapi/test/` builds clean (previously failed with the two errors above)
- [ ] Buildkite CI on #1421 passes after this lands and the regen PR is rebased

## Related

- Unblocks Buildkite CI on #1421
- #548 rollout on 9.2
