### PR TITLE
docs(reference): refocus on TypedClient + esdsl, split out low-level-api section

### DIFF
--- a/docs/reference/advanced/interceptors.md
+++ b/docs/reference/advanced/interceptors.md
@@ -20,10 +20,10 @@ type RoundTripFunc func(*http.Request) (*http.Response, error)
 type InterceptorFunc func(next RoundTripFunc) RoundTripFunc
 ```
 
-Interceptors are configured at client creation and cannot be changed after the transport is created.
+Interceptors are configured at client creation and cannot be changed after the transport is created. The examples on this page use `elasticsearch.NewTyped`; interceptors apply identically to the [low-level client](../low-level-api/index.md) built with `elasticsearch.New`.
 
 ```go
-es, err := elasticsearch.New(
+es, err := elasticsearch.NewTyped(
     elasticsearch.WithTransportOptions(
         elastictransport.WithInterceptors(
             myFirstInterceptor(),
@@ -59,7 +59,7 @@ sequenceDiagram
 
 ## Dynamic credential rotation [_interceptor_auth_provider]
 
-When credentials may change at runtime — for example, during token refresh or credential rotation — an interceptor can inject the latest credentials into each request dynamically.
+When credentials may change at runtime (for example, during token refresh or credential rotation), an interceptor can inject the latest credentials into each request dynamically.
 
 ```go
 func DynamicAuthInterceptor(provider *CredentialProvider) elastictransport.InterceptorFunc {
@@ -106,14 +106,14 @@ Usage:
 ```go
 authProvider := NewCredentialProvider("user1", "password1")
 
-es, err := elasticsearch.New(
+es, err := elasticsearch.NewTyped(
     elasticsearch.WithAddresses("https://localhost:9200"),
     elasticsearch.WithTransportOptions(
         elastictransport.WithInterceptors(DynamicAuthInterceptor(authProvider)),
     ),
 )
 
-// Later, rotate credentials — all future requests use the new credentials
+// Later, rotate credentials. All future requests use the new credentials.
 authProvider.Update("user2", "password2")
 ```
 
@@ -152,7 +152,7 @@ func ContextAuthInterceptor() elastictransport.InterceptorFunc {
 Usage:
 
 ```go
-es, err := elasticsearch.New(
+es, err := elasticsearch.NewTyped(
     elasticsearch.WithBasicAuth("default_user", "default_password"),
     elasticsearch.WithTransportOptions(
         elastictransport.WithInterceptors(ContextAuthInterceptor()),
@@ -160,19 +160,17 @@ es, err := elasticsearch.New(
 )
 
 // Uses default credentials
-res, err := es.Info()
+res, err := es.Info().Do(context.Background())
 if err != nil {
     log.Fatal(err)
 }
-defer res.Body.Close()
 
 // Uses per-request credentials
 ctx := WithBasicAuth(context.Background(), "tenant_a", "tenant_a_secret")
-res, err = es.Info(es.Info.WithContext(ctx))
+res, err = es.Info().Do(ctx)
 if err != nil {
     log.Fatal(err)
 }
-defer res.Body.Close()
 ```
 
 :::{dropdown} Challenge-response authentication (Kerberos/SPNEGO)
@@ -261,7 +259,7 @@ func LoggingInterceptor() elastictransport.InterceptorFunc {
 You can compose multiple interceptors for logging, metrics, and tracing:
 
 ```go
-es, err := elasticsearch.New(
+es, err := elasticsearch.NewTyped(
     elasticsearch.WithTransportOptions(
         elastictransport.WithInterceptors(
             LoggingInterceptor(),
@@ -320,7 +318,7 @@ func CountRetriesInterceptor() elastictransport.InterceptorFunc {
 Usage:
 
 ```go
-es, err := elasticsearch.New(
+es, err := elasticsearch.NewTyped(
     elasticsearch.WithAddresses("https://localhost:9200"),
     elasticsearch.WithTransportOptions(
         elastictransport.WithInterceptors(CountRetriesInterceptor()),
@@ -331,14 +329,14 @@ es, err := elasticsearch.New(
 ctx, counter := NewAttemptContext(context.Background())
 
 // Perform a request that might be retried
-res, err := es.Info(es.Info.WithContext(ctx))
+res, err := es.Info().Do(ctx)
 if err != nil {
     log.Fatal(err)
 }
-defer res.Body.Close()
+_ = res
 
 // Check how many attempts were made
-fmt.Printf("Request completed after %d attempts (%d retries)\n", 
+fmt.Printf("Request completed after %d attempts (%d retries)\n",
     counter.Attempts(), counter.Retries())
 ```
 

--- a/docs/reference/advanced/observability.md
+++ b/docs/reference/advanced/observability.md
@@ -8,6 +8,8 @@ applies_to:
 
 The Go client for {{es}} provides built-in support for distributed tracing via OpenTelemetry and transport-level metrics. These features help you monitor client behavior, diagnose performance issues, and correlate {{es}} requests with the rest of your application.
 
+The examples on this page use `elasticsearch.NewTyped`; instrumentation applies identically to the [low-level client](../low-level-api/index.md) built with `elasticsearch.New`.
+
 ## OpenTelemetry instrumentation [_otel_instrumentation]
 
 The client includes a built-in OpenTelemetry integration that creates spans for every {{es}} API call. This is the recommended approach for distributed tracing.
@@ -23,7 +25,7 @@ import (
 )
 
 // Use the global TracerProvider (set up elsewhere in your application)
-es, err := elasticsearch.New(
+es, err := elasticsearch.NewTyped(
     elasticsearch.WithInstrumentation(elasticsearch.NewOpenTelemetryInstrumentation(nil, false)),  // <1>
 )
 ```
@@ -99,7 +101,7 @@ func main() {
     otel.SetTracerProvider(tp)
 
     // Create the Elasticsearch client with instrumentation
-    es, err := elasticsearch.New(
+    es, err := elasticsearch.NewTyped(
         elasticsearch.WithAddresses("https://localhost:9200"),
         elasticsearch.WithInstrumentation(elasticsearch.NewOpenTelemetryInstrumentation(tp, true)),
     )
@@ -109,11 +111,9 @@ func main() {
     defer es.Close(context.Background())
 
     // Every API call now creates an OpenTelemetry span
-    res, err := es.Info()
-    if err != nil {
+    if _, err := es.Info().Do(context.Background()); err != nil {
         log.Fatal(err)
     }
-    defer res.Body.Close()
 }
 ```
 
@@ -122,7 +122,7 @@ func main() {
 The client can collect transport-level metrics including request counts, failures, and response status code distributions. Enable metrics using `WithTransportOptions`:
 
 ```go
-es, err := elasticsearch.New(
+es, err := elasticsearch.NewTyped(
     elasticsearch.WithTransportOptions(elastictransport.WithMetrics()),
 )
 ```
@@ -132,7 +132,7 @@ Once enabled, metrics are available through the transport's `Metrics()` method. 
 ```go
 import "expvar"
 
-es, err := elasticsearch.New(
+es, err := elasticsearch.NewTyped(
     elasticsearch.WithTransportOptions(elastictransport.WithMetrics()),
 )
 
@@ -145,17 +145,17 @@ expvar.Publish("go-elasticsearch", expvar.Func(func() any {
 
 The metrics include:
 
-- **Requests** — Total number of requests sent
-- **Failures** — Total number of failed requests
-- **Responses** — Count of responses grouped by HTTP status code
-- **Connections** — Information about live and dead connection pool members
+- **Requests**: total number of requests sent
+- **Failures**: total number of failed requests
+- **Responses**: count of responses grouped by HTTP status code
+- **Connections**: information about live and dead connection pool members
 
 ## Debug logging [_debug_logging]
 
 Enable debug logging to see detailed request and response information:
 
 ```go
-es, err := elasticsearch.New(
+es, err := elasticsearch.NewTyped(
     elasticsearch.WithTransportOptions(elastictransport.WithDebugLogger()),
 )
 ```
@@ -172,7 +172,7 @@ For more control over log output, use `WithLogger` with one of the built-in logg
 ```go
 import "github.com/elastic/elastic-transport-go/v8/elastictransport"
 
-es, err := elasticsearch.New(
+es, err := elasticsearch.NewTyped(
     elasticsearch.WithLogger(&elastictransport.ColorLogger{
         Output:             os.Stdout,
         EnableRequestBody:  true,
@@ -196,7 +196,7 @@ import (
     "go.elastic.co/apm/module/apmelasticsearch/v2"
 )
 
-es, err := elasticsearch.New(
+es, err := elasticsearch.NewTyped(
     elasticsearch.WithTransportOptions(
         elastictransport.WithTransport(apmelasticsearch.WrapRoundTripper(http.DefaultTransport)),
     ),
@@ -215,7 +215,7 @@ import (
     "go.opencensus.io/plugin/ochttp"
 )
 
-es, err := elasticsearch.New(
+es, err := elasticsearch.NewTyped(
     elasticsearch.WithTransportOptions(
         elastictransport.WithTransport(&ochttp.Transport{}),
     ),

--- a/docs/reference/connecting.md
+++ b/docs/reference/connecting.md
@@ -7,26 +7,11 @@ mapped_pages:
 
 This page contains the information you need to connect and use the Client with {{es}}.
 
+The examples below use `elasticsearch.NewTyped` to build a [typed client](typed-api/index.md). Every option also applies to `elasticsearch.New` for the [low-level client](low-level-api/index.md); both constructors take the same [functional options](configuration.md) and share the same transport.
+
 ## Connecting to Elastic Cloud [connecting-to-elastic-cloud]
 
 If you are using [Elastic Cloud](https://www.elastic.co/cloud), the client offers an easy way to connect to it. You must pass the Cloud ID that you can find in the cloud console and the corresponding API key.
-
-:::::::{tab-set}
-:group: APIs
-::::::{tab-item} Low-level API
-:sync: lowLevel
-
-```go
-es, err := elasticsearch.New(
-    elasticsearch.WithCloudID("CLOUD_ID"),
-    elasticsearch.WithAPIKey("API_KEY"),
-)
-```
-
-::::::
-
-::::::{tab-item} Fully-typed API
-:sync: typed
 
 ```go
 es, err := elasticsearch.NewTyped(
@@ -34,10 +19,6 @@ es, err := elasticsearch.NewTyped(
     elasticsearch.WithAPIKey("API_KEY"),
 )
 ```
-
-::::::
-
-:::::::
 
 ::::{important}
 You need to copy and store the `API key` in a secure place since you will not be able to view it again in Elastic Cloud.
@@ -73,29 +54,6 @@ The generated root CA certificate can be found in the `certs` directory in your 
 
 Once you have the `http_ca.crt` file somewhere accessible pass the content of the file to the client using `WithCACert`:
 
-:::::::{tab-set}
-:group: APIs
-::::::{tab-item} Low-level API
-:sync: lowLevel
-
-```go
-cert, _ := os.ReadFile("/path/to/http_ca.crt") // <1>
-
-es, err := elasticsearch.New(
-    elasticsearch.WithAddresses("https://localhost:9200"),
-    elasticsearch.WithBasicAuth("elastic", ELASTIC_PASSWORD),
-    elasticsearch.WithCACert(cert), // <2>
-)
-```
-
-1. Read the PEM-encoded CA certificate from disk.
-2. Pass the certificate bytes to `WithCACert` to verify the server's TLS certificate.
-
-::::::
-
-::::::{tab-item} Fully-typed API
-:sync: typed
-
 ```go
 cert, _ := os.ReadFile("/path/to/http_ca.crt") // <1>
 
@@ -108,35 +66,11 @@ es, err := elasticsearch.NewTyped(
 
 1. Read the PEM-encoded CA certificate from disk.
 2. Pass the certificate bytes to `WithCACert` to verify the server's TLS certificate.
-
-::::::
-
-:::::::
 
 ## Verifying HTTPS with certificate fingerprint [verifying-with-fingerprint]
 
 This method of verifying the HTTPS connection takes advantage of the certificate fingerprint value noted down earlier. Take this SHA256 fingerprint value and pass it to the Go {{es}} client via `CertificateFingerprint`:
 
-:::::::{tab-set}
-:group: APIs
-::::::{tab-item} Low-level API
-:sync: lowLevel
-
-```go
-es, err := elasticsearch.New(
-    elasticsearch.WithAddresses("https://localhost:9200"),
-    elasticsearch.WithBasicAuth("elastic", ELASTIC_PASSWORD),
-    elasticsearch.WithCertificateFingerprint(CERT_FINGERPRINT), // <1>
-)
-```
-
-1. The SHA-256 hex fingerprint of the CA certificate, useful when you don't have access to the CA file directly.
-
-::::::
-
-::::::{tab-item} Fully-typed API
-:sync: typed
-
 ```go
 es, err := elasticsearch.NewTyped(
     elasticsearch.WithAddresses("https://localhost:9200"),
@@ -146,10 +80,6 @@ es, err := elasticsearch.NewTyped(
 ```
 
 1. The SHA-256 hex fingerprint of the CA certificate, useful when you don't have access to the CA file directly.
-
-::::::
-
-:::::::
 
 The certificate fingerprint can be calculated using OpenSSL x509 with the certificate file:
 
@@ -180,59 +110,16 @@ Running {{es}} without security enabled is not recommended.
 
 If your cluster is configured with [security explicitly disabled](elasticsearch://reference/elasticsearch/configuration-reference/security-settings.md) then you can connect via HTTP:
 
-:::::::{tab-set}
-:group: APIs
-::::::{tab-item} Low-level API
-:sync: lowLevel
-
-```go
-es, err := elasticsearch.New(
-    elasticsearch.WithAddresses("http://localhost:9200"),
-)
-```
-
-::::::
-
-::::::{tab-item} Fully-typed API
-:sync: typed
-
 ```go
 es, err := elasticsearch.NewTyped(
     elasticsearch.WithAddresses("http://localhost:9200"),
 )
 ```
-
-::::::
-
-:::::::
 
 ## Connecting to multiple nodes [connecting-multiple-nodes]
 
 The Go {{es}} client supports sending API requests to multiple nodes in the cluster. This means that work will be more evenly spread across the cluster instead of hammering the same node over and over with requests. To configure the client with multiple nodes you can pass a list of URLs, each URL will be used as a separate node in the pool.
 
-:::::::{tab-set}
-:group: APIs
-::::::{tab-item} Low-level API
-:sync: lowLevel
-
-```go
-es, err := elasticsearch.New(
-    elasticsearch.WithAddresses( // <1>
-        "https://localhost:9200",
-        "https://localhost:9201",
-    ),
-    elasticsearch.WithCACert(caCert),
-    elasticsearch.WithBasicAuth("elastic", ELASTIC_PASSWORD),
-)
-```
-
-1. Each URL is used as a separate node in the connection pool.
-
-::::::
-
-::::::{tab-item} Fully-typed API
-:sync: typed
-
 ```go
 es, err := elasticsearch.NewTyped(
     elasticsearch.WithAddresses( // <1>
@@ -245,10 +132,6 @@ es, err := elasticsearch.NewTyped(
 ```
 
 1. Each URL is used as a separate node in the connection pool.
-
-::::::
-
-:::::::
 
 By default nodes are selected using round-robin, but alternate node selection strategies can be implemented via the `elastictransport.Selector` interface and provided to the client configuration.
 
@@ -262,27 +145,7 @@ This section contains code snippets to show you how to authenticate with {{es}}.
 
 ### Basic authentication [auth-basic]
 
-To set the cluster endpoints, the username, and the password programmatically, pass options to the `elasticsearch.New()` or `elasticsearch.NewTyped()` function.
-
-:::::::{tab-set}
-:group: APIs
-::::::{tab-item} Low-level API
-:sync: lowLevel
-
-```go
-es, err := elasticsearch.New(
-    elasticsearch.WithAddresses(
-        "https://localhost:9200",
-        "https://localhost:9201",
-    ),
-    elasticsearch.WithBasicAuth("foo", "bar"),
-)
-```
-
-::::::
-
-::::::{tab-item} Fully-typed API
-:sync: typed
+To set the cluster endpoints, the username, and the password programmatically, pass options to the `elasticsearch.NewTyped()` (or `elasticsearch.New()`) function.
 
 ```go
 es, err := elasticsearch.NewTyped(
@@ -293,10 +156,6 @@ es, err := elasticsearch.NewTyped(
     elasticsearch.WithBasicAuth("foo", "bar"),
 )
 ```
-
-::::::
-
-:::::::
 
 You can also include the username and password in the endpoint URL:
 
@@ -308,33 +167,12 @@ You can also include the username and password in the endpoint URL:
 
 HTTP Bearer authentication uses the `ServiceToken` parameter by passing the token as a string. This authentication method is used by [Service Account Tokens](https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-security-create-service-token) and [Bearer Tokens](https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-security-get-token).
 
-:::::::{tab-set}
-:group: APIs
-::::::{tab-item} Low-level API
-:sync: lowLevel
-
-```go
-es, err := elasticsearch.New(
-    elasticsearch.WithAddresses("https://localhost:9200"),
-    elasticsearch.WithServiceToken("token-value"),
-)
-```
-
-::::::
-
-::::::{tab-item} Fully-typed API
-:sync: typed
-
 ```go
 es, err := elasticsearch.NewTyped(
     elasticsearch.WithAddresses("https://localhost:9200"),
     elasticsearch.WithServiceToken("token-value"),
 )
 ```
-
-::::::
-
-:::::::
 
 ## Compatibility mode [compatibility-mode]
 
@@ -347,41 +185,7 @@ For every 8.0 and beyond `go-elasticsearch` client, you're all set! The compatib
 
 ## Using the client [client-usage]
 
-The {{es}} package ties together two separate packages for calling the Elasticsearch APIs and transferring data over HTTP: `esapi` and `estransport`, respectively.
-
-Use the `elasticsearch.New()` or `elasticsearch.NewTyped()` function to create the client with the default settings.
-
-:::::::{tab-set}
-:group: APIs
-::::::{tab-item} Low-level API
-:sync: lowLevel
-
-```go
-es, err := elasticsearch.New()
-if err != nil {
-  log.Fatalf("Error creating the client: %s", err)
-}
-defer func() {
-    ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
-    defer cancel()
-    if err := es.Close(ctx); err != nil {
-        log.Fatalf("Error closing the client: %s", err)
-    }
-} ()
-
-res, err := es.Info()
-if err != nil {
-  log.Fatalf("Error getting response: %s", err)
-}
-
-defer res.Body.Close()
-log.Println(res)
-```
-
-::::::
-
-::::::{tab-item} Fully-typed API
-:sync: typed
+Use `elasticsearch.NewTyped()` to create the typed client with the default settings. The [low-level client](low-level-api/index.md) uses `elasticsearch.New()` with the same options.
 
 ```go
 es, err := elasticsearch.NewTyped()
@@ -394,7 +198,7 @@ defer func() {
     if err := es.Close(ctx); err != nil {
         log.Fatalf("Error closing the client: %s", err)
     }
-} ()
+}()
 
 res, err := es.Info().Do(context.Background())
 if err != nil {
@@ -404,16 +208,12 @@ if err != nil {
 log.Println(res)
 ```
 
-::::::
-
-:::::::
-
 ## Using the client in a function-as-a-service environment [connecting-faas]
 
 :::{dropdown} Function-as-a-Service (FaaS) patterns
 This section illustrates the best practices for leveraging the {{es}} client in a Function-as-a-Service (FaaS) environment.
 The most influential optimization is to initialize the client outside of the function, the global scope.
-This practice does not only improve performance but also enables background functionality as — for example — [sniffing](https://www.elastic.co/blog/elasticsearch-sniffing-best-practices-what-when-why-how).
+This practice does not only improve performance but also enables background functionality such as [sniffing](https://www.elastic.co/blog/elasticsearch-sniffing-best-practices-what-when-why-how).
 The following examples provide a skeleton for the best practices.
 
 ### GCP Cloud Functions
@@ -430,15 +230,15 @@ import (
     "github.com/elastic/go-elasticsearch/v9"
 )
 
-var client *elasticsearch.Client
+var client *elasticsearch.TypedClient
 
 func init() {
     var err error
 
     ... // Client configuration
-    client, err = elasticsearch.New(opts...)
+    client, err = elasticsearch.NewTyped(opts...)
     if err != nil {
-        log.Fatalf("elasticsearch.New: %v", err)
+        log.Fatalf("elasticsearch.NewTyped: %v", err)
     }
 }
 
@@ -459,15 +259,15 @@ import (
     "github.com/elastic/go-elasticsearch/v9"
 )
 
-var client *elasticsearch.Client
+var client *elasticsearch.TypedClient
 
 func init() {
     var err error
 
     ... // Client configuration
-    client, err = elasticsearch.New(opts...)
+    client, err = elasticsearch.NewTyped(opts...)
     if err != nil {
-        log.Fatalf("elasticsearch.New: %v", err)
+        log.Fatalf("elasticsearch.NewTyped: %v", err)
     }
 }
 

--- a/docs/reference/getting-started.md
+++ b/docs/reference/getting-started.md
@@ -5,7 +5,7 @@ mapped_pages:
 
 # Getting started [getting-started-go]
 
-This page guides you through the installation process of the Go client, shows you how to instantiate the client, and how to perform basic Elasticsearch operations with it. You can use the client with either a low-level API or a fully typed API. This getting started shows you examples of both APIs.
+This page guides you through the installation process of the Go client, shows you how to instantiate the client, and how to perform basic Elasticsearch operations with it. The examples use the [typed API](/reference/typed-api/index.md) with the [`esdsl`](/reference/typed-api/esdsl.md) query builders, which is the recommended way to use the client. If you need raw-JSON control or an endpoint not yet covered by the typed API, see the [low-level API](/reference/low-level-api/index.md).
 
 ## Requirements [_requirements]
 
@@ -23,14 +23,10 @@ Refer to the [_Installation_](/reference/installation.md) page to learn more.
 
 ## Connecting [_connecting]
 
-:::::::{tab-set}
-:group: APIs
-::::::{tab-item} Low-level API
-:sync: lowLevel
-You can connect to the Elastic Cloud using an API key and the Elasticsearch endpoint for the low level API:
+Connect to Elastic Cloud using an API key and the Elasticsearch endpoint:
 
 ```go
-client, err := elasticsearch.New(
+client, err := elasticsearch.NewTyped(
     elasticsearch.WithCloudID("<CloudID>"), // <1>
     elasticsearch.WithAPIKey("<ApiKey>"),   // <2>
 )
@@ -39,25 +35,6 @@ client, err := elasticsearch.New(
 1. Your deployment's Cloud ID, found on the **My deployment** page.
 2. Your API key for authentication.
 
-::::::
-
-::::::{tab-item} Fully-typed API
-:sync: typed
-You can connect to the Elastic Cloud using an API key and the Elasticsearch endpoint for the fully-typed API:
-
-```go
-typedClient, err := elasticsearch.NewTyped(
-    elasticsearch.WithCloudID("<CloudID>"), // <1>
-    elasticsearch.WithAPIKey("<ApiKey>"),   // <2>
-)
-```
-
-1. Your deployment's Cloud ID, found on the **My deployment** page.
-2. Your API key for authentication.
-
-::::::
-
-:::::::
 Your Elasticsearch endpoint can be found on the **My deployment** page of your deployment:
 
 ![Finding Elasticsearch endpoint](images/es-endpoint.jpg)
@@ -76,260 +53,73 @@ Time to use Elasticsearch! This section walks you through the basic, and most im
 
 ::::::::{step} Create an index
 
-:::::::{tab-set}
-:group: APIs
-::::::{tab-item} Low-level API
-:sync: lowLevel
-This is how you create the `my_index` index with the low level API:
-
 ```go
-res, err := client.Indices.Create("my_index")
-if err != nil {
-    log.Fatal(err)
-}
-defer res.Body.Close()
+client.Indices.Create("my_index").Do(context.TODO())
 ```
-
-::::::
-
-::::::{tab-item} Fully-typed API
-:sync: typed
-This is how you create the `my_index` index with the fully-typed API:
-
-```go
-typedClient.Indices.Create("my_index").Do(context.TODO())
-```
-
-::::::
-
-:::::::
 
 ::::::::
 
 ::::::::{step} Index a document
 
-:::::::{tab-set}
-:group: APIs
-::::::{tab-item} Low-level API
-:sync: lowLevel
-This is a simple way of indexing a document by using the low-level API:
-
 ```go
 document := struct {
     Name string `json:"name"`
 }{
     "go-elasticsearch",
 }
-data, _ := json.Marshal(document)
-res, err := client.Index("my_index", bytes.NewReader(data))
-if err != nil {
-    log.Fatal(err)
-}
-defer res.Body.Close()
+client.Index("my_index").
+    Id("1").
+    Request(document).
+    Do(context.TODO())
 ```
-
-::::::
-
-::::::{tab-item} Fully-typed API
-:sync: typed
-This is a simple way of indexing a document by using the fully-typed API:
-
-```go
-document := struct {
-    Name string `json:"name"`
-}{
-    "go-elasticsearch",
-}
-typedClient.Index("my_index").
-        Id("1").
-        Request(document).
-        Do(context.TODO())
-```
-
-::::::
-
-:::::::
 
 ::::::::
 
 ::::::::{step} Get a document
 
-:::::::{tab-set}
-:group: APIs
-::::::{tab-item} Low-level API
-:sync: lowLevel
-You can get documents by using the following code with the low-level API:
-
 ```go
-res, err := client.Get("my_index", "id")
-if err != nil {
-    log.Fatal(err)
-}
-defer res.Body.Close()
+client.Get("my_index", "1").Do(context.TODO())
 ```
-
-::::::
-
-::::::{tab-item} Fully-typed API
-:sync: typed
-This is how you can get documents by using the fully-typed API:
-
-```go
-typedClient.Get("my_index", "id").Do(context.TODO())
-```
-
-::::::
-
-:::::::
 
 ::::::::
 
 ::::::::{step} Search documents
 
-:::::::{tab-set}
-:group: APIs
-::::::{tab-item} Low-level API
-:sync: lowLevel
-This is how you can create a single match query with the low-level API:
+Use the [`esdsl`](/reference/typed-api/esdsl.md) builders for a concise, fluent query syntax:
 
 ```go
-query := `{ "query": { "match_all": {} } }`
-res, err := client.Search(
-    client.Search.WithIndex("my_index"),
-    client.Search.WithBody(strings.NewReader(query)),
-)
-if err != nil {
-    log.Fatal(err)
-}
-defer res.Body.Close()
-```
-
-::::::
-
-::::::{tab-item} Fully-typed API
-:sync: typed
-This is how you can perform a single match query with the fully-typed API:
-
-```go
-typedClient.Search().
-    Index("my_index").
-    Request(&search.Request{
-        Query: &types.Query{MatchAll: &types.MatchAllQuery{}},
-    }).
-    Do(context.TODO())
-```
-
-::::::
-
-::::::{tab-item} esdsl API
-:sync: esdsl
-The [`esdsl`](/reference/typed-api/esdsl.md) package provides fluent builders for queries, aggregations, and mappings:
-
-```go
-typedClient.Search().
+client.Search().
     Index("my_index").
     Query(esdsl.NewMatchAllQuery()).
     Do(context.TODO())
 ```
 
-::::::
-
-:::::::
-
 ::::::::
 
 ::::::::{step} Update a document
 
-:::::::{tab-set}
-:group: APIs
-::::::{tab-item} Low-level API
-:sync: lowLevel
-This is how you can update a document, for example to add a new field, by using the low-level API:
-
 ```go
-res, err := client.Update("my_index", "id", strings.NewReader(`{"doc": {"language": "Go"}}`))
-if err != nil {
-    log.Fatal(err)
-}
-defer res.Body.Close()
-```
-
-::::::
-
-::::::{tab-item} Fully-typed API
-:sync: typed
-This is how you can update a document with the fully-typed API:
-
-```go
-typedClient.Update("my_index", "id").
+client.Update("my_index", "1").
     Request(&update.Request{
         Doc: json.RawMessage(`{"language": "Go"}`),
     }).Do(context.TODO())
 ```
 
-::::::
-
-:::::::
-
 ::::::::
 
 ::::::::{step} Delete a document
 
-:::::::{tab-set}
-:group: APIs
-::::::{tab-item} Low-level API
-:sync: lowLevel
-
 ```go
-res, err := client.Delete("my_index", "id")
-if err != nil {
-    log.Fatal(err)
-}
-defer res.Body.Close()
+client.Delete("my_index", "1").Do(context.TODO())
 ```
-
-::::::
-
-::::::{tab-item} Fully-typed API
-:sync: typed
-
-```go
-typedClient.Delete("my_index", "id").Do(context.TODO())
-```
-
-::::::
-
-:::::::
 
 ::::::::
 
 ::::::::{step} Delete an index
 
-:::::::{tab-set}
-:group: APIs
-::::::{tab-item} Low-level API
-:sync: lowLevel
-
 ```go
-res, err := client.Indices.Delete([]string{"my_index"})
-if err != nil {
-    log.Fatal(err)
-}
-defer res.Body.Close()
+client.Indices.Delete("my_index").Do(context.TODO())
 ```
-
-::::::
-
-::::::{tab-item} Fully-typed API
-:sync: typed
-
-```go
-typedClient.Indices.Delete("my_index").Do(context.TODO())
-```
-
-::::::
-
-:::::::
 
 ::::::::
 
@@ -339,3 +129,4 @@ typedClient.Indices.Delete("my_index").Do(context.TODO())
 
 - Learn more about the [_Typed API_](/reference/typed-api/index.md), a strongly typed Go API for {{es}}.
 - Explore the [_esdsl builders_](/reference/typed-api/esdsl.md) for a fluent syntax to construct queries, aggregations, and mappings.
+- If you need the low-level API or are migrating from it, see the [_Low-level API_](/reference/low-level-api/index.md) and the [_migration guide_](/reference/low-level-api/migration.md).

--- a/docs/reference/getting-started.md
+++ b/docs/reference/getting-started.md
@@ -69,7 +69,7 @@ document := struct {
 }
 client.Index("my_index").
     Id("1").
-    Request(document).
+    Document(document).
     Do(context.TODO())
 ```
 

--- a/docs/reference/index.md
+++ b/docs/reference/index.md
@@ -12,10 +12,9 @@ Full documentation is hosted at [GitHub](https://github.com/elastic/go-elasticse
 
 ## Features [_features]
 
-- One-to-one mapping with REST API.
-- Generalized, pluggable architecture.
-- Two API styles: [low-level](using-the-api/index.md) and [fully typed](typed-api/index.md).
-- [Fluent DSL builders](typed-api/esdsl.md) for constructing queries, aggregations, mappings, and sort options.
+- Strongly typed [typed API](typed-api/index.md) with compile-time safety and decoded responses.
+- Fluent [esdsl builders](typed-api/esdsl.md) for queries, aggregations, mappings, and sort options.
+- [Low-level API](low-level-api/index.md) for raw JSON control and endpoints not yet covered by the typed API.
 - Built-in [OpenTelemetry instrumentation](advanced/observability.md) for distributed tracing.
 - [Interceptors](advanced/interceptors.md) for custom middleware (auth rotation, observability, etc.).
 - Automatic retries, request compression, and node discovery.
@@ -24,7 +23,7 @@ Full documentation is hosted at [GitHub](https://github.com/elastic/go-elasticse
 
 ## Architecture [_architecture]
 
-The client has a layered architecture where both the low-level and typed APIs share the same transport infrastructure:
+The client has a layered architecture where the typed and low-level APIs share the same transport infrastructure:
 
 ```mermaid
 graph LR
@@ -44,62 +43,44 @@ The **transport layer** handles retry logic, request compression, node selection
 
 ## Usage [_usage]
 
-:::::::{tab-set}
-:group: APIs
-::::::{tab-item} Low-level API
-:sync: lowLevel
+The typed client combined with the `esdsl` builders is the recommended way to use this library:
 
 ```go subs=true
 package main
 
 import (
     "context"
+    "fmt"
     "log"
 
     "github.com/elastic/go-elasticsearch/v{{ version.elasticsearch-client-go | M }}"
+    "github.com/elastic/go-elasticsearch/v{{ version.elasticsearch-client-go | M }}/typedapi/esdsl"
 )
 
 func main() {
-    es, _ := elasticsearch.New()
-    defer es.Close(context.Background())
-
-    res, err := es.Info()
+    es, err := elasticsearch.NewTyped(
+        elasticsearch.WithAddresses("http://localhost:9200"),
+    )
     if err != nil {
         log.Fatal(err)
     }
-    defer res.Body.Close()
-
-    log.Println(res)
-}
-```
-
-::::::
-
-::::::{tab-item} Fully-typed API
-:sync: typed
-
-```go subs=true
-package main
-
-import (
-    "context"
-    "log"
-
-    "github.com/elastic/go-elasticsearch/v{{ version.elasticsearch-client-go | M }}"
-)
-
-func main() {
-    es, _ := elasticsearch.NewTyped(
-        elasticsearch.WithAddresses("http://localhost:9200"),
-    )
     defer es.Close(context.Background())
-    log.Println(es.Info().Do(context.Background()))
+
+    res, err := es.Search().
+        Index("my-index").
+        Query(esdsl.NewMatchQuery("title", "golang")).
+        Do(context.Background())
+    if err != nil {
+        log.Fatal(err)
+    }
+
+    for _, hit := range res.Hits.Hits {
+        fmt.Println(hit.Source_)
+    }
 }
 ```
 
-::::::
-
-:::::::
+If you need raw JSON control or an endpoint the typed API does not yet cover, see the [low-level API](low-level-api/index.md). You can mix both styles in the same program: they share the same transport and can run against the same client. The [migration guide](low-level-api/migration.md) walks through moving existing low-level code to the typed API one endpoint at a time.
 
 ::::{note}
 Please have a look at the collection of comprehensive examples in the repository at <https://github.com/elastic/go-elasticsearch/tree/main/_examples>.

--- a/docs/reference/installation.md
+++ b/docs/reference/installation.md
@@ -43,10 +43,10 @@ cat > main.go <<-END
   )
 
   func main() {
-    es, _ := elasticsearch.New()
+    es, _ := elasticsearch.NewTyped()
     defer es.Close(context.Background())
     log.Println(elasticsearch.Version)
-    log.Println(es.Info())
+    log.Println(es.Info().Do(context.Background()))
   }
 END
 

--- a/docs/reference/low-level-api/index.md
+++ b/docs/reference/low-level-api/index.md
@@ -1,0 +1,186 @@
+---
+navigation_title: "Low-level API"
+---
+
+# Low-level API [low_level_api]
+
+The low-level API provides a one-to-one mapping with the {{es}} REST API. Each endpoint accepts raw `io.Reader` request bodies and returns `*esapi.Response` objects whose `Body` is an `io.ReadCloser` you read and close yourself.
+
+The rest of this documentation is built around the [typed API](../typed-api/index.md) and the [esdsl builders](../typed-api/esdsl.md), which together cover the vast majority of {{es}} endpoints with compile-time safety, automatic JSON encoding and decoding, and fluent query construction. **We recommend the typed API for new code.** If you are already using the low-level API, the [migration guide](migration.md) shows how to adopt the typed API without rewriting your whole codebase.
+
+## When to use the low-level API [_when_low_level]
+
+Reach for the low-level API when:
+
+- You need an endpoint that is not covered by the typed API.
+- You want full control over request serialization, for example to plug in a custom JSON encoder or a streaming body.
+- You are working with pre-baked JSON payloads and do not want to model them as Go structs.
+
+If none of these apply, prefer the [typed API](../typed-api/index.md).
+
+## Creating a client [_low_level_client]
+
+Use `elasticsearch.New` with functional options:
+
+```go subs=true
+package main
+
+import (
+    "context"
+    "log"
+
+    "github.com/elastic/go-elasticsearch/v{{ version.elasticsearch-client-go | M }}"
+)
+
+func main() {
+    client, err := elasticsearch.New(
+        elasticsearch.WithAddresses("https://localhost:9200"),
+        elasticsearch.WithAPIKey("API_KEY"),
+    )
+    if err != nil {
+        log.Fatalf("creating client: %s", err)
+    }
+    defer client.Close(context.Background())
+
+    res, err := client.Info()
+    if err != nil {
+        log.Fatalf("info: %s", err)
+    }
+    defer res.Body.Close()
+    log.Println(res)
+}
+```
+
+For full configuration options, see the [Configuration reference](../configuration.md).
+
+::::{note}
+`NewClient(Config)` and `NewDefaultClient()` still work but are deprecated. Use `New` with [functional options](../configuration.md) instead.
+::::
+
+## Response handling [_low_level_response_handling]
+
+Every low-level call returns an `*esapi.Response` whose body you must read and close. Failing to close the body prevents Go's HTTP client from reusing the underlying TCP connection.
+
+```go
+res, err := client.Search(
+    client.Search.WithIndex("my-index"),
+    client.Search.WithBody(strings.NewReader(`{"query":{"match_all":{}}}`)),
+)
+if err != nil {
+    log.Fatal(err)
+}
+defer res.Body.Close() // <1>
+
+if res.IsError() { // <2>
+    log.Fatalf("search failed: %s", res.String())
+}
+
+var result map[string]any
+if err := json.NewDecoder(res.Body).Decode(&result); err != nil { // <3>
+    log.Fatal(err)
+}
+```
+
+1. Always close the response body, even on the success path.
+2. `IsError()` returns `true` for HTTP status codes >= 400.
+3. Decode the body yourself into whatever shape fits your application.
+
+## Common operations [_low_level_operations]
+
+A condensed tour of the most common CRUD and search calls. For detailed tutorials, see the [typed API equivalents](../using-the-api/index.md); the low-level signatures below are stable and map directly to the corresponding REST endpoints.
+
+### Create an index
+
+```go
+mapping := `{"mappings":{"properties":{"price":{"type":"integer"}}}}`
+
+res, err := client.Indices.Create(
+    "test-index",
+    client.Indices.Create.WithBody(strings.NewReader(mapping)),
+)
+if err != nil {
+    log.Fatal(err)
+}
+defer res.Body.Close()
+```
+
+### Index a document
+
+```go
+document := struct {
+    Name  string `json:"name"`
+    Price int    `json:"price"`
+}{Name: "Foo", Price: 10}
+
+data, _ := json.Marshal(document)
+res, err := client.Index(
+    "test-index",
+    bytes.NewReader(data),
+    client.Index.WithDocumentID("1"),
+)
+if err != nil {
+    log.Fatal(err)
+}
+defer res.Body.Close()
+```
+
+### Get a document
+
+```go
+res, err := client.Get("test-index", "1")
+if err != nil {
+    log.Fatal(err)
+}
+defer res.Body.Close()
+```
+
+### Search
+
+```go
+query := `{"query":{"match":{"name":{"query":"Foo"}}}}`
+
+res, err := client.Search(
+    client.Search.WithIndex("test-index"),
+    client.Search.WithBody(strings.NewReader(query)),
+)
+if err != nil {
+    log.Fatal(err)
+}
+defer res.Body.Close()
+```
+
+### Delete a document
+
+```go
+res, err := client.Delete("test-index", "1")
+if err != nil {
+    log.Fatal(err)
+}
+defer res.Body.Close()
+```
+
+### Bulk
+
+```go
+var buf bytes.Buffer
+buf.WriteString(`{"index":{"_index":"test","_id":"1"}}` + "\n")
+buf.WriteString(`{"title":"Test"}` + "\n")
+
+res, err := client.Bulk(bytes.NewReader(buf.Bytes()))
+if err != nil {
+    log.Fatal(err)
+}
+defer res.Body.Close()
+```
+
+For a higher-level alternative that handles batching, flushing, and concurrency, see [`esutil.BulkIndexer`](../using-the-api/bulk-indexing.md#_bulk_indexer_helper). The BulkIndexer works with both the low-level and typed clients.
+
+## API reference [_low_level_reference]
+
+The full set of low-level endpoints, parameters, and option functions is documented on pkg.go.dev:
+
+- [`esapi` package reference](https://pkg.go.dev/github.com/elastic/go-elasticsearch/v9/esapi)
+
+## Migrating to the typed API [_low_level_migration_pointer]
+
+You do not have to switch everything at once. An `*elasticsearch.Client` already satisfies the transport interface used by the typed API packages, so you can adopt typed endpoints one at a time while keeping the rest of your code untouched. See the [migration guide](migration.md) for the details.

--- a/docs/reference/low-level-api/migration.md
+++ b/docs/reference/low-level-api/migration.md
@@ -1,0 +1,271 @@
+---
+navigation_title: "Migrating to the typed API"
+---
+
+# Migrating from the low-level API to the typed API [low_level_migration]
+
+The Go client ships two API surfaces over a shared transport: the [low-level API](index.md) (`*elasticsearch.Client`) and the [typed API](../typed-api/index.md) (`*elasticsearch.TypedClient`). This page explains how to move existing code from the low-level API to the typed API, and shows how to migrate gradually (one endpoint at a time) without rewriting your whole codebase.
+
+## Why migrate [_why_migrate]
+
+The typed API gives you:
+
+- **Type-safe requests.** Requests are Go structs generated from the {{es}} specification, so invalid fields are caught at compile time.
+- **Decoded responses.** Every endpoint returns a typed response; no manual JSON parsing and no forgetting to close response bodies.
+- **Fluent builders.** The [`esdsl`](../typed-api/esdsl.md) package provides chainable builders for queries, aggregations, mappings, and sort options, replacing deeply nested struct literals.
+- **Less boilerplate.** No more `io.Reader` wrapping, no `defer res.Body.Close()`, no `res.IsError()` checks.
+
+## Full migration [_full_migration]
+
+If you can commit to the typed API everywhere, replace the constructor and the call sites:
+
+:::::::{tab-set}
+::::::{tab-item} Before
+
+```go
+// Modern functional-options form.
+client, err := elasticsearch.New(
+    elasticsearch.WithAddresses("https://localhost:9200"),
+    elasticsearch.WithAPIKey("API_KEY"),
+)
+
+// Older, deprecated Config form (still works).
+client, err := elasticsearch.NewClient(elasticsearch.Config{
+    Addresses: []string{"https://localhost:9200"},
+    APIKey:    "API_KEY",
+})
+```
+
+::::::
+
+::::::{tab-item} After
+
+```go
+client, err := elasticsearch.NewTyped(
+    elasticsearch.WithAddresses("https://localhost:9200"),
+    elasticsearch.WithAPIKey("API_KEY"),
+)
+```
+
+::::::
+
+:::::::
+
+Both constructors take the same [functional options](../configuration.md) and share the same transport, retry, instrumentation, and interceptor infrastructure. The deprecated `NewClient(Config{...})` form has a typed equivalent in `NewTypedClient(Config{...})`, but both are deprecated, so a migration is a good moment to move to the functional-options form as well.
+
+### Side-by-side operations [_side_by_side]
+
+A few common call-site translations:
+
+**Index a document**
+
+:::::::{tab-set}
+::::::{tab-item} Low-level
+
+```go
+data, _ := json.Marshal(doc)
+res, err := client.Index(
+    "my-index",
+    bytes.NewReader(data),
+    client.Index.WithDocumentID("1"),
+)
+if err != nil {
+    log.Fatal(err)
+}
+defer res.Body.Close()
+```
+
+::::::
+
+::::::{tab-item} Typed
+
+```go
+res, err := client.Index("my-index").
+    Id("1").
+    Request(doc).
+    Do(ctx)
+```
+
+::::::
+
+:::::::
+
+**Search**
+
+:::::::{tab-set}
+::::::{tab-item} Low-level
+
+```go
+query := `{"query":{"match":{"title":{"query":"golang"}}}}`
+res, err := client.Search(
+    client.Search.WithIndex("my-index"),
+    client.Search.WithBody(strings.NewReader(query)),
+)
+if err != nil {
+    log.Fatal(err)
+}
+defer res.Body.Close()
+
+var result map[string]any
+json.NewDecoder(res.Body).Decode(&result)
+```
+
+::::::
+
+::::::{tab-item} Typed + esdsl
+
+```go subs=true
+import "github.com/elastic/go-elasticsearch/v{{ version.elasticsearch-client-go | M }}/typedapi/esdsl"
+```
+
+```go
+res, err := client.Search().
+    Index("my-index").
+    Query(esdsl.NewMatchQuery("title", "golang")).
+    Do(ctx)
+if err != nil {
+    log.Fatal(err)
+}
+for _, hit := range res.Hits.Hits {
+    fmt.Println(hit.Source_)
+}
+```
+
+::::::
+
+:::::::
+
+**Bulk**
+
+:::::::{tab-set}
+::::::{tab-item} Low-level
+
+```go
+var buf bytes.Buffer
+buf.WriteString(`{"index":{"_index":"my-index","_id":"1"}}` + "\n")
+buf.WriteString(`{"title":"Test"}` + "\n")
+
+res, err := client.Bulk(bytes.NewReader(buf.Bytes()))
+if err != nil {
+    log.Fatal(err)
+}
+defer res.Body.Close()
+```
+
+::::::
+
+::::::{tab-item} Typed
+
+```go
+index := "my-index"
+id := "1"
+
+bulk := client.Bulk()
+if err := bulk.IndexOp(
+    types.IndexOperation{Index_: &index, Id_: &id},
+    map[string]any{"title": "Test"},
+); err != nil {
+    log.Fatal(err)
+}
+
+res, err := bulk.Do(ctx)
+if err != nil {
+    log.Fatal(err)
+}
+if res.Errors {
+    // One or more operations failed.
+}
+```
+
+::::::
+
+:::::::
+
+For more call-site patterns, see [CRUD operations](../using-the-api/crud-operations.md), [Searching](../using-the-api/searching.md), [Aggregations](../using-the-api/aggregations.md), and [Bulk indexing](../using-the-api/bulk-indexing.md).
+
+## Partial migration [_partial_migration]
+
+You do not have to switch the whole codebase at once. The typed API endpoints live in small, focused packages under `typedapi/` (for example `typedapi/core/search`, `typedapi/indices/create`, `typedapi/core/bulk`). Each endpoint package exports a constructor that takes an `elastictransport.Interface`, which is just:
+
+```go
+// from github.com/elastic/elastic-transport-go/v8/elastictransport
+type Interface interface {
+    Perform(*http.Request) (*http.Response, error)
+}
+```
+
+`*elasticsearch.Client` (low-level) and `*elasticsearch.TypedClient` (typed) both embed `BaseClient`, which implements `Perform`. That means **you can pass an existing low-level client directly into any typed endpoint package**: no second client, no duplicated configuration, same transport and connection pool.
+
+### Example: migrate just the search call
+
+Keep your existing low-level `*elasticsearch.Client` for every call except search. Build a `search.New(client)` wherever you want typed search:
+
+```go subs=true
+package main
+
+import (
+    "context"
+    "fmt"
+    "log"
+
+    "github.com/elastic/go-elasticsearch/v{{ version.elasticsearch-client-go | M }}"
+    "github.com/elastic/go-elasticsearch/v{{ version.elasticsearch-client-go | M }}/typedapi/core/search"
+    "github.com/elastic/go-elasticsearch/v{{ version.elasticsearch-client-go | M }}/typedapi/esdsl"
+)
+
+func main() {
+    client, err := elasticsearch.New( // <1>
+        elasticsearch.WithAddresses("https://localhost:9200"),
+        elasticsearch.WithAPIKey("API_KEY"),
+    )
+    if err != nil {
+        log.Fatal(err)
+    }
+    defer client.Close(context.Background())
+
+    // Unchanged: all other calls keep using the low-level client.
+    res, err := client.Indices.Exists([]string{"my-index"})
+    if err != nil {
+        log.Fatal(err)
+    }
+    defer res.Body.Close()
+
+    // Migrated: search uses the typed package directly, backed by the
+    // same client and the same transport.
+    typedSearch := search.New(client) // <2>
+    result, err := typedSearch.
+        Index("my-index").
+        Query(esdsl.NewMatchQuery("title", "golang")). // <3>
+        Do(context.Background())
+    if err != nil {
+        log.Fatal(err)
+    }
+    for _, hit := range result.Hits.Hits {
+        fmt.Println(hit.Source_)
+    }
+}
+```
+
+1. The existing low-level client. Keep it.
+2. `search.New` accepts any `elastictransport.Interface`. `*elasticsearch.Client` satisfies it via the embedded `BaseClient.Perform` method, so no adapter is needed.
+3. The `esdsl` builders work with any typed endpoint, regardless of how you built the client.
+
+The same pattern applies to every typed endpoint package: `typedapi/indices/create`, `typedapi/core/bulk`, `typedapi/cluster/health`, and so on. Import the package for the endpoint you want to migrate, call `New(client)`, and use the builder.
+
+### Strategy [_partial_migration_strategy]
+
+A typical gradual migration looks like:
+
+1. **Start with the hot spots.** Migrate the endpoints where typed requests and decoded responses give the most value: usually search, aggregations, and bulk indexing.
+2. **Let new code use `NewTyped` directly.** New call sites can use `*elasticsearch.TypedClient` from the start; old call sites keep using the low-level client.
+3. **Replace the constructor last.** Once most call sites are typed, swap `elasticsearch.New(...)` for `elasticsearch.NewTyped(...)`. Any typed endpoint packages you used for partial migration keep working against the new client, because `*TypedClient` also satisfies `elastictransport.Interface`. What stops compiling is the remaining low-level call sites (`client.Search(...)`, `client.Indices.Create(...)`, `client.Bulk(...)`, etc.), because `*TypedClient` does not embed `*esapi.API`. Treat those as the last batch to migrate.
+
+## Endpoints not covered by the typed API [_typed_api_gaps]
+
+The typed API covers the most widely used endpoints, but it does not yet cover every endpoint in the REST API. If you hit a gap, keep calling that endpoint through the low-level client: the two share the same transport, so you can mix and match freely in the same application. Check the [`typedapi` godoc](https://pkg.go.dev/github.com/elastic/go-elasticsearch/v9/typedapi) for the current set of supported endpoints.
+
+## Further reading [_migration_further_reading]
+
+- [Typed API overview](../typed-api/index.md): namespaces, builders, NDJSON payloads.
+- [esdsl builders](../typed-api/esdsl.md): fluent query, aggregation, and mapping construction.
+- [Typed API conventions](../typed-api/conventions.md): naming, enums, and unions.

--- a/docs/reference/low-level-api/migration.md
+++ b/docs/reference/low-level-api/migration.md
@@ -82,7 +82,7 @@ defer res.Body.Close()
 ```go
 res, err := client.Index("my-index").
     Id("1").
-    Request(doc).
+    Document(doc).
     Do(ctx)
 ```
 

--- a/docs/reference/toc.yml
+++ b/docs/reference/toc.yml
@@ -16,6 +16,9 @@ toc:
     children:
       - file: typed-api/conventions.md
       - file: typed-api/esdsl.md
+  - file: low-level-api/index.md
+    children:
+      - file: low-level-api/migration.md
   - file: advanced/index.md
     children:
       - file: advanced/interceptors.md

--- a/docs/reference/typed-api/index.md
+++ b/docs/reference/typed-api/index.md
@@ -33,7 +33,7 @@ For full configuration options, see the [Configuration reference](../configurati
 
 ## Relationship to the low-level client [_typed_api_relationship]
 
-The typed client and the low-level client share the same underlying transport, configuration, and connection pool. The typed API is a higher-level abstraction built on top of the same infrastructure:
+The typed client and the [low-level client](../low-level-api/index.md) share the same underlying transport, configuration, and connection pool. The typed API is a higher-level abstraction built on top of the same infrastructure:
 
 ```mermaid
 graph TB
@@ -52,7 +52,7 @@ graph TB
     OPTS --> TP
 ```
 
-You can use both clients in the same application since they share the same transport. Choose the typed API for compile-time safety, or fall back to the low-level API for maximum flexibility.
+Because both clients implement the same transport interface, individual typed endpoint packages (`typedapi/core/search`, `typedapi/indices/create`, ...) accept either client type. That means you can mix the two styles in a single application, and you can migrate existing low-level code to the typed API one endpoint at a time. See the [migration guide](../low-level-api/migration.md).
 
 ## API namespaces [_typed_api_namespaces]
 
@@ -165,6 +165,7 @@ If you already have a newline-delimited JSON payload, you can submit it directly
 
 ## Learn more [_typed_api_learn_more]
 
-- [Conventions](conventions.md) — Naming, structure, enums, and unions in the typed API
-- [esdsl builders](esdsl.md) — Fluent DSL builders for queries, aggregations, mappings, and sort options
-- [Using the API](../using-the-api/index.md) — Practical examples comparing both API styles
+- [Conventions](conventions.md): naming, structure, enums, and unions in the typed API
+- [esdsl builders](esdsl.md): fluent DSL builders for queries, aggregations, mappings, and sort options
+- [Using the API](../using-the-api/index.md): practical examples for common operations
+- [Low-level API](../low-level-api/index.md) and [migration guide](../low-level-api/migration.md): raw-JSON control and migration instructions

--- a/docs/reference/using-the-api/aggregations.md
+++ b/docs/reference/using-the-api/aggregations.md
@@ -5,83 +5,13 @@ mapped_pages:
 
 # Aggregations [aggregations]
 
-This page covers how to run aggregations with the Go client. For the full aggregations reference, see [Aggregations](docs-content://explore-analyze/query-filter/aggregations.md) in the {{es}} documentation.
-
-Given documents with a `price` field, we run a sum aggregation on `index_name`.
-
-:::::::{tab-set}
-:group: APIs
-::::::{tab-item} Low-level API
-:sync: lowLevel
-
-```go
-query := `{
-  "size": 0,
-  "aggs": {
-    "total_prices": {
-      "sum": {
-        "field": "price"
-      }
-    }
-  }
-}`
-
-res, err := client.Search(
-    client.Search.WithIndex("index_name"), // <1>
-    client.Search.WithBody(strings.NewReader(query)), // <2>
-)
-if err != nil {
-    log.Fatal(err)
-}
-defer res.Body.Close()
-```
-
-1. Specifies the index name.
-2. Pass the aggregation query as raw JSON. Setting `"size": 0` retrieves only the aggregation result.
-
-::::::
-
-::::::{tab-item} Fully-typed API
-:sync: typed
-
-The `some` package provides helpers for inline pointers on primitive types:
-
-```go
-import "github.com/elastic/go-elasticsearch/v9/typedapi/some"
-```
-
-```go
-totalPricesAgg, err := es.Search().
-    Index("index_name"). // <1>
-    Request(
-        &search.Request{
-            Size: some.Int(0), // <2>
-            Aggregations: map[string]types.Aggregations{
-                "total_prices": { // <3>
-                    Sum: &types.SumAggregation{
-                        Field: some.String("price"), // <4>
-                    },
-                },
-            },
-        },
-    ).Do(context.Background())
-```
-
-1. Specifies the index name.
-2. Sets the size to 0 to retrieve only the result of the aggregation.
-3. Specifies the field name on which the sum aggregation runs.
-4. The `SumAggregation` is part of the `Aggregations` map.
-
-::::::
-
-::::::{tab-item} esdsl API
-:sync: esdsl
-
-The [`esdsl`](/reference/typed-api/esdsl.md) aggregation builders let you define aggregations with a fluent syntax:
+This page covers how to run aggregations with the Go client using the [typed API](/reference/typed-api/index.md) and the [`esdsl`](/reference/typed-api/esdsl.md) builders. For the full aggregations reference, see [Aggregations](docs-content://explore-analyze/query-filter/aggregations.md) in the {{es}} documentation. For raw-JSON aggregations, see the [low-level API](/reference/low-level-api/index.md).
 
 ```go subs=true
 import "github.com/elastic/go-elasticsearch/v{{ version.elasticsearch-client-go | M }}/typedapi/esdsl"
 ```
+
+Given documents with a `price` field, we run a sum aggregation on `index_name`. The `esdsl` aggregation builders let you define aggregations with a fluent syntax:
 
 ```go
 totalPricesAgg, err := es.Search().
@@ -96,8 +26,4 @@ totalPricesAgg, err := es.Search().
 1. Specifies the index name.
 2. Sets the size to 0 to retrieve only the result of the aggregation.
 3. Names the aggregation `total_prices`.
-4. `NewSumAggregation()` creates a sum aggregation builder - chain `.Field()` to set the target field.
-
-::::::
-
-:::::::
+4. `NewSumAggregation()` creates a sum aggregation builder. Chain `.Field()` to set the target field.

--- a/docs/reference/using-the-api/bulk-indexing.md
+++ b/docs/reference/using-the-api/bulk-indexing.md
@@ -5,49 +5,11 @@ mapped_pages:
 
 # Bulk indexing [bulk]
 
-When ingesting many documents, use the Bulk API to send multiple operations in a single request. For the full bulk API reference, see the [Bulk API documentation](https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-bulk).
+When ingesting many documents, use the Bulk API to send multiple operations in a single request. For the full bulk API reference, see the [Bulk API documentation](https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-bulk). For raw-NDJSON bulk requests, see the [low-level API](/reference/low-level-api/index.md).
 
 ## Direct bulk requests [_direct_bulk]
 
-:::::::{tab-set}
-:group: APIs
-::::::{tab-item} Low-level API
-:sync: lowLevel
-
-With the low-level client, build the NDJSON payload yourself and submit it with `Bulk()`:
-
-```go
-client, err := elasticsearch.New()
-if err != nil {
-    // Handle error.
-}
-defer func() {
-    if err := client.Close(context.Background()); err != nil {
-        // Handle error.
-    }
-}()
-
-var buf bytes.Buffer
-buf.WriteString(`{ "index" : { "_index" : "test", "_id" : "1" } }` + "\n") // <1>
-buf.WriteString(`{ "title" : "Test" }` + "\n") // <2>
-
-res, err := client.Bulk(bytes.NewReader(buf.Bytes())) // <3>
-if err != nil {
-    // Handle error.
-}
-defer res.Body.Close()
-```
-
-1. Each operation line specifies the action and metadata.
-2. The document body follows. The final line must end with `\n`.
-3. Send the NDJSON payload as an `io.Reader`.
-
-::::::
-
-::::::{tab-item} Fully-typed API
-:sync: typed
-
-With the typed client, you can build a bulk request by appending operations and then executing it:
+With the typed client, build a bulk request by appending operations and then executing it:
 
 ```go
 index := "my-index"
@@ -82,20 +44,16 @@ if res.Errors {
 2. Append index operations with metadata and document body.
 3. Execute the bulk request.
 
-::::::
-
-:::::::
-
-The client repository contains complete, runnable examples for bulk ingestion (manual NDJSON, `esutil.BulkIndexer`, typed bulk, benchmarks, Kafka ingestion): [`_examples/bulk`](https://github.com/elastic/go-elasticsearch/tree/main/_examples/bulk).
+The client repository contains complete, runnable examples for bulk ingestion (typed bulk, `esutil.BulkIndexer`, benchmarks, Kafka ingestion): [`_examples/bulk`](https://github.com/elastic/go-elasticsearch/tree/main/_examples/bulk).
 
 ## BulkIndexer helper [_bulk_indexer_helper]
 
-For a higher-level API that takes care of batching, flushing, and concurrency, use the `esutil.BulkIndexer` helper.
+For a higher-level API that takes care of batching, flushing, and concurrency, use the `esutil.BulkIndexer` helper. `BulkIndexer` accepts any client that implements the transport interface (`Perform(*http.Request) (*http.Response, error)`), so it works with both `*elasticsearch.TypedClient` and `*elasticsearch.Client`.
 
 The BulkIndexer is designed to be **long-lived**: create it once, keep adding items over time (potentially from multiple goroutines), and call `Close()` once when you are done (for example with `defer`).
 
 ```go
-client, err := elasticsearch.New()
+client, err := elasticsearch.NewTyped()
 if err != nil {
     // Handle error.
 }
@@ -129,7 +87,7 @@ _ = indexer.Add(ctx, esutil.BulkIndexerItem{
 })
 ```
 
-1. The Elasticsearch client instance.
+1. Any client that implements the transport interface. Here we pass a `*elasticsearch.TypedClient`; `*elasticsearch.Client` works identically.
 2. The default index name for all items.
 3. Number of concurrent worker goroutines.
 4. Flush threshold in bytes (flush when the buffer reaches this size).
@@ -139,7 +97,7 @@ The `esutil.BulkIndexerConfig` struct supports the following fields:
 
 | Field           | Type                                    | Description                                                          |
 | --------------- | --------------------------------------- | -------------------------------------------------------------------- |
-| `Client`        | `*elasticsearch.Client`                 | The Elasticsearch client (required).                                 |
+| `Client`        | `esapi.Transport`                       | Any transport that implements `Perform` (required).                  |
 | `Index`         | `string`                                | Default index name for items that don't specify one.                 |
 | `NumWorkers`    | `int`                                   | Number of concurrent worker goroutines (default: number of CPUs).    |
 | `FlushBytes`    | `int`                                   | Flush threshold in bytes.                                            |
@@ -159,7 +117,7 @@ The `esutil.BulkIndexerConfig` struct supports the following fields:
 
 ### Explicit flushing [_explicit_flushing]
 
-In addition to automatic flushing (based on `FlushBytes` and `FlushInterval`), you can explicitly flush the indexer at any time using `Flush()`. This drains all currently queued items, flushes all worker buffers to Elasticsearch, and waits for completion. The indexer remains usable after `Flush()` — you can continue adding items.
+In addition to automatic flushing (based on `FlushBytes` and `FlushInterval`), you can explicitly flush the indexer at any time using `Flush()`. This drains all currently queued items, flushes all worker buffers to Elasticsearch, and waits for completion. The indexer remains usable after `Flush()`; you can continue adding items.
 
 This is useful when you need to ensure all pending documents are sent before proceeding, for example after ingesting a batch of records or before reading back recently indexed data.
 
@@ -183,7 +141,7 @@ if err := indexer.Flush(ctx); err != nil {
     // Handle error.
 }
 
-// The indexer is still usable — keep adding items or close it when done.
+// The indexer is still usable; keep adding items or close it when done.
 ```
 
 `Flush()` follows the same callback model as automatic flushes: per-item results are delivered through the `OnSuccess` and `OnFailure` callbacks on each `BulkIndexerItem`. `Flush` itself only returns an error for transport-level failures or context cancellation.

--- a/docs/reference/using-the-api/crud-operations.md
+++ b/docs/reference/using-the-api/crud-operations.md
@@ -5,72 +5,17 @@ mapped_pages:
 
 # CRUD operations [crud_operations]
 
-This page covers common CRUD (Create, Read, Update, Delete) operations with the Go client.
-
-## Creating an index [indices]
-
-For this example on how to create an index, lets create an index named `test-index` and provide a mapping for the field `price` which will be an integer.
-
-:::::::{tab-set}
-:group: APIs
-::::::{tab-item} Low-level API
-:sync: lowLevel
-
-```go
-mapping := `{
-  "mappings": {
-    "properties": {
-      "price": { "type": "integer" }
-    }
-  }
-}`
-
-res, err := client.Indices.Create(
-    "test-index", // <1>
-    client.Indices.Create.WithBody(strings.NewReader(mapping)), // <2>
-)
-if err != nil {
-    log.Fatal(err)
-}
-defer res.Body.Close() // <3>
-```
-
-1. The name of the index to create.
-2. Pass the JSON mapping as the request body.
-3. Always close the response body to ensure HTTP connection reuse.
-
-::::::
-
-::::::{tab-item} Fully-typed API
-:sync: typed
-
-Notice how using the builder for the `IntegerNumberProperty` will automatically apply the correct value for the `type` field.
-
-```go
-res, err := es.Indices.Create("test-index"). // <1>
-    Request(&create.Request{
-        Mappings: &types.TypeMapping{
-            Properties: map[string]types.Property{
-                "price": types.NewIntegerNumberProperty(), // <2>
-            },
-        },
-    }).
-    Do(context.Background())
-```
-
-1. The name of the index to create.
-2. The typed builder automatically sets the correct `type` field for the property.
-
-::::::
-
-::::::{tab-item} esdsl API
-:sync: esdsl
-
-The [`esdsl`](/reference/typed-api/esdsl.md) mapping builders provide a fluent syntax for defining index mappings:
+This page covers common CRUD (Create, Read, Update, Delete) operations with the Go client using the [typed API](/reference/typed-api/index.md) and the [`esdsl`](/reference/typed-api/esdsl.md) builders. For the low-level equivalents, see the [low-level API](/reference/low-level-api/index.md).
 
 ```go subs=true
 import "github.com/elastic/go-elasticsearch/v{{ version.elasticsearch-client-go | M }}/typedapi/esdsl"
 ```
+
+## Creating an index [indices]
+
+For this example, let's create an index named `test-index` and provide a mapping for the field `price` which will be an integer.
+
+The [`esdsl`](/reference/typed-api/esdsl.md) mapping builders provide a fluent syntax for defining index mappings. The correct `type` field is set automatically for each property:
 
 ```go
 res, err := es.Indices.Create("test-index"). // <1>
@@ -83,53 +28,11 @@ res, err := es.Indices.Create("test-index"). // <1>
 
 1. The name of the index to create.
 2. Start a mapping builder with `NewTypeMapping()`.
-3. Chain `AddProperty()` calls to define each field. The correct `type` is set automatically.
-
-::::::
-
-:::::::
+3. Chain `AddProperty()` calls to define each field.
 
 ## Indexing a document [indexing]
 
 The standard way of indexing a document is to provide the document body to the index request. The document will be serialized as JSON and sent to {{es}}.
-
-:::::::{tab-set}
-:group: APIs
-::::::{tab-item} Low-level API
-:sync: lowLevel
-
-```go
-document := struct {
-    Id    int    `json:"id"`
-    Name  string `json:"name"`
-    Price int    `json:"price"`
-}{
-    Id:    1,
-    Name:  "Foo",
-    Price: 10,
-}
-
-data, _ := json.Marshal(document)
-res, err := client.Index(
-    "index_name",              // <1>
-    bytes.NewReader(data),     // <2>
-    client.Index.WithDocumentID("1"), // <3>
-)
-if err != nil {
-    log.Fatal(err)
-}
-defer res.Body.Close() // <4>
-```
-
-1. The target index name.
-2. The document body as an `io.Reader`.
-3. Optionally set the document ID.
-4. Always close the response body to ensure HTTP connection reuse.
-
-::::::
-
-::::::{tab-item} Fully-typed API
-:sync: typed
 
 ```go
 document := struct {
@@ -163,38 +66,9 @@ res, err := es.Index("index_name").
     }`)).Do(context.Background())
 ```
 
-::::::
-
-:::::::
-
 ## Retrieving a document [retrieving_document]
 
 Retrieving a document follows the API as part of the argument of the endpoint. You provide the `index` and the `id`, then run the query.
-
-:::::::{tab-set}
-:group: APIs
-::::::{tab-item} Low-level API
-:sync: lowLevel
-
-```go
-res, err := client.Get(
-    "index_name", // <1>
-    "doc_id",     // <2>
-)
-if err != nil {
-    log.Fatal(err)
-}
-defer res.Body.Close() // <3>
-```
-
-1. The index to retrieve the document from.
-2. The document ID.
-3. Always close the response body to ensure HTTP connection reuse.
-
-::::::
-
-::::::{tab-item} Fully-typed API
-:sync: typed
 
 ```go
 res, err := es.Get(
@@ -206,37 +80,9 @@ res, err := es.Get(
 1. The index to retrieve the document from.
 2. The document ID.
 
-::::::
-
-:::::::
-
 ## Checking for a document existence [_checking_for_a_document_existence]
 
-If you do not wish to retrieve the content of the document and want only to check if it exists in your index:
-
-:::::::{tab-set}
-:group: APIs
-::::::{tab-item} Low-level API
-:sync: lowLevel
-
-```go
-res, err := client.Exists("index_name", "doc_id")
-if err != nil {
-    // Handle error.
-}
-defer res.Body.Close()
-
-if !res.IsError() {
-    // The document exists!
-}
-```
-
-::::::
-
-::::::{tab-item} Fully-typed API
-:sync: typed
-
-The typed API provides the `IsSuccess` shortcut:
+If you do not wish to retrieve the content of the document and want only to check if it exists in your index, use the `IsSuccess` shortcut:
 
 ```go
 if exists, err := es.Exists("index_name", "doc_id").IsSuccess(nil); exists {
@@ -247,7 +93,3 @@ if exists, err := es.Exists("index_name", "doc_id").IsSuccess(nil); exists {
 ```
 
 Result is `true` if everything succeeds, `false` if the document doesn't exist. If an error occurs during the request, you will get `false` and the relevant error.
-
-::::::
-
-:::::::

--- a/docs/reference/using-the-api/crud-operations.md
+++ b/docs/reference/using-the-api/crud-operations.md
@@ -47,7 +47,7 @@ document := struct {
 
 res, err := es.Index("index_name"). // <1>
     Id("1").                         // <2>
-    Request(document).               // <3>
+    Document(document).              // <3>
     Do(context.Background())
 ```
 

--- a/docs/reference/using-the-api/dense-vectors.md
+++ b/docs/reference/using-the-api/dense-vectors.md
@@ -9,87 +9,15 @@ mapped_pages:
 stack: ga 9.3
 ```
 
-When working with vector embeddings for semantic search or machine learning applications, the Go client provides support for dense vector indexing and k-nearest neighbors (kNN) search. For the full kNN search reference, see [kNN search](docs-content://solutions/search/vector/knn.md) in the {{es}} documentation.
-
-## Creating an index with dense vector mapping [_creating_dense_vector_index]
-
-Before indexing documents with vectors, create an index with the appropriate dense vector mapping.
-
-:::::::{tab-set}
-:group: APIs
-::::::{tab-item} Low-level API
-:sync: lowLevel
-
-```go
-mapping := `{
-  "mappings": {
-    "properties": {
-      "docid":  { "type": "keyword" },
-      "title":  { "type": "text" },
-      "emb": {
-        "type": "dense_vector",
-        "dims": 1536,
-        "index": true,
-        "similarity": "cosine"
-      }
-    }
-  }
-}`
-
-res, err := client.Indices.Create(
-    "my-vectors", // <1>
-    client.Indices.Create.WithBody(strings.NewReader(mapping)), // <2>
-)
-if err != nil {
-    log.Fatal(err)
-}
-defer res.Body.Close()
-```
-
-1. The name of the index to create.
-2. Pass the full mapping as a JSON body, including dense vector configuration.
-
-::::::
-
-::::::{tab-item} Fully-typed API
-:sync: typed
-
-```go
-similarity := densevectorsimilarity.Cosine
-
-res, err := es.Indices.
-    Create("my-vectors").
-    Request(&create.Request{
-        Mappings: &types.TypeMapping{
-            Properties: map[string]types.Property{
-                "docid": types.NewKeywordProperty(),
-                "title": types.NewTextProperty(),
-                "emb": types.DenseVectorProperty{ // <1>
-                    Dims:       some.Int(1536), // <2>
-                    Index:      some.Bool(true), // <3>
-                    Similarity: &similarity, // <4>
-                },
-            },
-        },
-    }).
-    Do(context.Background())
-```
-
-1. Define the vector field as a `DenseVectorProperty`.
-2. Specify the dimensionality of your vectors (e.g., 1536 for OpenAI embeddings).
-3. Enable indexing to support kNN search capabilities.
-4. Set the similarity metric: `Cosine`, `DotProduct`, or `L2Norm`.
-
-::::::
-
-::::::{tab-item} esdsl API
-:sync: esdsl
-
-The [`esdsl`](/reference/typed-api/esdsl.md) mapping builders provide a concise, fluent syntax:
+When working with vector embeddings for semantic search or machine learning applications, the Go client provides support for dense vector indexing and k-nearest neighbors (kNN) search. This page uses the [typed API](/reference/typed-api/index.md) with the [`esdsl`](/reference/typed-api/esdsl.md) builders. For the full kNN search reference, see [kNN search](docs-content://solutions/search/vector/knn.md) in the {{es}} documentation.
 
 ```go subs=true
 import "github.com/elastic/go-elasticsearch/v{{ version.elasticsearch-client-go | M }}/typedapi/esdsl"
 ```
+
+## Creating an index with dense vector mapping [_creating_dense_vector_index]
+
+Before indexing documents with vectors, create an index with the appropriate dense vector mapping. The [`esdsl`](/reference/typed-api/esdsl.md) mapping builders provide a concise, fluent syntax:
 
 ```go
 mappings := esdsl.NewTypeMapping().
@@ -110,43 +38,9 @@ res, err := es.Indices.
 2. Specify the dimensionality of your vectors (e.g., 1536 for OpenAI embeddings).
 3. Enable indexing to support kNN search capabilities.
 4. Set the similarity metric: `Cosine`, `DotProduct`, or `L2Norm`.
-5. Pass the mapping builder directly - no `Request` wrapper needed.
-
-::::::
-
-:::::::
+5. Pass the mapping builder directly; no `Request` wrapper needed.
 
 ## Indexing documents with vectors [_using_densevectorf32]
-
-:::::::{tab-set}
-:group: APIs
-::::::{tab-item} Low-level API
-:sync: lowLevel
-
-```go
-doc := `{
-    "docid": "doc1",
-    "title": "Example document with vector embedding",
-    "emb": [0.1, 0.2, 0.3, 0.4, 0.5]
-}`
-
-res, err := client.Index(
-    "my-vectors", // <1>
-    strings.NewReader(doc), // <2>
-)
-if err != nil {
-    log.Fatal(err)
-}
-defer res.Body.Close()
-```
-
-1. The target index.
-2. Vectors are passed as JSON arrays of floats.
-
-::::::
-
-::::::{tab-item} Fully-typed API
-:sync: typed
 
 The `types.DenseVectorF32` type automatically encodes `[]float32` vectors as base64 strings during JSON serialization, reducing payload size and improving indexing speed:
 
@@ -171,82 +65,9 @@ res, err := es.Index("my-vectors").
 1. Use `types.DenseVectorF32` instead of `[]float32` for vector fields.
 2. Assign float32 slices directly; base64 encoding happens automatically during serialization.
 
-::::::
-
-:::::::
-
 ## Searching with kNN [_knn_search]
 
-Once your vectors are indexed, you can perform k-nearest neighbors (kNN) search to find similar documents:
-
-:::::::{tab-set}
-:group: APIs
-::::::{tab-item} Low-level API
-:sync: lowLevel
-
-```go
-query := `{
-  "query": {
-    "knn": {
-      "field": "emb",
-      "query_vector": [0.1, 0.2, 0.3, 0.4, 0.5],
-      "k": 10,
-      "num_candidates": 100
-    }
-  }
-}`
-
-res, err := client.Search(
-    client.Search.WithIndex("my-vectors"), // <1>
-    client.Search.WithBody(strings.NewReader(query)), // <2>
-)
-if err != nil {
-    log.Fatal(err)
-}
-defer res.Body.Close()
-```
-
-1. The index containing your vectors.
-2. Pass the kNN query as raw JSON.
-
-::::::
-
-::::::{tab-item} Fully-typed API
-:sync: typed
-
-```go
-queryVector := []float32{0.1, 0.2, 0.3, 0.4, 0.5} // <1>
-k := 10
-numCandidates := 100
-
-res, err := es.Search().
-    Index("my-vectors").
-    Request(&search.Request{
-        Query: &types.Query{
-            Knn: &types.KnnQuery{ // <2>
-                Field:         "emb", // <3>
-                QueryVector:   queryVector, // <4>
-                K:             &k, // <5>
-                NumCandidates: &numCandidates, // <6>
-            },
-        },
-    }).
-    Do(context.Background())
-```
-
-1. Define your query vector (typically from the same embedding model).
-2. Build the kNN query using the `KnnQuery` struct.
-3. Specify which vector field to search.
-4. Provide the query vector to find similar vectors.
-5. Return the top 10 nearest neighbors.
-6. Consider 100 candidates during the search for better accuracy.
-
-::::::
-
-::::::{tab-item} esdsl API
-:sync: esdsl
-
-The [`esdsl`](/reference/typed-api/esdsl.md) query builders provide a fluent syntax for kNN search:
+Once your vectors are indexed, you can perform k-nearest neighbors (kNN) search to find similar documents. The `esdsl` query builders provide a fluent syntax for kNN search:
 
 ```go
 queryVector := []float32{0.1, 0.2, 0.3, 0.4, 0.5} // <1>
@@ -270,13 +91,9 @@ res, err := es.Search().
 5. Return the top 10 nearest neighbors.
 6. Consider 100 candidates during the search for better accuracy.
 
-::::::
-
-:::::::
-
 ## Performance benefits [_performance_benefits]
 
-Using `types.DenseVectorF32` (typed API) provides significant performance improvements over standard JSON arrays of floats:
+Using `types.DenseVectorF32` provides significant performance improvements over standard JSON arrays of floats:
 
 - **Reduced payload size**: base64 encoding is more compact than JSON number arrays
 - **Faster parsing**: Eliminates JSON number parsing overhead

--- a/docs/reference/using-the-api/dense-vectors.md
+++ b/docs/reference/using-the-api/dense-vectors.md
@@ -58,7 +58,7 @@ document := Document{
 }
 
 res, err := es.Index("my-vectors").
-    Request(document).
+    Document(document).
     Do(context.Background())
 ```
 
@@ -118,7 +118,7 @@ document := Document{
 }
 
 res, err := es.Index("my-vectors").
-    Request(document).
+    Document(document).
     Do(context.Background())
 ```
 

--- a/docs/reference/using-the-api/esql.md
+++ b/docs/reference/using-the-api/esql.md
@@ -6,7 +6,7 @@ mapped_pages:
 
 # ES|QL in the Go client [esql]
 
-This page helps you understand and use [ES|QL](docs-content://explore-analyze/query-filter/languages/esql.md) in the Go client.
+This page helps you understand and use [ES|QL](docs-content://explore-analyze/query-filter/languages/esql.md) in the Go client with the [typed API](/reference/typed-api/index.md). For raw-JSON ES|QL queries, see the [low-level API](/reference/low-level-api/index.md).
 
 There are two ways to use ES|QL in the Go client:
 
@@ -18,41 +18,6 @@ There are two ways to use ES|QL in the Go client:
 The [ES|QL query API](https://www.elastic.co/docs/api/doc/elasticsearch/group/endpoint-esql) allows you to specify how results should be returned. You can choose a [response format](docs-content://explore-analyze/query-filter/languages/esql-rest.md#esql-rest-format) such as CSV, text, or JSON, then fine-tune it with parameters like column separators and locale.
 
 The following example gets ES|QL results as CSV and parses them:
-
-:::::::{tab-set}
-:group: APIs
-::::::{tab-item} Low-level API
-:sync: lowLevel
-
-```go
-queryBody := `{
-    "query": "from library | where author == \"Isaac Asimov\" | sort release_date desc | limit 10",
-    "format": "csv"
-}`
-
-res, err := client.Esql.Query( // <1>
-    strings.NewReader(queryBody), // <2>
-)
-if err != nil {
-    log.Fatal(err)
-}
-defer res.Body.Close()
-
-reader := csv.NewReader(res.Body) // <3>
-rows, err := reader.ReadAll()
-for _, row := range rows {
-    fmt.Println(row)
-}
-```
-
-1. Call the ES|QL query endpoint.
-2. Pass the query and format as a JSON body.
-3. Parse the CSV response directly from the response body.
-
-::::::
-
-::::::{tab-item} Fully-typed API
-:sync: typed
 
 ```go
 queryAuthor := `from library
@@ -78,10 +43,6 @@ for _, row := range rows {
 1. Create an ES|QL query request.
 2. Set the ES|QL query string.
 3. Request CSV format for the response.
-
-::::::
-
-:::::::
 
 ## Consume ES|QL results [esql-consume-results]
 

--- a/docs/reference/using-the-api/index.md
+++ b/docs/reference/using-the-api/index.md
@@ -4,129 +4,13 @@ navigation_title: "Using the API"
 
 # Using the API [using_the_api]
 
-The Go client for {{es}} offers two API styles, plus fluent DSL builders that enhance the typed API:
+The examples in this section use the [typed API](/reference/typed-api/index.md) together with the [`esdsl`](/reference/typed-api/esdsl.md) builders: the recommended way to use the Go client. The typed API gives you strongly typed request and response structs generated from the [elasticsearch-specification](https://github.com/elastic/elasticsearch-specification), and `esdsl` provides fluent, chainable builders for queries, aggregations, mappings, and sort options.
 
-- **Low-level API** — provides a one-to-one mapping with the {{es}} REST API. Each endpoint accepts and returns raw `io.Reader` bodies and `*esapi.Response` objects. This gives you full control over serialization and request construction.
-- **Fully-typed API** — provides a strongly typed, builder-pattern API generated from the [elasticsearch-specification](https://github.com/elastic/elasticsearch-specification). Requests and responses are modeled as Go structs, giving you compile-time safety and IDE autocompletion.
-- **[esdsl builders](/reference/typed-api/esdsl.md)** — a companion to the typed API that provides fluent, chainable builders for constructing queries, aggregations, mappings, and sort options. Instead of manually assembling nested structs, you use `esdsl.NewMatchQuery("title", "Go")` and pass it directly to the typed client.
+If you need raw-JSON control or an endpoint not yet covered by the typed API, see the [low-level API](/reference/low-level-api/index.md). The two APIs share the same transport, so you can mix them in the same application. See the [migration guide](/reference/low-level-api/migration.md) for how to adopt the typed API one endpoint at a time.
 
-All three approaches share the same underlying transport and [configuration](../configuration.md). You can mix and match them in the same application.
+## Example [_typed_example]
 
-## Comparing API styles [_comparing_api_styles]
-
-|                        | Low-level API                                   | Fully-typed API                                  | esdsl API                                                     |
-| ---------------------- | ----------------------------------------------- | ------------------------------------------------ | ------------------------------------------------------------- |
-| **Type safety**        | Runtime (raw JSON)                              | Compile-time (Go structs)                        | Compile-time (fluent builders)                                |
-| **IDE autocompletion** | Limited                                         | Full support for fields, enums, and methods      | Full support with guided method chains                        |
-| **Serialization**      | Manual (`io.Reader`, `json.Marshal`)            | Automatic (structs marshaled by the client)      | Automatic (builders produce typed structs)                    |
-| **Response handling**  | Raw `*esapi.Response` with `io.ReadCloser` body | Typed response structs                           | Typed response structs (same as fully-typed)                  |
-| **Flexibility**        | Full control over request/response bytes        | Constrained to the specification model           | Constrained to the specification model                        |
-| **Code verbosity**     | Lower for simple requests                       | Lower for complex queries with nested structures | Lowest for complex queries - minimal nesting, fluent chaining |
-
-::::{important}
-When using the low-level API, you **must** always read and close the response body, even if your code does not use it. Failing to do so prevents Go's HTTP client from reusing the underlying TCP connection, which degrades performance and can cause resource leaks.
-
-```go
-res, err := client.Search(
-    client.Search.WithIndex("my-index"),
-    client.Search.WithBody(strings.NewReader(query)),
-)
-if err != nil {
-    log.Fatal(err)
-}
-defer res.Body.Close()
-```
-
-The fully-typed API handles this automatically. Each endpoint's `Do()` method reads and closes the response body internally, so you only work with typed response structs.
-::::
-
-## When to use which [_when_to_use_which]
-
-**Choose the low-level API when:**
-
-- You need full control over request serialization (e.g., custom JSON encoders)
-- You are working with endpoints not yet covered by the typed API
-- You prefer working with raw JSON bytes
-
-**Choose the typed API with structs when:**
-
-- You want compile-time safety and IDE autocompletion
-- You are working with simple, flat request structures
-- You want typed response objects instead of parsing JSON manually
-
-**Choose the typed API with esdsl builders when:**
-
-- You are building complex queries with deeply nested structures (bool queries, compound filters)
-- You are composing aggregations with sub-aggregations
-- You want the most concise code with fluent method chaining
-- You are constructing queries dynamically at runtime
-
-::::{tip}
-You don't have to choose one exclusively. All three approaches share the same transport, so you can use `esdsl` builders for queries, typed structs for simple operations, and fall back to the low-level API for edge cases - all in the same application.
-::::
-
-## Side-by-side example [_side_by_side_example]
-
-Here is the same search operation using all three approaches:
-
-:::::::{tab-set}
-:group: APIs
-::::::{tab-item} Low-level API
-:sync: lowLevel
-
-```go
-res, err := es.Search(
-    es.Search.WithIndex("my-index"),
-    es.Search.WithBody(strings.NewReader(`{
-        "query": {
-            "match": {
-                "title": "golang"
-            }
-        }
-    }`)),
-)
-if err != nil {
-    log.Fatal(err)
-}
-defer res.Body.Close()
-
-// Parse the response body manually
-var result map[string]any
-json.NewDecoder(res.Body).Decode(&result)
-```
-
-::::::
-
-::::::{tab-item} Fully-typed API
-:sync: typed
-
-```go
-res, err := es.Search().
-    Index("my-index").
-    Request(&search.Request{
-        Query: &types.Query{
-            Match: map[string]types.MatchQuery{
-                "title": {Query: "golang"},
-            },
-        },
-    }).
-    Do(context.Background())
-if err != nil {
-    log.Fatal(err)
-}
-
-// Response is already typed
-for _, hit := range res.Hits.Hits {
-    fmt.Println(hit.Source_)
-}
-```
-
-::::::
-
-::::::{tab-item} esdsl API
-:sync: esdsl
-
-The [`esdsl`](/reference/typed-api/esdsl.md) package provides fluent builders that plug directly into the typed API:
+The same search operation, expressed with the typed API and `esdsl`:
 
 ```go subs=true
 import "github.com/elastic/go-elasticsearch/v{{ version.elasticsearch-client-go | M }}/typedapi/esdsl"
@@ -141,23 +25,19 @@ if err != nil {
     log.Fatal(err)
 }
 
-// Response is already typed
-for _, hit := range res.Hits.Hits {
+for _, hit := range res.Hits.Hits { // <2>
     fmt.Println(hit.Source_)
 }
 ```
 
-1. The `esdsl` builder replaces the struct-based query construction with a fluent, chainable syntax.
-
-::::::
-
-:::::::
+1. `esdsl` builders produce typed query structs with a fluent, chainable syntax. No deeply nested struct literals.
+2. The response is already typed and decoded. No `io.Reader` to parse, no `defer res.Body.Close()`.
 
 ## What's covered in this section [_using_api_contents]
 
-- [CRUD operations](crud-operations.md) — Index, get, update, and delete documents
-- [Searching](searching.md) — Build and run search queries
-- [Aggregations](aggregations.md) — Run aggregations on your data
-- [Bulk indexing](bulk-indexing.md) — Efficiently ingest large volumes of documents
-- [ES|QL](esql.md) — Use the Elasticsearch Query Language
-- [Dense vectors and kNN search](dense-vectors.md) — Work with vector embeddings and similarity search
+- [CRUD operations](crud-operations.md): index, get, update, and delete documents
+- [Searching](searching.md): build and run search queries
+- [Aggregations](aggregations.md): run aggregations on your data
+- [Bulk indexing](bulk-indexing.md): efficiently ingest large volumes of documents
+- [ES|QL](esql.md): use the Elasticsearch Query Language
+- [Dense vectors and kNN search](dense-vectors.md): work with vector embeddings and similarity search

--- a/docs/reference/using-the-api/searching.md
+++ b/docs/reference/using-the-api/searching.md
@@ -6,63 +6,25 @@ mapped_pages:
 
 # Searching [search]
 
-This page covers how to build and run search queries with the Go client. For the full {{es}} search API reference, see the [Search API documentation](https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-search).
+This page covers how to build and run search queries with the Go client using the [typed API](/reference/typed-api/index.md) and the [`esdsl`](/reference/typed-api/esdsl.md) builders. For the full {{es}} search API reference, see the [Search API documentation](https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-search). For raw-JSON searches, see the [low-level API](/reference/low-level-api/index.md).
+
+```go subs=true
+import "github.com/elastic/go-elasticsearch/v{{ version.elasticsearch-client-go | M }}/typedapi/esdsl"
+```
 
 ## Running a search [_running_a_search]
 
-As an example, let's search for a document with a field `name` with a value of `Foo` in the index named `index_name`.
-
-:::::::{tab-set}
-:group: APIs
-::::::{tab-item} Low-level API
-:sync: lowLevel
-
-```go
-query := `{
-  "query": {
-    "match": {
-      "name": { "query": "Foo" }
-    }
-  }
-}`
-
-res, err := client.Search(
-    client.Search.WithIndex("index_name"),       // <1>
-    client.Search.WithBody(strings.NewReader(query)), // <2>
-)
-if err != nil {
-    log.Fatal(err)
-}
-defer res.Body.Close() // <3>
-```
-
-1. The targeted index for this search.
-2. Pass the JSON query body as an `io.Reader`.
-3. Always close the response body when done.
-
-::::::
-
-::::::{tab-item} Fully-typed API
-:sync: typed
-
-With a struct request:
+As an example, let's search for a document with a field `name` with a value of `Foo` in the index named `index_name`. The `esdsl` query builders provide a concise, fluent syntax:
 
 ```go
 res, err := es.Search().
     Index("index_name"). // <1>
-    Request(&search.Request{ // <2>
-        Query: &types.Query{
-            Match: map[string]types.MatchQuery{
-                "name": {Query: "Foo"}, // <3>
-            },
-        },
-    }).Do(context.Background()) // <4>
+    Query(esdsl.NewMatchQuery("name", "Foo")). // <2>
+    Do(context.Background())
 ```
 
 1. The targeted index for this search.
-2. The request part of the search.
-3. Match query specifies that `name` should match `Foo`.
-4. The query is run with a `context.Background` and returns the typed response.
+2. `NewMatchQuery` takes the field name and query text directly; no struct nesting required.
 
 It produces the following JSON:
 
@@ -78,44 +40,23 @@ It produces the following JSON:
 }
 ```
 
-::::::
+## Request structures [_request_structures]
 
-::::::{tab-item} esdsl API
-:sync: esdsl
-
-The [`esdsl`](/reference/typed-api/esdsl.md) query builders provide a concise, fluent syntax:
-
-```go subs=true
-import "github.com/elastic/go-elasticsearch/v{{ version.elasticsearch-client-go | M }}/typedapi/esdsl"
-```
+If you prefer working with typed structs directly, you can pass a `search.Request` to `Request`:
 
 ```go
 res, err := es.Search().
-    Index("index_name"). // <1>
-    Query(esdsl.NewMatchQuery("name", "Foo")). // <2>
-    Do(context.Background())
-```
-
-1. The targeted index for this search.
-2. `NewMatchQuery` takes the field name and query text directly - no struct nesting required.
-
-::::::
-
-:::::::
-
-## Request structures [_request_structures]
-
-The typed API models each endpoint's body as a Go `Request` struct. For example, a simple term query for `"Foo"` in the `name` field:
-
-```go
-search.Request{
-    Query: &types.Query{
-        Term: map[string]types.TermQuery{
-            "name": {Value: "Foo"},
+    Index("index_name").
+    Request(&search.Request{
+        Query: &types.Query{
+            Term: map[string]types.TermQuery{
+                "name": {Value: "Foo"},
+            },
         },
-    },
-}
+    }).Do(context.Background())
 ```
+
+The `esdsl` builders and struct-based requests produce identical payloads; mix and match based on how complex the query is.
 
 ## Paginating results [_paginating_results]
 
@@ -209,37 +150,7 @@ The older `scroll` API still works but is no longer the recommended approach for
 
 ## Raw JSON [_raw_json]
 
-If you want to use your own pre-baked JSON queries using templates or a specific encoder, you can pass the body directly. Both API styles support raw JSON payloads:
-
-:::::::{tab-set}
-:group: APIs
-::::::{tab-item} Low-level API
-:sync: lowLevel
-
-```go
-res, err := client.Search(
-    client.Search.WithIndex("index_name"),
-    client.Search.WithBody(strings.NewReader(`{
-      "query": {
-        "term": {
-          "user.id": {
-            "value": "kimchy",
-            "boost": 1.0
-          }
-        }
-      }
-    }`)),
-)
-if err != nil {
-    log.Fatal(err)
-}
-defer res.Body.Close()
-```
-
-::::::
-
-::::::{tab-item} Fully-typed API
-:sync: typed
+If you want to use your own pre-baked JSON queries using templates or a specific encoder, you can pass the body directly with `Raw`:
 
 ```go
 res, err := es.Search().
@@ -257,7 +168,3 @@ res, err := es.Search().
 ```
 
 No further validation or serialization is done on what is sent through this method. Setting a payload with `Raw` takes precedence over any request structure you may submit before running the query.
-
-::::::
-
-:::::::


### PR DESCRIPTION
## Summary

The reference docs currently present three API styles (`esapi`, `typedapi`, `esdsl`) with near-equal weight on most how-to pages (crud, search, aggregations, dense-vectors, ...) and each page shows three parallel tabs for the same operation. That creates choice paralysis for users who are just trying to figure out how to call Elasticsearch from Go.

This PR refocuses `docs/reference` on the recommended path: `TypedClient` + `esdsl`. The low-level API gets its own dedicated section with a single reference page and a migration guide.

### What changed

- **How-to pages now show only the typed API + esdsl.** The low-level tabs are removed from `getting-started.md`, `using-the-api/{crud-operations,searching,aggregations,bulk-indexing,esql,dense-vectors}.md`.
- **New `low-level-api/` section** with two pages:
  - [`low-level-api/index.md`](https://github.com/elastic/go-elasticsearch/blob/claude/interesting-yalow-c351e0/docs/reference/low-level-api/index.md) — single focused esapi reference: when to use it, `elasticsearch.New(...)` constructor, response handling, condensed CRUD / search / bulk walkthrough, pointer to pkg.go.dev for the full endpoint list.
  - [`low-level-api/migration.md`](https://github.com/elastic/go-elasticsearch/blob/claude/interesting-yalow-c351e0/docs/reference/low-level-api/migration.md) — esapi -> typedapi migration guide, covering full migration, partial migration, and the endpoint-coverage caveat.
- **Partial migration pattern documented.** `*elasticsearch.Client` embeds `BaseClient`, which implements `Perform(*http.Request)`, so it satisfies `elastictransport.Interface`. That means any `typedapi/<namespace>/<endpoint>.New(tp)` package can be used against an existing low-level client. Users can migrate one endpoint at a time without a full rewrite or a second client. Example in the migration doc.
- **Advanced pages (`interceptors.md`, `observability.md`) now lead with `NewTyped`** instead of `elasticsearch.New`. Interceptors and instrumentation are transport-level and work identically with either client; the docs now say so and use the typed client consistently.
- **Top-level pages (`index.md`, `getting-started.md`, `connecting.md`, `installation.md`, `typed-api/index.md`) reworded** so the typed-first story is clear and consistent.
- **TOC updated** to add the new `low-level-api/` section between `typed-api/` and `advanced/`.

Net diff: +607 / -1285. Fewer parallel examples, smaller surface area to keep in sync.

### Non-goals / out of scope

- No source-code changes. Scope is strictly `docs/reference/` plus `toc.yml`.
- No changes to `_examples/`, `README.md`, or CHANGELOG. The empty `_examples/interceptor/` directory and any `_examples/*` alignment can be done as a follow-up PR.
- No new typed-api features or generator changes.
- Deprecated `NewClient(Config)` / `NewTypedClient(Config)` constructors are already documented as deprecated in code; this PR does not add/remove that layer. The migration doc shows both the deprecated `Config` form and the modern functional-options form as "before" examples so readers from both eras can follow along.

### Verification

- `make lint` passes.
- No deprecated constructors in examples: `grep -rnE "elasticsearch\.(NewClient|NewTypedClient|NewDefaultClient|NewBaseClient)\b" docs/reference/` returns empty (the only references are in `migration.md` as labeled "before" examples).
- All files listed in `toc.yml` exist on disk.
- Markdown link targets within `docs/reference/` all resolve.
- Partial-migration technical claim verified against the source:
  - `elastictransport.Interface` requires only `Perform(*http.Request) (*http.Response, error)` (elastic-transport-go).
  - `BaseClient.Perform` is defined at [`elasticsearch.go:513`](https://github.com/elastic/go-elasticsearch/blob/claude/interesting-yalow-c351e0/elasticsearch.go#L513).
  - `typedapi/core/search.New(tp elastictransport.Interface)` signature at [`typedapi/core/search/search.go:143`](https://github.com/elastic/go-elasticsearch/blob/claude/interesting-yalow-c351e0/typedapi/core/search/search.go#L143).

### Test plan

- [ ] CI `docs-build` job (uses `elastic/docs-actions`) passes, including Vale linting.
- [ ] Docs preview renders the new `low-level-api/` section in the sidebar in the correct position.
- [ ] Partial-migration code snippet in `migration.md` compiles (copy into a scratch `main.go` and `go build`).
- [ ] Spot-check that no prior reader landing on a bookmarked old anchor (e.g., `_using_the_api`) gets a broken page; `mapped_pages:` frontmatter is preserved on all existing pages.
