### PR TITLE
fix(esutil): use math/rand for FlushJitter so 8.19 (Go 1.21) builds

### DIFF
--- a/esutil/bulk_indexer.go
+++ b/esutil/bulk_indexer.go
@@ -24,7 +24,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"math/rand/v2"
+	"math/rand"
 	"net/http"
 	"runtime"
 	"strconv"
@@ -523,12 +523,12 @@ func (bi *bulkIndexer) init() {
 
 // nextFlushInterval returns FlushInterval plus a random jitter in
 // [0, FlushJitter) when FlushJitter > 0. Callers are independent worker
-// goroutines; math/rand/v2's top-level functions are goroutine-safe.
+// goroutines; math/rand's top-level functions are goroutine-safe.
 func (bi *bulkIndexer) nextFlushInterval() time.Duration {
 	if bi.config.FlushJitter <= 0 {
 		return bi.config.FlushInterval
 	}
-	return bi.config.FlushInterval + rand.N(bi.config.FlushJitter) //nolint:gosec // G404: non-crypto randomness is intentional for flush-interval jitter
+	return bi.config.FlushInterval + time.Duration(rand.Int63n(int64(bi.config.FlushJitter))) //nolint:gosec // G404: non-crypto randomness is intentional for flush-interval jitter
 }
 
 // worker represents an indexer worker.


### PR DESCRIPTION
## Summary

[#1386](https://github.com/elastic/go-elasticsearch/pull/1386) introduced `BulkIndexerConfig.FlushJitter` using `math/rand/v2` and `rand.N`. Both require Go 1.22+, but the 8.19 branch still targets Go 1.21, so the backport fails to build there:

```
esutil/bulk_indexer.go:528:40: rand.N requires go1.22 or later (module is go1.21)
```

This switches the single call site to `math/rand` v1, which works on every supported Go version.

## Why `math/rand` v1 is safe here

- `rand.Int63n` has existed since Go 1.0.
- Top-level `math/rand` functions are goroutine-safe (package-level lock).
- Since Go 1.20, the global source is automatically seeded per process, so no `rand.Seed` call is needed.
- The jitter is non-cryptographic by design; v1 randomness quality is more than sufficient.

Keeping everything on `math/rand` v1 means we can cherry-pick the feature to 8.19 without a per-branch patch.

## Test plan

- [x] `make lint`
- [x] `go test -run 'TestBulkIndexerNextFlushInterval|TestBulkIndexerFlushJitter' ./esutil/...` — green
- [x] Builds cleanly on Go 1.21 (verified by construction: only uses APIs present since Go 1.0).
- [ ] Backports to 9.4 / 9.3 / 9.2 / 8.19 land cleanly (I'll handle backports).
