### PR TITLE
fix: drop render: markdown from issue templates so content renders

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug.yml
+++ b/.github/ISSUE_TEMPLATE/bug.yml
@@ -56,7 +56,6 @@ body:
     attributes:
       label: Current Behavior
       description: What's happening? Include error messages.
-      render: markdown
     validations:
       required: true
 
@@ -65,7 +64,6 @@ body:
     attributes:
       label: Expected Behavior
       description: What did you expect to happen?
-      render: markdown
     validations:
       required: true
 
@@ -86,7 +84,6 @@ body:
           fmt.Println("Hello, world!")
         }
         ```
-      render: markdown
     validations:
       required: true
 
@@ -98,12 +95,11 @@ body:
         Please provide details about your environment.
         This will help us to reproduce and fix the issue faster.
       value: |
-        - OS: 
-        - Architecture: 
-        - Authentication method: 
-        - Connection type (HTTP/HTTPS): 
+        - OS:
+        - Architecture:
+        - Authentication method:
+        - Connection type (HTTP/HTTPS):
         - Proxy/Load balancer:
-      render: markdown
 
   - type: textarea
     id: logs

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -15,7 +15,6 @@ body:
       label: Description
       description: |
         Please give us as much context as possible about the feature.
-      render: markdown
     validations:
       required: true
 


### PR DESCRIPTION
## Summary

Fixes the issue template problem reported by @TLINDEN in the PS of #1433: feature requests submitted via the template had their content wrapped in an outer ` ```markdown ` code block, so the Markdown never rendered and any fenced code blocks the user pasted were mangled.

Root cause: per [GitHub's issue forms spec](https://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/syntax-for-githubs-form-schema#render), `render: <value>` on a `textarea` explicitly *"formats submitted text into a codeblock ... the text will not be parsed as Markdown."* That is the opposite of what #1063 ("Ensure markdown rendering in bug issue template") intended -- the key was added to the wrong fields.

This drops `render: markdown` from every textarea where users are expected to write Markdown:

- `feature_request.yml`: Description
- `bug.yml`: Current Behavior, Expected Behavior, Steps to Reproduce, Environment Details

`render: shell` on the "Relevant log output" field is kept, since that field genuinely is a raw log dump and belongs in a code block.

Also trims trailing whitespace from the Environment Details `value` list while touching the file.

## Test plan

- [x] `python3 -c "import yaml; yaml.safe_load(open(...))"` passes on both templates
- [ ] After merge, open a test feature request and bug report on a fork or preview, paste Markdown including fenced code, and confirm it renders (cannot preview issue-form rendering locally; GitHub has no preview for `.github/ISSUE_TEMPLATE/*.yml` changes until merged to the default branch)
