### PR TITLE
docs(examples): add pagination example and reference docs section

### DIFF
--- a/_examples/search/Makefile
+++ b/_examples/search/Makefile
@@ -1,7 +1,8 @@
 export ELASTICSEARCH_URL=http://elastic:elastic@localhost:9200
 
-test:  ## Run example
+test:  ## Run examples
 	go run -tags search_default default.go
+	go run -tags search_pagination pagination.go
 
 setup:
 

--- a/_examples/search/README.md
+++ b/_examples/search/README.md
@@ -13,6 +13,20 @@ make test
 go run -tags search_default default.go
 ```
 
+The [`pagination.go`](pagination.go) example walks the same API through both
+supported pagination strategies:
+
+- `from` + `size` for small result sets, and
+- a point in time (PIT) plus `search_after` for deep pagination over a
+  consistent snapshot of the index.
+
+```bash
+go run -tags search_pagination pagination.go
+```
+
+See [Paginate search results](https://www.elastic.co/docs/reference/elasticsearch/rest-apis/paginate-search-results)
+for the corresponding Elasticsearch reference.
+
 ## Notes
 
 - `TypedClient.Search()` returns a fluent builder. Chain `Index(...)`,

--- a/_examples/search/pagination.go
+++ b/_examples/search/pagination.go
@@ -1,0 +1,192 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+//go:build search_pagination
+// +build search_pagination
+
+// This example demonstrates two ways to paginate through search results
+// with the typed client (`TypedClient`):
+//
+//   - `from` + `size` for small result sets, and
+//   - a point in time (PIT) plus `search_after` for deep pagination over a
+//     consistent snapshot of the index.
+package main
+
+import (
+	"context"
+	"log"
+	"strconv"
+	"time"
+
+	"github.com/elastic/go-elasticsearch/v9"
+	"github.com/elastic/go-elasticsearch/v9/typedapi/core/search"
+	"github.com/elastic/go-elasticsearch/v9/typedapi/esdsl"
+	"github.com/elastic/go-elasticsearch/v9/typedapi/types/enums/sortorder"
+)
+
+const (
+	paginationIndex = "search-pagination-demo"
+	totalDocs       = 25
+	pageSize        = 10
+)
+
+type product struct {
+	Name  string `json:"name"`
+	Price int    `json:"price"`
+}
+
+func main() {
+	log.SetFlags(0)
+
+	es, err := elasticsearch.NewTyped()
+	if err != nil {
+		log.Fatalf("Error creating typed client: %s", err)
+	}
+	defer closePaginationClient(es)
+
+	ctx := context.Background()
+	setupPaginationData(ctx, es)
+
+	log.Println("=== Pagination with from + size ===")
+	runFromSizeExample(ctx, es)
+
+	log.Println()
+	log.Println("=== Pagination with PIT + search_after ===")
+	runPITSearchAfterExample(ctx, es)
+}
+
+func closePaginationClient(es *elasticsearch.TypedClient) {
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	_ = es.Close(ctx)
+}
+
+func setupPaginationData(ctx context.Context, es *elasticsearch.TypedClient) {
+	if ok, _ := es.Indices.Exists(paginationIndex).IsSuccess(ctx); ok {
+		if _, err := es.Indices.Delete(paginationIndex).Do(ctx); err != nil {
+			log.Fatalf("Error deleting index: %s", err)
+		}
+	}
+	if _, err := es.Indices.Create(paginationIndex).Do(ctx); err != nil {
+		log.Fatalf("Error creating index: %s", err)
+	}
+
+	for i := 1; i <= totalDocs; i++ {
+		doc := product{Name: "product-" + strconv.Itoa(i), Price: i * 10}
+		if _, err := es.Index(paginationIndex).
+			Id(strconv.Itoa(i)).
+			Document(doc).
+			Do(ctx); err != nil {
+			log.Fatalf("Error indexing document %d: %s", i, err)
+		}
+	}
+
+	if _, err := es.Indices.Refresh().Index(paginationIndex).Do(ctx); err != nil {
+		log.Fatalf("Error refreshing index: %s", err)
+	}
+
+	log.Printf("Prepared demo index [%s] with %d documents", paginationIndex, totalDocs)
+}
+
+// runFromSizeExample walks pages using the `from` and `size` parameters.
+//
+// This is the simplest form of pagination and is the right tool for small
+// result sets. Elasticsearch refuses to page past the 10,000th hit with
+// `from` + `size` by default (the `index.max_result_window` setting), so
+// for anything deeper use PIT + search_after (see runPITSearchAfterExample).
+func runFromSizeExample(ctx context.Context, es *elasticsearch.TypedClient) {
+	seen := 0
+	for page := 0; ; page++ {
+		res, err := es.Search().
+			Index(paginationIndex).
+			Query(esdsl.NewMatchAllQuery()).
+			From(page * pageSize).
+			Size(pageSize).
+			Do(ctx)
+		if err != nil {
+			log.Fatalf("Error running search (from/size): %s", err)
+		}
+		log.Printf("page=%d hits=%d", page, len(res.Hits.Hits))
+		seen += len(res.Hits.Hits)
+		if len(res.Hits.Hits) < pageSize {
+			break
+		}
+	}
+	log.Printf("from/size: visited %d documents", seen)
+}
+
+// runPITSearchAfterExample walks pages using a point in time (PIT) and
+// `search_after`. This is the recommended approach for deep pagination
+// and for exports where a consistent view of the index matters across
+// pages (PIT pins a snapshot; concurrent writes don't shift results).
+//
+// A deterministic sort is required for `search_after` to have stable
+// cursor values. `_shard_doc` is the cheapest tie-breaker and is
+// available whenever a PIT is in use.
+func runPITSearchAfterExample(ctx context.Context, es *elasticsearch.TypedClient) {
+	pit, err := es.OpenPointInTime(paginationIndex).KeepAlive("1m").Do(ctx)
+	if err != nil {
+		log.Fatalf("Error opening PIT: %s", err)
+	}
+	defer func() {
+		if _, err := es.ClosePointInTime().Id(pit.Id).Do(ctx); err != nil {
+			log.Printf("Error closing PIT: %s", err)
+		}
+	}()
+
+	// Note: no Index(...) here. The PIT already pins the target indices;
+	// setting Index together with Pit is rejected by the server.
+	req := es.Search().
+		Query(esdsl.NewMatchAllQuery()).
+		Pit(esdsl.NewPointInTimeReference().
+			Id(pit.Id).
+			KeepAlive(esdsl.NewDuration().String("1m"))).
+		Sort(esdsl.NewSortOptions().
+			AddSortOption("_shard_doc", esdsl.NewFieldSort(sortorder.Asc))).
+		Size(pageSize)
+
+	seen := 0
+	for page := 0; ; page++ {
+		res, err := req.Do(ctx)
+		if err != nil {
+			log.Fatalf("Error running search (search_after): %s", err)
+		}
+		if len(res.Hits.Hits) == 0 {
+			break
+		}
+		log.Printf("page=%d hits=%d", page, len(res.Hits.Hits))
+		seen += len(res.Hits.Hits)
+
+		req = nextPITPage(req, res)
+	}
+	log.Printf("PIT + search_after: visited %d documents", seen)
+}
+
+// nextPITPage advances the builder to fetch the page after res. It reuses
+// the same builder so any Query, Size, or Sort settings carry over. The
+// PIT id can rotate between requests, so prefer res.PitId when the server
+// returned one.
+func nextPITPage(req *search.Search, res *search.Response) *search.Search {
+	last := res.Hits.Hits[len(res.Hits.Hits)-1]
+	req = req.SearchAfterValues(last.Sort)
+	if res.PitId != nil {
+		req = req.Pit(esdsl.NewPointInTimeReference().
+			Id(*res.PitId).
+			KeepAlive(esdsl.NewDuration().String("1m")))
+	}
+	return req
+}

--- a/docs/reference/using-the-api/searching.md
+++ b/docs/reference/using-the-api/searching.md
@@ -124,72 +124,9 @@ A `Search` call returns at most `size` hits per request (defaulting to 10). Two 
 - **`from` + `size`** is the simplest option. It works well for small result sets, but {{es}} refuses to page past the 10,000th hit by default (controlled by `index.max_result_window`). Raising that setting becomes expensive fast because each shard has to materialise and sort `from + size` hits per request.
 - **`search_after`** combined with a **point in time (PIT)** is the recommended approach for deep pagination and for exports where a consistent view across pages matters. The PIT pins a snapshot of the index so concurrent writes do not shift results between pages.
 
-The [`_examples/search/pagination.go`](https://github.com/elastic/go-elasticsearch/blob/main/_examples/search/pagination.go) example is a runnable walkthrough of both strategies with the typed client. See [Paginate search results](https://www.elastic.co/docs/reference/elasticsearch/rest-apis/paginate-search-results) for the full Elasticsearch reference.
+Both examples below use the [`esdsl`](/reference/typed-api/esdsl.md) builders with the typed client. The [`_examples/search/pagination.go`](https://github.com/elastic/go-elasticsearch/blob/main/_examples/search/pagination.go) example is a runnable walkthrough of both strategies. See [Paginate search results](https://www.elastic.co/docs/reference/elasticsearch/rest-apis/paginate-search-results) for the full Elasticsearch reference.
 
 ### `from` + `size` [_from_size]
-
-:::::::{tab-set}
-:group: APIs
-::::::{tab-item} Low-level API
-:sync: lowLevel
-
-```go
-const pageSize = 50
-for page := 0; ; page++ {
-    res, err := client.Search(
-        client.Search.WithContext(ctx),
-        client.Search.WithIndex("index_name"),
-        client.Search.WithBody(strings.NewReader(`{"query":{"match_all":{}}}`)),
-        client.Search.WithFrom(page*pageSize), // <1>
-        client.Search.WithSize(pageSize),      // <2>
-    )
-    if err != nil {
-        log.Fatal(err)
-    }
-    res.Body.Close()
-    // decode and process the page body...
-}
-```
-
-1. Starting document offset. Must be non-negative and, together with `size`, stay below `index.max_result_window`.
-2. Number of hits per page.
-
-::::::
-
-::::::{tab-item} Fully-typed API
-:sync: typed
-
-```go
-const pageSize = 50
-from, size := 0, pageSize
-req := &search.Request{
-    Query: &types.Query{MatchAll: &types.MatchAllQuery{}},
-    From:  &from, // <1>
-    Size:  &size, // <2>
-}
-for {
-    res, err := es.Search().Index("index_name").Request(req).Do(ctx)
-    if err != nil {
-        log.Fatal(err)
-    }
-    for _, hit := range res.Hits.Hits {
-        // process hit
-    }
-    if len(res.Hits.Hits) < pageSize {
-        break
-    }
-    from += pageSize
-    req.From = &from
-}
-```
-
-1. `From` and `Size` are `*int` on `search.Request`; bind a variable and update it between pages.
-2. Number of hits per page.
-
-::::::
-
-::::::{tab-item} esdsl API
-:sync: esdsl
 
 ```go
 const pageSize = 50
