### PR TITLE
fix(gen): percent-escape user-supplied path parts in esapi generator

### DIFF
--- a/esapi/esapi.escape.go
+++ b/esapi/esapi.escape.go
@@ -1,0 +1,38 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package esapi
+
+import (
+	"net/url"
+	"strings"
+)
+
+// escapePathPart percent-escapes a single URL path segment while preserving
+// commas. Commas act as separators inside comma-joined list path params
+// (e.g. "index1,index2"), so each element is escaped independently and the
+// commas are re-joined verbatim.
+func escapePathPart(s string) string {
+	if !strings.Contains(s, ",") {
+		return url.PathEscape(s)
+	}
+	parts := strings.Split(s, ",")
+	for i, p := range parts {
+		parts[i] = url.PathEscape(p)
+	}
+	return strings.Join(parts, ",")
+}

--- a/esapi/esapi_escape_internal_test.go
+++ b/esapi/esapi_escape_internal_test.go
@@ -1,0 +1,48 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+//go:build !integration
+// +build !integration
+
+package esapi
+
+import "testing"
+
+func TestEscapePathPart(t *testing.T) {
+	tests := []struct {
+		name string
+		in   string
+		want string
+	}{
+		{"empty", "", ""},
+		{"plain", "plain", "plain"},
+		{"slash", "a/b", "a%2Fb"},
+		{"date-math", "<my-index-{now/d}>", "%3Cmy-index-%7Bnow%2Fd%7D%3E"},
+		{"commas preserved", "idx1,idx2", "idx1,idx2"},
+		{"slash in list elements", "a/b,c/d", "a%2Fb,c%2Fd"},
+		{"date-math inside list", "<idx-{now/d}>,plain", "%3Cidx-%7Bnow%2Fd%7D%3E,plain"},
+		{"already encoded double-escapes", "%2F", "%252F"},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := escapePathPart(tc.in)
+			if got != tc.want {
+				t.Errorf("escapePathPart(%q) = %q, want %q", tc.in, got, tc.want)
+			}
+		})
+	}
+}

