### PR TITLE
fix(gen): pass []string to DeletePrivileges in xpack test boilerplate

### DIFF
--- a/internal/build/cmd/generate/commands/gentests/generator.go
+++ b/internal/build/cmd/generate/commands/gentests/generator.go
@@ -700,7 +700,7 @@ func (g *Generator) genXPackSetup() {
 						if v.Read.Metadata.Reserved {
 							continue
 						}
-						es.Security.DeletePrivileges(k, "_all")
+						es.Security.DeletePrivileges([]string{k}, "_all")
 					}
 				}
 			}


### PR DESCRIPTION
## Summary

Backport the `DeletePrivileges([]string{k}, "_all")` boilerplate fix from main to 9.2.

Follow-up to #1423 (which fixed `DeleteIndexTemplate` the same way). Same root cause: spec drift picked up in the 9.2 regen changed `SecurityDeletePrivileges` to take `[]string` for the `name` arg, but the test generator's xpack cleanup boilerplate still passes a bare string variable:

```
./xpack_graph__explore_test.go:485:35: cannot use k (variable of type string)
  as []string value in argument to es.Security.DeletePrivileges
```

main/9.4/9.3 already emit `[]string{k}` (landed in `3c657dad` alongside the other 9.3.0 bump changes, same commit that gave us the date-normalization and DeleteIndexTemplate fixes). 8.19 still types the param as a plain string, so doesn't need this.

## Fix

One-line change in the xpack cleanup block of `gentests/generator.go`:

- `DeletePrivileges(k, "_all")` → `DeletePrivileges([]string{k}, "_all")`

## Test plan

- [x] Checked out `regen-esapi-long-int64-9.2`'s esapi locally, ran `make gen-tests` with this change on top of the merged #1423, regenerated `esapi/test/` builds clean
- [ ] Buildkite CI on #1421 passes after this lands and the regen PR is rebased

## Related

- Follow-up to #1423
- Unblocks Buildkite CI on #1421
- #548 rollout on 9.2