@@ -204,7 +141,7 @@ for page := 0; ; page++ {
         log.Fatal(err)
     }
     for _, hit := range res.Hits.Hits {
-        // process hit
+        _ = hit
     }
     if len(res.Hits.Hits) < pageSize {
         break
@@ -215,148 +152,7 @@ for page := 0; ; page++ {
 1. Starting document offset. Must be non-negative and, together with `size`, stay below `index.max_result_window`.
 2. Number of hits per page.
 
-::::::
-
-:::::::
-
 ### PIT + `search_after` [_pit_search_after]
-
-:::::::{tab-set}
-:group: APIs
-::::::{tab-item} Low-level API
-:sync: lowLevel
-
-The low-level API can drive PIT + `search_after`, but you are responsible for building the request body, decoding the response to pull `pit_id` and the sort cursor out yourself, and closing the PIT by hand. The typed clients below take care of all of that. This tab is here for completeness; prefer the typed or `esdsl` variants for this flow.
-
-```go
-openRes, err := client.OpenPointInTime(
-    []string{"index_name"},
-    time.Minute, // keep_alive
-    client.OpenPointInTime.WithContext(ctx),
-)
-if err != nil {
-    log.Fatal(err)
-}
-var pit struct {
-    ID string `json:"id"`
-}
-json.NewDecoder(openRes.Body).Decode(&pit)
-openRes.Body.Close()
-defer func() {
-    body, _ := json.Marshal(map[string]string{"id": pit.ID})
-    resp, _ := client.ClosePointInTime(bytes.NewReader(body))
-    if resp != nil {
-        resp.Body.Close()
-    }
-}()
-
-body := map[string]any{
-    "query": map[string]any{"match_all": map[string]any{}},
-    "pit":   map[string]any{"id": pit.ID, "keep_alive": "1m"},
-    "sort":  []map[string]any{{"_shard_doc": map[string]any{"order": "asc"}}},
-    "size":  1000,
-}
-for {
-    raw, _ := json.Marshal(body)
-    res, err := client.Search(
-        client.Search.WithContext(ctx),
-        client.Search.WithBody(bytes.NewReader(raw)),
-    )
-    if err != nil {
-        log.Fatal(err)
-    }
-    payload, _ := io.ReadAll(res.Body)
-    res.Body.Close()
-
-    var decoded struct {
-        PitId *string `json:"pit_id,omitempty"`
-        Hits  struct {
-            Hits []struct {
-                Sort []json.RawMessage `json:"sort"`
-            } `json:"hits"`
-        } `json:"hits"`
-    }
-    json.Unmarshal(payload, &decoded)
-
-    if len(decoded.Hits.Hits) == 0 {
-        break
-    }
-    last := decoded.Hits.Hits[len(decoded.Hits.Hits)-1]
-    body["search_after"] = last.Sort             // <1>
-    if decoded.PitId != nil {
-        body["pit"].(map[string]any)["id"] = *decoded.PitId // <2>
-    }
-}
-```
-
-1. Advance the cursor using the raw sort values from the last hit of the previous page.
-2. The PIT id can rotate between requests. When the response includes a new `pit_id`, use it for the next page.
-
-::::::
-
-::::::{tab-item} Fully-typed API
-:sync: typed
-
-```go subs=true
-import (
-    "github.com/elastic/go-elasticsearch/v{{ version.elasticsearch-client-go | M }}/typedapi/core/search"
-    "github.com/elastic/go-elasticsearch/v{{ version.elasticsearch-client-go | M }}/typedapi/types"
-    "github.com/elastic/go-elasticsearch/v{{ version.elasticsearch-client-go | M }}/typedapi/types/enums/sortorder"
-)
-```
-
-```go
-pit, err := es.OpenPointInTime("index_name").KeepAlive("1m").Do(ctx) // <1>
-if err != nil {
-    log.Fatal(err)
-}
-defer es.ClosePointInTime().Id(pit.Id).Do(ctx) // <2>
-
-keepAlive := types.Duration("1m")
-asc := sortorder.Asc
-size := 1000
-req := &search.Request{
-    Query: &types.Query{MatchAll: &types.MatchAllQuery{}},
-    Pit:   &types.PointInTimeReference{Id: pit.Id, KeepAlive: keepAlive}, // <3>
-    Sort: []types.SortCombinations{ // <4>
-        types.SortOptions{
-            SortOptions: map[string]types.FieldSort{
-                "_shard_doc": {Order: &asc},
-            },
-        },
-    },
-    Size: &size,
-}
-for {
-    res, err := es.Search().Request(req).Do(ctx)
-    if err != nil {
-        log.Fatal(err)
-    }
-    if len(res.Hits.Hits) == 0 {
-        break
-    }
-    for _, hit := range res.Hits.Hits {
-        // process hit
-    }
-    last := res.Hits.Hits[len(res.Hits.Hits)-1]
-    req.SearchAfter = last.Sort // <5>
-    if res.PitId != nil {       // <6>
-        req.Pit.Id = *res.PitId
-    }
-}
-```
-
-1. Open a PIT scoped to the target indices. `KeepAlive` only needs to cover the next request, not the whole scan; each search extends it.
-2. Release the PIT when you are done. PITs hold shard resources, so do not leak them.
-3. Attach the PIT to the search. Do not set `Index(...)` together with `Pit`; the index list is baked into the PIT and the server rejects the combination.
-4. A deterministic sort is required for `search_after` to produce stable cursor values. `_shard_doc` is the cheapest tie-breaker and is available whenever a PIT is in use. If you already sort on another field, keep that sort and append `_shard_doc` as a secondary, otherwise hits with equal primary sort values can skip or repeat across pages.
-5. `Request.SearchAfter` is `[]types.FieldValue`, which is exactly the type of `hit.Sort`.
-6. The PIT id can rotate between requests. When the response includes a new `PitId`, use it for the next page.
-
-::::::
-
-::::::{tab-item} esdsl API
-:sync: esdsl
 
 ```go subs=true
 import (
@@ -390,7 +186,7 @@ for {
         break
     }
     for _, hit := range res.Hits.Hits {
-        // process hit
+        _ = hit
     }
     last := res.Hits.Hits[len(res.Hits.Hits)-1]
     req = req.SearchAfterValues(last.Sort) // <5>
@@ -408,10 +204,6 @@ for {
 4. A deterministic sort is required for `search_after` to produce stable cursor values. `_shard_doc` is the cheapest tie-breaker and is available whenever a PIT is in use. If you already sort on another field, keep that sort and append `_shard_doc` as a secondary, otherwise hits with equal primary sort values can skip or repeat across pages.
 5. Advance the cursor using the last hit's sort values. `SearchAfterValues` takes `[]types.FieldValue`, which is exactly the type of `hit.Sort`.
 6. The PIT id can rotate between requests. When the response includes a new `PitId`, use it for the next page.
-
-::::::
-
-:::::::
 
 The older `scroll` API still works but is no longer the recommended approach for deep pagination; prefer PIT + `search_after`.
 

--- a/docs/reference/using-the-api/searching.md
+++ b/docs/reference/using-the-api/searching.md
@@ -117,6 +117,304 @@ search.Request{
 }
 ```
 
+## Paginating results [_paginating_results]
+
+A `Search` call returns at most `size` hits per request (defaulting to 10). Two strategies cover almost every pagination need:
+
+- **`from` + `size`** is the simplest option. It works well for small result sets, but {{es}} refuses to page past the 10,000th hit by default (controlled by `index.max_result_window`). Raising that setting becomes expensive fast because each shard has to materialise and sort `from + size` hits per request.
+- **`search_after`** combined with a **point in time (PIT)** is the recommended approach for deep pagination and for exports where a consistent view across pages matters. The PIT pins a snapshot of the index so concurrent writes do not shift results between pages.
+
+The [`_examples/search/pagination.go`](https://github.com/elastic/go-elasticsearch/blob/main/_examples/search/pagination.go) example is a runnable walkthrough of both strategies with the typed client. See [Paginate search results](https://www.elastic.co/docs/reference/elasticsearch/rest-apis/paginate-search-results) for the full Elasticsearch reference.
+
+### `from` + `size` [_from_size]
+
+:::::::{tab-set}
+:group: APIs
+::::::{tab-item} Low-level API
+:sync: lowLevel
+
+```go
+const pageSize = 50
+for page := 0; ; page++ {
+    res, err := client.Search(
+        client.Search.WithContext(ctx),
+        client.Search.WithIndex("index_name"),
+        client.Search.WithBody(strings.NewReader(`{"query":{"match_all":{}}}`)),
+        client.Search.WithFrom(page*pageSize), // <1>
+        client.Search.WithSize(pageSize),      // <2>
+    )
+    if err != nil {
+        log.Fatal(err)
+    }
+    res.Body.Close()
+    // decode and process the page body...
+}
+```
+
+1. Starting document offset. Must be non-negative and, together with `size`, stay below `index.max_result_window`.
+2. Number of hits per page.
+
+::::::
+
+::::::{tab-item} Fully-typed API
+:sync: typed
+
+```go
+const pageSize = 50
+from, size := 0, pageSize
+req := &search.Request{
+    Query: &types.Query{MatchAll: &types.MatchAllQuery{}},
+    From:  &from, // <1>
+    Size:  &size, // <2>
+}
+for {
+    res, err := es.Search().Index("index_name").Request(req).Do(ctx)
+    if err != nil {
+        log.Fatal(err)
+    }
+    for _, hit := range res.Hits.Hits {
+        // process hit
+    }
+    if len(res.Hits.Hits) < pageSize {
+        break
+    }
+    from += pageSize
+    req.From = &from
+}
+```
+
+1. `From` and `Size` are `*int` on `search.Request`; bind a variable and update it between pages.
+2. Number of hits per page.
+
+::::::
+
+::::::{tab-item} esdsl API
+:sync: esdsl
+
+```go
+const pageSize = 50
+for page := 0; ; page++ {
+    res, err := es.Search().
+        Index("index_name").
+        Query(esdsl.NewMatchAllQuery()).
+        From(page * pageSize). // <1>
+        Size(pageSize).        // <2>
+        Do(ctx)
+    if err != nil {
+        log.Fatal(err)
+    }
+    for _, hit := range res.Hits.Hits {
+        // process hit
+    }
+    if len(res.Hits.Hits) < pageSize {
+        break
+    }
+}
+```
+
+1. Starting document offset. Must be non-negative and, together with `size`, stay below `index.max_result_window`.
+2. Number of hits per page.
+
+::::::
+
+:::::::
+
+### PIT + `search_after` [_pit_search_after]
+
+:::::::{tab-set}
+:group: APIs
+::::::{tab-item} Low-level API
+:sync: lowLevel
+
+The low-level API can drive PIT + `search_after`, but you are responsible for building the request body, decoding the response to pull `pit_id` and the sort cursor out yourself, and closing the PIT by hand. The typed clients below take care of all of that. This tab is here for completeness; prefer the typed or `esdsl` variants for this flow.
+
+```go
+openRes, err := client.OpenPointInTime(
+    []string{"index_name"},
+    time.Minute, // keep_alive
+    client.OpenPointInTime.WithContext(ctx),
+)
+if err != nil {
+    log.Fatal(err)
+}
+var pit struct {
+    ID string `json:"id"`
+}
+json.NewDecoder(openRes.Body).Decode(&pit)
+openRes.Body.Close()
+defer func() {
+    body, _ := json.Marshal(map[string]string{"id": pit.ID})
+    resp, _ := client.ClosePointInTime(bytes.NewReader(body))
+    if resp != nil {
+        resp.Body.Close()
+    }
+}()
+
+body := map[string]any{
+    "query": map[string]any{"match_all": map[string]any{}},
+    "pit":   map[string]any{"id": pit.ID, "keep_alive": "1m"},
+    "sort":  []map[string]any{{"_shard_doc": map[string]any{"order": "asc"}}},
+    "size":  1000,
+}
+for {
+    raw, _ := json.Marshal(body)
+    res, err := client.Search(
+        client.Search.WithContext(ctx),
+        client.Search.WithBody(bytes.NewReader(raw)),
+    )
+    if err != nil {
+        log.Fatal(err)
+    }
+    payload, _ := io.ReadAll(res.Body)
+    res.Body.Close()
+
+    var decoded struct {
+        PitId *string `json:"pit_id,omitempty"`
+        Hits  struct {
+            Hits []struct {
+                Sort []json.RawMessage `json:"sort"`
+            } `json:"hits"`
+        } `json:"hits"`
+    }
+    json.Unmarshal(payload, &decoded)
+
+    if len(decoded.Hits.Hits) == 0 {
+        break
+    }
+    last := decoded.Hits.Hits[len(decoded.Hits.Hits)-1]
+    body["search_after"] = last.Sort             // <1>
+    if decoded.PitId != nil {
+        body["pit"].(map[string]any)["id"] = *decoded.PitId // <2>
+    }
+}
+```
+
+1. Advance the cursor using the raw sort values from the last hit of the previous page.
+2. The PIT id can rotate between requests. When the response includes a new `pit_id`, use it for the next page.
+
+::::::
+
+::::::{tab-item} Fully-typed API
+:sync: typed
+
+```go subs=true
+import (
+    "github.com/elastic/go-elasticsearch/v{{ version.elasticsearch-client-go | M }}/typedapi/core/search"
+    "github.com/elastic/go-elasticsearch/v{{ version.elasticsearch-client-go | M }}/typedapi/types"
+    "github.com/elastic/go-elasticsearch/v{{ version.elasticsearch-client-go | M }}/typedapi/types/enums/sortorder"
+)
+```
+
+```go
+pit, err := es.OpenPointInTime("index_name").KeepAlive("1m").Do(ctx) // <1>
+if err != nil {
+    log.Fatal(err)
+}
+defer es.ClosePointInTime().Id(pit.Id).Do(ctx) // <2>
+
+keepAlive := types.Duration("1m")
+asc := sortorder.Asc
+size := 1000
+req := &search.Request{
+    Query: &types.Query{MatchAll: &types.MatchAllQuery{}},
+    Pit:   &types.PointInTimeReference{Id: pit.Id, KeepAlive: keepAlive}, // <3>
+    Sort: []types.SortCombinations{ // <4>
+        types.SortOptions{
+            SortOptions: map[string]types.FieldSort{
+                "_shard_doc": {Order: &asc},
+            },
+        },
+    },
+    Size: &size,
+}
+for {
+    res, err := es.Search().Request(req).Do(ctx)
+    if err != nil {
+        log.Fatal(err)
+    }
+    if len(res.Hits.Hits) == 0 {
+        break
+    }
+    for _, hit := range res.Hits.Hits {
+        // process hit
+    }
+    last := res.Hits.Hits[len(res.Hits.Hits)-1]
+    req.SearchAfter = last.Sort // <5>
+    if res.PitId != nil {       // <6>
+        req.Pit.Id = *res.PitId
+    }
+}
+```
+
+1. Open a PIT scoped to the target indices. `KeepAlive` only needs to cover the next request, not the whole scan; each search extends it.
+2. Release the PIT when you are done. PITs hold shard resources, so do not leak them.
+3. Attach the PIT to the search. Do not set `Index(...)` together with `Pit`; the index list is baked into the PIT and the server rejects the combination.
+4. A deterministic sort is required for `search_after` to produce stable cursor values. `_shard_doc` is the cheapest tie-breaker and is available whenever a PIT is in use. If you already sort on another field, keep that sort and append `_shard_doc` as a secondary, otherwise hits with equal primary sort values can skip or repeat across pages.
+5. `Request.SearchAfter` is `[]types.FieldValue`, which is exactly the type of `hit.Sort`.
+6. The PIT id can rotate between requests. When the response includes a new `PitId`, use it for the next page.
+
+::::::
+
+::::::{tab-item} esdsl API
+:sync: esdsl
+
+```go subs=true
+import (
+    "github.com/elastic/go-elasticsearch/v{{ version.elasticsearch-client-go | M }}/typedapi/esdsl"
+    "github.com/elastic/go-elasticsearch/v{{ version.elasticsearch-client-go | M }}/typedapi/types/enums/sortorder"
+)
+```
+
+```go
+pit, err := es.OpenPointInTime("index_name").KeepAlive("1m").Do(ctx) // <1>
+if err != nil {
+    log.Fatal(err)
+}
+defer es.ClosePointInTime().Id(pit.Id).Do(ctx) // <2>
+
+req := es.Search().
+    Query(esdsl.NewMatchAllQuery()).
+    Pit(esdsl.NewPointInTimeReference(). // <3>
+        Id(pit.Id).
+        KeepAlive(esdsl.NewDuration().String("1m"))).
+    Sort(esdsl.NewSortOptions(). // <4>
+        AddSortOption("_shard_doc", esdsl.NewFieldSort(sortorder.Asc))).
+    Size(1000)
+
+for {
+    res, err := req.Do(ctx)
+    if err != nil {
+        log.Fatal(err)
+    }
+    if len(res.Hits.Hits) == 0 {
+        break
+    }
+    for _, hit := range res.Hits.Hits {
+        // process hit
+    }
+    last := res.Hits.Hits[len(res.Hits.Hits)-1]
+    req = req.SearchAfterValues(last.Sort) // <5>
+    if res.PitId != nil { // <6>
+        req = req.Pit(esdsl.NewPointInTimeReference().
+            Id(*res.PitId).
+            KeepAlive(esdsl.NewDuration().String("1m")))
+    }
+}
+```
+
+1. Open a PIT scoped to the target indices. `KeepAlive` only needs to cover the next request, not the whole scan; each search extends it.
+2. Release the PIT when you are done. PITs hold shard resources, so do not leak them.
+3. Attach the PIT to the search. Do not call `.Index(...)` together with `.Pit(...)`; the index list is baked into the PIT and the server rejects the combination.
+4. A deterministic sort is required for `search_after` to produce stable cursor values. `_shard_doc` is the cheapest tie-breaker and is available whenever a PIT is in use. If you already sort on another field, keep that sort and append `_shard_doc` as a secondary, otherwise hits with equal primary sort values can skip or repeat across pages.
+5. Advance the cursor using the last hit's sort values. `SearchAfterValues` takes `[]types.FieldValue`, which is exactly the type of `hit.Sort`.
+6. The PIT id can rotate between requests. When the response includes a new `PitId`, use it for the next page.
+
+::::::
+
+:::::::
+
+The older `scroll` API still works but is no longer the recommended approach for deep pagination; prefer PIT + `search_after`.
+
 ## Raw JSON [_raw_json]
 
 If you want to use your own pre-baked JSON queries using templates or a specific encoder, you can pass the body directly. Both API styles support raw JSON payloads:


### PR DESCRIPTION
## Summary

Adds pagination coverage for the typed client in both the runnable examples and the reference docs, in response to [#1433](https://github.com/elastic/go-elasticsearch/issues/1433) where a user naturally reached for `from`/`size` but had nothing in the client docs pointing them at `search_after` for paging past the 10,000-hit window.

- **New runnable example** at `_examples/search/pagination.go` (build tag `search_pagination`). It sets up a small demo index and walks both supported pagination strategies with the typed client:
  - `from` + `size` for small result sets, and
  - point-in-time (PIT) plus `search_after` for deep pagination over a consistent snapshot.
  The search example `Makefile` and `README.md` are updated to surface it.
- **New `## Paginating results` section** in `docs/reference/using-the-api/searching.md`. It mirrors the rest of the page by providing tabbed code samples across all three API styles (low-level `esapi`, fully-typed `types.*`, and `esdsl`), with numbered callouts covering the PIT lifecycle, the `Index`/`Pit` mutual exclusion, the `_shard_doc` tie-breaker, the `hit.Sort` → `SearchAfter` handoff, and PIT id rotation. The low-level PIT + `search_after` tab carries a short note that the typed clients are the ergonomic choice for this flow (manual body construction, manual `pit_id` extraction, manual close).
- Includes links between the reference doc and the runnable example, plus a pointer to the upstream [Paginate search results](https://www.elastic.co/docs/reference/elasticsearch/rest-apis/paginate-search-results) reference.

No code changes outside the example and docs; no generated code touched.

## Test plan

- [x] `make lint` clean
- [x] `go build -tags search_default ./...` clean in `_examples/search/`
- [x] `go build -tags search_pagination ./...` clean in `_examples/search/`
- [x] `gofmt -l _examples/search/` clean
- [x] All three API-style snippets in the new docs section were compile-verified against the current tree via a throwaway file (since removed)
- [ ] Run `go run -tags search_pagination pagination.go` against a live cluster to confirm the PIT + `search_after` loop terminates and reports 25 visited documents
- [ ] Visual check of the rendered docs page (tab-set alignment, callout numbering, `{{ version.elasticsearch-client-go | M }}` substitution)