--- a/internal/build/cmd/generate/commands/gensource/generator.go
+++ b/internal/build/cmd/generate/commands/gensource/generator.go
@@ -509,6 +509,7 @@ func (r ` + g.Endpoint.MethodWithNamespace() + `Request) Do(providedCtx context.
 	var (
 		method  string
 		path    strings.Builder
+		rawPath strings.Builder
 		params  map[string]string
 		ctx     context.Context
 	)` + "\n\n")
@@ -607,6 +608,7 @@ func (r ` + g.Endpoint.MethodWithNamespace() + `Request) Do(providedCtx context.
 		// even if some arguments are missing.
 		pathGrow.WriteString(`7 + `)
 		pathContent.WriteString(`path.WriteString("http://")` + "\n")
+		pathContent.WriteString(`rawPath.WriteString("http://")` + "\n")
 
 		// FIXME: Select longest path based on number of template entries, not string length
 		longestPath := g.Endpoint.URL.Paths[0]
@@ -633,6 +635,7 @@ func (r ` + g.Endpoint.MethodWithNamespace() + `Request) Do(providedCtx context.
 			}
 			pathGrow.WriteString(`len("` + longestPath.Path + `")`)
 			pathContent.WriteString(`	path.WriteString("` + longestPath.Path + `")` + "\n")
+			pathContent.WriteString(`	rawPath.WriteString("` + longestPath.Path + `")` + "\n")
 
 		} else {
 			pathParts := make([]string, 0)
@@ -654,17 +657,20 @@ func (r ` + g.Endpoint.MethodWithNamespace() + `Request) Do(providedCtx context.
 						p = a.GoName()
 						pathGrow.WriteString(`1 + `)
 						pathContent.WriteString(`	path.WriteString("/")` + "\n")
+						pathContent.WriteString(`	rawPath.WriteString("/")` + "\n")
 						switch a.Type {
 						case "int", "integer":
 							requiredArgsValidation.WriteString(`if r.` + p + ` == nil { return nil, errors.New("` + a.Name + ` is required and cannot be nil") }` + "\n")
 							pathGrow.WriteString(`len(strconv.Itoa(*r.` + p + `)) + `)
 							pathContent.WriteString(`	path.WriteString(strconv.Itoa(*r.` + p + `))` + "\n")
+							pathContent.WriteString(`	rawPath.WriteString(strconv.Itoa(*r.` + p + `))` + "\n")
 							pathContent.WriteString(`if instrument, ok := r.Instrument.(Instrumentation); ok {
 								instrument.RecordPathPart(ctx, "` + a.Name + `", strconv.Itoa(*r.` + p + `))
 							}` + "\n")
 						case "string", "enum":
 							pathGrow.WriteString(`len(r.` + p + `) + `)
 							pathContent.WriteString(`	path.WriteString(r.` + p + `)` + "\n")
+							pathContent.WriteString(`	rawPath.WriteString(escapePathPart(r.` + p + `))` + "\n")
 							pathContent.WriteString(`if instrument, ok := r.Instrument.(Instrumentation); ok {
 								instrument.RecordPathPart(ctx, "` + a.Name + `", r.` + p + `)
 							}` + "\n")
@@ -672,6 +678,7 @@ func (r ` + g.Endpoint.MethodWithNamespace() + `Request) Do(providedCtx context.
 							requiredArgsValidation.WriteString(`if len(r.` + p + `) == 0 { return nil, errors.New("` + a.Name + ` is required and cannot be nil or empty") }` + "\n")
 							pathGrow.WriteString(`len(strings.Join(r.` + p + `, ",")) + `)
 							pathContent.WriteString(`	path.WriteString(strings.Join(r.` + p + `, ","))` + "\n")
+							pathContent.WriteString(`	rawPath.WriteString(escapePathPart(strings.Join(r.` + p + `, ",")))` + "\n")
 							pathContent.WriteString(`if instrument, ok := r.Instrument.(Instrumentation); ok {
 								instrument.RecordPathPart(ctx, "` + a.Name + `", strings.Join(r.` + p + `, ","))
 							}` + "\n")
@@ -679,6 +686,7 @@ func (r ` + g.Endpoint.MethodWithNamespace() + `Request) Do(providedCtx context.
 							requiredArgsValidation.WriteString(`if r.` + p + ` == nil { return nil, errors.New("` + a.Name + ` is required and cannot be nil") }` + "\n")
 							pathGrow.WriteString(`len(strconv.FormatInt(*r.` + p + `, 10)) + `)
 							pathContent.WriteString(`	path.WriteString(strconv.FormatInt(*r.` + p + `, 10))` + "\n")
+							pathContent.WriteString(`	rawPath.WriteString(strconv.FormatInt(*r.` + p + `, 10))` + "\n")
 							pathContent.WriteString(`if instrument, ok := r.Instrument.(Instrumentation); ok {
 								instrument.RecordPathPart(ctx, "` + a.Name + `", strconv.FormatInt(*r.` + p + `, 10))
 							}` + "\n")
@@ -701,7 +709,9 @@ func (r ` + g.Endpoint.MethodWithNamespace() + `Request) Do(providedCtx context.
 								pathGrow.WriteString(`1 + len(r.` + p + `) + `)
 								pathContent.WriteString(`	if r.` + p + ` != "" {` + "\n")
 								pathContent.WriteString(`		path.WriteString("/")` + "\n")
+								pathContent.WriteString(`		rawPath.WriteString("/")` + "\n")
 								pathContent.WriteString(`		path.WriteString(r.` + p + `)` + "\n")
+								pathContent.WriteString(`		rawPath.WriteString(escapePathPart(r.` + p + `))` + "\n")
 								pathContent.WriteString(`if instrument, ok := r.Instrument.(Instrumentation); ok {
 								instrument.RecordPathPart(ctx, "` + a.Name + `", r.` + p + `)
 							}` + "\n")
@@ -710,7 +720,9 @@ func (r ` + g.Endpoint.MethodWithNamespace() + `Request) Do(providedCtx context.
 								pathGrow.WriteString(`1 + len(strings.Join(r.` + p + `, ",")) + `)
 								pathContent.WriteString(`	if len(r.` + p + `) > 0 {` + "\n")
 								pathContent.WriteString(`		path.WriteString("/")` + "\n")
+								pathContent.WriteString(`		rawPath.WriteString("/")` + "\n")
 								pathContent.WriteString(`		path.WriteString(strings.Join(r.` + p + `, ","))` + "\n")
+								pathContent.WriteString(`		rawPath.WriteString(escapePathPart(strings.Join(r.` + p + `, ",")))` + "\n")
 								pathContent.WriteString(`if instrument, ok := r.Instrument.(Instrumentation); ok {
 								instrument.RecordPathPart(ctx, "` + a.Name + `", strings.Join(r.` + p + `, ","))
 							}` + "\n")
@@ -720,7 +732,9 @@ func (r ` + g.Endpoint.MethodWithNamespace() + `Request) Do(providedCtx context.
 								pathContent.WriteString(`		value := strconv.FormatInt(int64(*r.` + p + `), 10)` + "\n")
 								pathContent.WriteString(`		path.Grow(1 + len(value))` + "\n")
 								pathContent.WriteString(`		path.WriteString("/")` + "\n")
+								pathContent.WriteString(`		rawPath.WriteString("/")` + "\n")
 								pathContent.WriteString(`		path.WriteString(value)` + "\n")
+								pathContent.WriteString(`		rawPath.WriteString(value)` + "\n")
 								pathContent.WriteString(`if instrument, ok := r.Instrument.(Instrumentation); ok {
 								instrument.RecordPathPart(ctx, "` + a.Name + `", value)
 							}` + "\n")
@@ -741,13 +755,16 @@ func (r ` + g.Endpoint.MethodWithNamespace() + `Request) Do(providedCtx context.
 							p = a.GoName()
 							pathGrow.WriteString("1 +")
 							pathContent.WriteString(`	path.WriteString("/")` + "\n")
+							pathContent.WriteString(`	rawPath.WriteString("/")` + "\n")
 							switch a.Type {
 							case "string", "enum":
 								pathGrow.WriteString(`len(r.` + p + `)`)
 								pathContent.WriteString(`	path.WriteString(r.` + p + `)` + "\n")
+								pathContent.WriteString(`	rawPath.WriteString(escapePathPart(r.` + p + `))` + "\n")
 							case "list":
 								pathGrow.WriteString(`len(strings.Join(r.` + p + `, ","))`)
 								pathContent.WriteString(`	path.WriteString(strings.Join(r.` + p + `, ","))` + "\n")
+								pathContent.WriteString(`	rawPath.WriteString(escapePathPart(strings.Join(r.` + p + `, ",")))` + "\n")
 							default:
 								panic(fmt.Sprintf("FAIL: %q: unexpected type %q for URL param %q\n", g.Endpoint.Name, a.Type, a.Name))
 							}
@@ -760,7 +777,9 @@ func (r ` + g.Endpoint.MethodWithNamespace() + `Request) Do(providedCtx context.
 				if p == "" {
 					pathGrow.WriteString(`1 + len("` + v + `") + `)
 					pathContent.WriteString(`	path.WriteString("/")` + "\n")
+					pathContent.WriteString(`	rawPath.WriteString("/")` + "\n")
 					pathContent.WriteString(`	path.WriteString("` + v + `")` + "\n")
+					pathContent.WriteString(`	rawPath.WriteString("` + v + `")` + "\n")
 				}
 			}
 		}
@@ -869,6 +888,9 @@ func (r ` + g.Endpoint.MethodWithNamespace() + `Request) Do(providedCtx context.
 		}
 		return nil, err
 	}` + "\n\n")
+
+	g.w(`req.URL.Path = path.String()[7:]
+	req.URL.RawPath = rawPath.String()[7:]` + "\n\n")
 
 	g.w(`if len(params) > 0 {
 		q := req.URL.Query()

--- a/internal/build/cmd/generate/commands/gensource/overrides.go
+++ b/internal/build/cmd/generate/commands/gensource/overrides.go
@@ -76,16 +76,26 @@ func init() {
 				Matching: []string{"cluster.stats"},
 				Func: func(*Endpoint, ...interface{}) string {
 					return `
+	path.WriteString("http://")
+	rawPath.WriteString("http://")
 	path.Grow(len("/nodes/_cluster/stats/nodes/") + len(strings.Join(r.NodeID, ",")))
 	path.WriteString("/")
+	rawPath.WriteString("/")
 	path.WriteString("_cluster")
+	rawPath.WriteString("_cluster")
 	path.WriteString("/")
+	rawPath.WriteString("/")
 	path.WriteString("stats")
+	rawPath.WriteString("stats")
 	if len(r.NodeID) > 0 {
 		path.WriteString("/")
+		rawPath.WriteString("/")
 		path.WriteString("nodes")
+		rawPath.WriteString("nodes")
 		path.WriteString("/")
+		rawPath.WriteString("/")
 		path.WriteString(strings.Join(r.NodeID, ","))
+		rawPath.WriteString(escapePathPart(strings.Join(r.NodeID, ",")))
 	}
 `
 				},
@@ -94,13 +104,19 @@ func init() {
 				Matching: []string{"indices.put_mapping"},
 				Func: func(*Endpoint, ...interface{}) string {
 					return `
+	path.WriteString("http://")
+	rawPath.WriteString("http://")
 	path.Grow(len(strings.Join(r.Index, ",")) + len("/_mapping") + 1)
 	if len(r.Index) > 0 {
 		path.WriteString("/")
+		rawPath.WriteString("/")
 		path.WriteString(strings.Join(r.Index, ","))
+		rawPath.WriteString(escapePathPart(strings.Join(r.Index, ",")))
 	}
 	path.WriteString("/")
+	rawPath.WriteString("/")
 	path.WriteString("_mapping")
+	rawPath.WriteString("_mapping")
 `
 				},
 			},
@@ -108,8 +124,11 @@ func init() {
 				Matching: []string{"scroll"},
 				Func: func(*Endpoint, ...interface{}) string {
 					return `
+	path.WriteString("http://")
+	rawPath.WriteString("http://")
 	path.Grow(len("/_search/scroll"))
 	path.WriteString("/_search/scroll")
+	rawPath.WriteString("/_search/scroll")
 `
 				},
 			},


### PR DESCRIPTION
User-supplied path parts (index names, document IDs, node IDs) are
currently written raw into the path strings.Builder passed to
http.NewRequest. Go's net/url auto-escapes most reserved characters but
deliberately leaves '/' alone because it treats the string as a full
path, so requests whose index name or ID contains '/' break — most
notably date-math names like '<my-index-{now/d}>', which must hit the
server as /%3Cmy-index-%7Bnow%2Fd%7D%3E. Caller-side pre-escaping also
fails because a literal '%' in URL.Path is re-escaped to %25.

Mirror the approach taken in the typedapi generator
(elastic/elastic-client-generator-go#141): maintain a dual path /
rawPath strings.Builder in each generated Do method. User segments are
written raw to path and through a new escapePathPart helper to rawPath;
static segments and separators are written to both identically. After
newRequest succeeds, assign req.URL.Path and req.URL.RawPath from the
two builders so the transport serializes the escaped form.

escapePathPart uses url.PathEscape and preserves commas so
comma-joined list path params keep their element separators while
each element is independently escaped.

This PR contains only the generator change + the hand-written helper.
The mechanical esapi/ regeneration will land in a follow-up.

Closes #183
Refs #52
Refs elastic/elastic-client-generator-go#141
