### PR TITLE
docs(bulk-indexer): document FlushJitter config option

### DIFF
--- a/docs/reference/using-the-api/bulk-indexing.md
+++ b/docs/reference/using-the-api/bulk-indexing.md
@@ -144,6 +144,7 @@ The `esutil.BulkIndexerConfig` struct supports the following fields:
 | `NumWorkers`    | `int`                                   | Number of concurrent worker goroutines (default: number of CPUs).    |
 | `FlushBytes`    | `int`                                   | Flush threshold in bytes.                                            |
 | `FlushInterval` | `time.Duration`                         | Periodic flush interval.                                             |
+| `FlushJitter`   | `time.Duration`                         | Max random jitter added to `FlushInterval` per worker to avoid lockstep flushes. Default: 0 (disabled). |
 | `Pipeline`      | `string`                                | Default ingest pipeline for all items.                               |
 | `Refresh`       | `string`                                | Refresh policy after each flush (`"true"`, `"false"`, `"wait_for"`). |
 | `Routing`       | `string`                                | Default routing value for all items.                                 |


### PR DESCRIPTION
## Summary

Adds a row to the `BulkIndexerConfig` reference table in [docs/reference/using-the-api/bulk-indexing.md](https://github.com/elastic/go-elasticsearch/blob/main/docs/reference/using-the-api/bulk-indexing.md) documenting the new `FlushJitter` config option.

This was split out of https://github.com/elastic/go-elasticsearch/pull/1386 so the feature branch backports cleanly to version branches, which do not carry `docs/reference/**`.

Depends on #1386 landing first (the field itself is added there).

## Test plan

- [x] Row renders correctly alongside the other config fields (markdown table is valid).
- [x] Merge only after #1386 lands, so the documented field actually exists on `main`.
