### PR TITLE
feat(client): add (*Client).ToTyped() conversion method

### DIFF
--- a/elasticsearch.go
+++ b/elasticsearch.go
@@ -58,9 +58,6 @@ const (
 
 	compatibilityHeader = "application/vnd.elasticsearch+json;compatible-with=9"
 
-	// typedClientMetaFlag is the client-meta fragment appended to requests
-	// that go through the TypedClient, marking high-level API usage for
-	// telemetry attribution.
 	typedClientMetaFlag = "hl=1"
 )
 
@@ -396,15 +393,11 @@ func NewTyped(opts ...Option) (*TypedClient, error) {
 }
 
 // ToTyped returns a [TypedClient] that shares the underlying transport,
-// connection pool, and configuration of this [Client]. The returned client
-// records typed-API usage in its client-meta telemetry header ("hl=1"),
-// so requests issued through it are attributed correctly.
+// connection pool, and configuration of this [Client].
 //
-// ToTyped is intended to be called once per [Client] and the result reused.
-// Calling it in a hot path (for example, on every request) allocates a new
-// [typedapi.MethodAPI] tree and re-runs the product check on first use,
-// neither of which is free. Cache the returned *TypedClient alongside the
-// original *Client.
+// ToTyped is intended to be called once per [Client] and the result
+// reused. Each call allocates a new [typedapi.MethodAPI] tree, and the
+// returned client will re-run the product check on its first request.
 //
 // Because the transport is shared, closing either client closes the
 // connection pool used by both.

--- a/elasticsearch.go
+++ b/elasticsearch.go
@@ -390,6 +390,38 @@ func NewTyped(opts ...Option) (*TypedClient, error) {
 	return client, nil
 }
 
+// ToTyped returns a [TypedClient] that shares the underlying transport,
+// connection pool, and configuration of this [Client]. The returned client
+// records typed-API usage in its client-meta telemetry header ("hl=1"),
+// so requests issued through it are attributed correctly.
+//
+// ToTyped is intended to be called once per [Client] and the result reused.
+// Calling it in a hot path (for example, on every request) allocates a new
+// [typedapi.MethodAPI] tree and re-runs the product check on first use,
+// neither of which is free. Cache the returned *TypedClient alongside the
+// original *Client.
+//
+// Because the transport is shared, closing either client closes the
+// connection pool used by both.
+func (c *Client) ToTyped() *TypedClient {
+	metaHeader := c.metaHeader
+	if !strings.Contains(metaHeader, "hl=1") {
+		metaHeader = strings.Join([]string{metaHeader, "hl=1"}, ",")
+	}
+
+	tc := &TypedClient{
+		BaseClient: BaseClient{
+			Transport:           c.Transport,
+			disableMetaHeader:   c.disableMetaHeader,
+			metaHeader:          metaHeader,
+			compatibilityHeader: c.compatibilityHeader,
+			autoDrainBody:       c.autoDrainBody,
+		},
+	}
+	tc.MethodAPI = typedapi.NewMethodAPI(tc)
+	return tc
+}
+
 func newTransport(cfg Config) (*elastictransport.Client, error) {
 	var addrs []string
 

--- a/elasticsearch.go
+++ b/elasticsearch.go
@@ -57,6 +57,11 @@ const (
 	HeaderClientMeta = "x-elastic-client-meta"
 
 	compatibilityHeader = "application/vnd.elasticsearch+json;compatible-with=9"
+
+	// typedClientMetaFlag is the client-meta fragment appended to requests
+	// that go through the TypedClient, marking high-level API usage for
+	// telemetry attribution.
+	typedClientMetaFlag = "hl=1"
 )
 
 var (
@@ -281,7 +286,7 @@ func NewTypedClient(cfg Config) (*TypedClient, error) {
 	compatHeaderEnv := os.Getenv(esCompatHeader)
 	compatibilityHeader, _ := strconv.ParseBool(compatHeaderEnv)
 
-	metaHeader := strings.Join([]string{initMetaHeader(tp), "hl=1"}, ",")
+	metaHeader := strings.Join([]string{initMetaHeader(tp), typedClientMetaFlag}, ",")
 
 	client := &TypedClient{
 		BaseClient: BaseClient{
@@ -370,7 +375,7 @@ func NewBase(opts ...Option) (*BaseClient, error) {
 //	    elasticsearch.WithAPIKey("base64-encoded-key"),
 //	)
 func NewTyped(opts ...Option) (*TypedClient, error) {
-	ro, err := resolveOptions(opts, "hl=1")
+	ro, err := resolveOptions(opts, typedClientMetaFlag)
 	if err != nil {
 		return nil, err
 	}
@@ -405,8 +410,8 @@ func NewTyped(opts ...Option) (*TypedClient, error) {
 // connection pool used by both.
 func (c *Client) ToTyped() *TypedClient {
 	metaHeader := c.metaHeader
-	if !strings.Contains(metaHeader, "hl=1") {
-		metaHeader = strings.Join([]string{metaHeader, "hl=1"}, ",")
+	if !strings.Contains(metaHeader, typedClientMetaFlag) {
+		metaHeader = strings.Join([]string{metaHeader, typedClientMetaFlag}, ",")
 	}
 
 	tc := &TypedClient{

--- a/elasticsearch_internal_test.go
+++ b/elasticsearch_internal_test.go
@@ -916,146 +916,136 @@ func TestNewTypedClient(t *testing.T) {
 	}
 }
 
-func TestToTyped(t *testing.T) {
-	newMockTransport := func(capture *http.Header) (elastictransport.Interface, error) {
-		return elastictransport.New(elastictransport.Config{
-			URLs: []*url.URL{{Scheme: "http", Host: "foo"}},
-			Transport: &mockTransp{
-				RoundTripFunc: func(req *http.Request) (*http.Response, error) {
-					if capture != nil {
-						*capture = req.Header.Clone()
-					}
-					return &http.Response{
-						Header:     http.Header{"X-Elastic-Product": []string{"Elasticsearch"}},
-						StatusCode: http.StatusOK,
-						Status:     "OK",
-						Body: io.NopCloser(strings.NewReader(`{
-							"version":{"number":"8.0.0-SNAPSHOT","build_flavor":"default"},
-							"tagline":"You Know, for Search"
-						}`)),
-					}, nil
-				},
+func toTypedMockTransport(t *testing.T, capture *http.Header) elastictransport.Interface {
+	t.Helper()
+	tp, err := elastictransport.NewClient(
+		elastictransport.WithURLs(&url.URL{Scheme: "http", Host: "foo"}),
+		elastictransport.WithTransport(&mockTransp{
+			RoundTripFunc: func(req *http.Request) (*http.Response, error) {
+				if capture != nil {
+					*capture = req.Header.Clone()
+				}
+				return &http.Response{
+					Header:     http.Header{"X-Elastic-Product": []string{"Elasticsearch"}},
+					StatusCode: http.StatusOK,
+					Status:     "OK",
+					Body: io.NopCloser(strings.NewReader(`{
+						"version":{"number":"8.0.0-SNAPSHOT","build_flavor":"default"},
+						"tagline":"You Know, for Search"
+					}`)),
+				}, nil
 			},
-		})
+		}),
+	)
+	if err != nil {
+		t.Fatalf("unexpected error: %s", err)
+	}
+	return tp
+}
+
+func TestToTyped_AddsTypedFlag(t *testing.T) {
+	var captured http.Header
+	c, err := New()
+	if err != nil {
+		t.Fatalf("unexpected error: %s", err)
+	}
+	c.Transport = toTypedMockTransport(t, &captured)
+
+	tc := c.ToTyped()
+	if _, err := tc.Info().Do(context.Background()); err != nil {
+		t.Fatalf("unexpected error: %s", err)
 	}
 
-	t.Run("adds hl=1 to meta header", func(t *testing.T) {
-		var captured http.Header
-		tp, err := newMockTransport(&captured)
-		if err != nil {
-			t.Fatalf("unexpected error: %s", err)
-		}
+	h := captured.Get(HeaderClientMeta)
+	if !metaHeaderReValidation.MatchString(h) {
+		t.Errorf("expected meta header to match regexp, got: %s", h)
+	}
+	if !strings.Contains(h, "hl=1") {
+		t.Errorf("expected meta header to contain hl=1, got: %s", h)
+	}
+}
 
-		c, err := New()
-		if err != nil {
-			t.Fatalf("unexpected error: %s", err)
-		}
-		c.Transport = tp
+func TestToTyped_SharesTransport(t *testing.T) {
+	c, err := New()
+	if err != nil {
+		t.Fatalf("unexpected error: %s", err)
+	}
+	tc := c.ToTyped()
+	if tc.Transport != c.Transport {
+		t.Errorf("expected converted client to share the source transport")
+	}
+}
 
-		tc := c.ToTyped()
-		if _, err := tc.Info().Do(context.Background()); err != nil {
-			t.Fatalf("unexpected error: %s", err)
-		}
+func TestToTyped_PreservesConfigFlags(t *testing.T) {
+	c, err := New(WithCompatibilityMode(), WithAutoDrainBody())
+	if err != nil {
+		t.Fatalf("unexpected error: %s", err)
+	}
+	tc := c.ToTyped()
+	if !tc.compatibilityHeader {
+		t.Errorf("expected compatibilityHeader to be carried over")
+	}
+	if !tc.autoDrainBody {
+		t.Errorf("expected autoDrainBody to be carried over")
+	}
+	if tc.disableMetaHeader {
+		t.Errorf("expected disableMetaHeader to remain false")
+	}
+}
 
-		h := captured.Get(HeaderClientMeta)
-		if !metaHeaderReValidation.MatchString(h) {
-			t.Errorf("expected meta header to match regexp, got: %s", h)
-		}
-		if !strings.Contains(h, "hl=1") {
-			t.Errorf("expected meta header to contain hl=1, got: %s", h)
-		}
-	})
+func TestToTyped_PreservesDisableMetaHeader(t *testing.T) {
+	var captured http.Header
+	c, err := New(WithDisableMetaHeader())
+	if err != nil {
+		t.Fatalf("unexpected error: %s", err)
+	}
+	c.Transport = toTypedMockTransport(t, &captured)
 
-	t.Run("shares transport with source client", func(t *testing.T) {
-		c, err := New()
-		if err != nil {
-			t.Fatalf("unexpected error: %s", err)
-		}
-		tc := c.ToTyped()
-		if tc.Transport != c.Transport {
-			t.Errorf("expected converted client to share the source transport")
-		}
-	})
+	tc := c.ToTyped()
+	if !tc.disableMetaHeader {
+		t.Errorf("expected disableMetaHeader to be carried over")
+	}
 
-	t.Run("preserves configuration flags", func(t *testing.T) {
-		c, err := New(
-			WithCompatibilityMode(),
-			WithAutoDrainBody(),
-		)
-		if err != nil {
-			t.Fatalf("unexpected error: %s", err)
-		}
-		tc := c.ToTyped()
-		if !tc.compatibilityHeader {
-			t.Errorf("expected compatibilityHeader to be carried over")
-		}
-		if !tc.autoDrainBody {
-			t.Errorf("expected autoDrainBody to be carried over")
-		}
-		if tc.disableMetaHeader {
-			t.Errorf("expected disableMetaHeader to remain false")
-		}
-	})
+	if _, err := tc.Info().Do(context.Background()); err != nil {
+		t.Fatalf("unexpected error: %s", err)
+	}
+	if h := captured.Get(HeaderClientMeta); h != "" {
+		t.Errorf("expected no meta header when disabled, got: %s", h)
+	}
+}
 
-	t.Run("preserves disableMetaHeader", func(t *testing.T) {
-		var captured http.Header
-		tp, err := newMockTransport(&captured)
-		if err != nil {
-			t.Fatalf("unexpected error: %s", err)
-		}
+func TestToTyped_IdempotentFlag(t *testing.T) {
+	c, err := New()
+	if err != nil {
+		t.Fatalf("unexpected error: %s", err)
+	}
+	first := c.ToTyped()
+	if strings.Count(first.metaHeader, "hl=1") != 1 {
+		t.Errorf("expected exactly one hl=1, got: %s", first.metaHeader)
+	}
 
-		c, err := New(WithDisableMetaHeader())
-		if err != nil {
-			t.Fatalf("unexpected error: %s", err)
-		}
-		c.Transport = tp
+	// Simulate a Client whose metaHeader already contains hl=1: the
+	// conversion must not append a second occurrence.
+	c.metaHeader = first.metaHeader
+	second := c.ToTyped()
+	if strings.Count(second.metaHeader, "hl=1") != 1 {
+		t.Errorf("expected exactly one hl=1, got: %s", second.metaHeader)
+	}
+}
 
-		tc := c.ToTyped()
-		if !tc.disableMetaHeader {
-			t.Errorf("expected disableMetaHeader to be carried over")
-		}
-
-		if _, err := tc.Info().Do(context.Background()); err != nil {
-			t.Fatalf("unexpected error: %s", err)
-		}
-		if h := captured.Get(HeaderClientMeta); h != "" {
-			t.Errorf("expected no meta header when disabled, got: %s", h)
-		}
-	})
-
-	t.Run("hl=1 is not duplicated", func(t *testing.T) {
-		c, err := New()
-		if err != nil {
-			t.Fatalf("unexpected error: %s", err)
-		}
-		first := c.ToTyped()
-		if strings.Count(first.metaHeader, "hl=1") != 1 {
-			t.Errorf("expected exactly one hl=1, got: %s", first.metaHeader)
-		}
-
-		// Simulate a Client whose metaHeader already contains hl=1: the
-		// conversion must not append a second occurrence.
-		c.metaHeader = first.metaHeader
-		second := c.ToTyped()
-		if strings.Count(second.metaHeader, "hl=1") != 1 {
-			t.Errorf("expected exactly one hl=1, got: %s", second.metaHeader)
-		}
-	})
-
-	t.Run("source client meta header is not mutated", func(t *testing.T) {
-		c, err := New()
-		if err != nil {
-			t.Fatalf("unexpected error: %s", err)
-		}
-		before := c.metaHeader
-		_ = c.ToTyped()
-		if c.metaHeader != before {
-			t.Errorf("source metaHeader mutated: before=%q after=%q", before, c.metaHeader)
-		}
-		if strings.Contains(c.metaHeader, "hl=1") {
-			t.Errorf("source Client metaHeader should not contain hl=1, got: %s", c.metaHeader)
-		}
-	})
+func TestToTyped_SourceNotMutated(t *testing.T) {
+	c, err := New()
+	if err != nil {
+		t.Fatalf("unexpected error: %s", err)
+	}
+	before := c.metaHeader
+	_ = c.ToTyped()
+	if c.metaHeader != before {
+		t.Errorf("source metaHeader mutated: before=%q after=%q", before, c.metaHeader)
+	}
+	if strings.Contains(c.metaHeader, "hl=1") {
+		t.Errorf("source Client metaHeader should not contain hl=1, got: %s", c.metaHeader)
+	}
 }
 
 func TestContentTypeOverride(t *testing.T) {

--- a/elasticsearch_internal_test.go
+++ b/elasticsearch_internal_test.go
@@ -916,6 +916,148 @@ func TestNewTypedClient(t *testing.T) {
 	}
 }
 
+func TestToTyped(t *testing.T) {
+	newMockTransport := func(capture *http.Header) (elastictransport.Interface, error) {
+		return elastictransport.New(elastictransport.Config{
+			URLs: []*url.URL{{Scheme: "http", Host: "foo"}},
+			Transport: &mockTransp{
+				RoundTripFunc: func(req *http.Request) (*http.Response, error) {
+					if capture != nil {
+						*capture = req.Header.Clone()
+					}
+					return &http.Response{
+						Header:     http.Header{"X-Elastic-Product": []string{"Elasticsearch"}},
+						StatusCode: http.StatusOK,
+						Status:     "OK",
+						Body: io.NopCloser(strings.NewReader(`{
+							"version":{"number":"8.0.0-SNAPSHOT","build_flavor":"default"},
+							"tagline":"You Know, for Search"
+						}`)),
+					}, nil
+				},
+			},
+		})
+	}
+
+	t.Run("adds hl=1 to meta header", func(t *testing.T) {
+		var captured http.Header
+		tp, err := newMockTransport(&captured)
+		if err != nil {
+			t.Fatalf("unexpected error: %s", err)
+		}
+
+		c, err := New()
+		if err != nil {
+			t.Fatalf("unexpected error: %s", err)
+		}
+		c.Transport = tp
+
+		tc := c.ToTyped()
+		if _, err := tc.Info().Do(context.Background()); err != nil {
+			t.Fatalf("unexpected error: %s", err)
+		}
+
+		h := captured.Get(HeaderClientMeta)
+		if !metaHeaderReValidation.MatchString(h) {
+			t.Errorf("expected meta header to match regexp, got: %s", h)
+		}
+		if !strings.Contains(h, "hl=1") {
+			t.Errorf("expected meta header to contain hl=1, got: %s", h)
+		}
+	})
+
+	t.Run("shares transport with source client", func(t *testing.T) {
+		c, err := New()
+		if err != nil {
+			t.Fatalf("unexpected error: %s", err)
+		}
+		tc := c.ToTyped()
+		if tc.Transport != c.Transport {
+			t.Errorf("expected converted client to share the source transport")
+		}
+	})
+
+	t.Run("preserves configuration flags", func(t *testing.T) {
+		c, err := New(
+			WithCompatibilityMode(),
+			WithAutoDrainBody(),
+		)
+		if err != nil {
+			t.Fatalf("unexpected error: %s", err)
+		}
+		tc := c.ToTyped()
+		if !tc.compatibilityHeader {
+			t.Errorf("expected compatibilityHeader to be carried over")
+		}
+		if !tc.autoDrainBody {
+			t.Errorf("expected autoDrainBody to be carried over")
+		}
+		if tc.disableMetaHeader {
+			t.Errorf("expected disableMetaHeader to remain false")
+		}
+	})
+
+	t.Run("preserves disableMetaHeader", func(t *testing.T) {
+		var captured http.Header
+		tp, err := newMockTransport(&captured)
+		if err != nil {
+			t.Fatalf("unexpected error: %s", err)
+		}
+
+		c, err := New(WithDisableMetaHeader())
+		if err != nil {
+			t.Fatalf("unexpected error: %s", err)
+		}
+		c.Transport = tp
+
+		tc := c.ToTyped()
+		if !tc.disableMetaHeader {
+			t.Errorf("expected disableMetaHeader to be carried over")
+		}
+
+		if _, err := tc.Info().Do(context.Background()); err != nil {
+			t.Fatalf("unexpected error: %s", err)
+		}
+		if h := captured.Get(HeaderClientMeta); h != "" {
+			t.Errorf("expected no meta header when disabled, got: %s", h)
+		}
+	})
+
+	t.Run("hl=1 is not duplicated", func(t *testing.T) {
+		c, err := New()
+		if err != nil {
+			t.Fatalf("unexpected error: %s", err)
+		}
+		first := c.ToTyped()
+		if strings.Count(first.metaHeader, "hl=1") != 1 {
+			t.Errorf("expected exactly one hl=1, got: %s", first.metaHeader)
+		}
+
+		// Simulate a Client whose metaHeader already contains hl=1: the
+		// conversion must not append a second occurrence.
+		c.metaHeader = first.metaHeader
+		second := c.ToTyped()
+		if strings.Count(second.metaHeader, "hl=1") != 1 {
+			t.Errorf("expected exactly one hl=1, got: %s", second.metaHeader)
+		}
+	})
+
+	t.Run("source client meta header is not mutated", func(t *testing.T) {
+		c, err := New()
+		if err != nil {
+			t.Fatalf("unexpected error: %s", err)
+		}
+		before := c.metaHeader
+		_ = c.ToTyped()
+		if c.metaHeader != before {
+			t.Errorf("source metaHeader mutated: before=%q after=%q", before, c.metaHeader)
+		}
+		if strings.Contains(c.metaHeader, "hl=1") {
+			t.Errorf("source Client metaHeader should not contain hl=1, got: %s", c.metaHeader)
+		}
+	})
+}
+
 func TestContentTypeOverride(t *testing.T) {
 	t.Run("default JSON Content-Type", func(t *testing.T) {
 		contentType := "application/json"


### PR DESCRIPTION
## What

Adds `(*Client).ToTyped() *TypedClient` so callers holding a `*elasticsearch.Client` can obtain a `*TypedClient` without rebuilding the transport.

```go
c, _ := elasticsearch.New(...)
tc := c.ToTyped()
_, _ = tc.Info().Do(ctx)
```

The returned `TypedClient` shares the source `Client`'s:

- `Transport` (and therefore its connection pool)
- `compatibilityHeader`, `autoDrainBody`, `disableMetaHeader` settings

## Why

We're promoting `TypedClient` as the preferred API surface, but a lot of existing code holds a `*Client` from legacy `NewClient`/`New` paths or from shared infrastructure packages. Today there's no way to hand those callers a `TypedClient` without building a whole new transport, which duplicates configuration and creates a second connection pool. `ToTyped` closes that gap.

## Design notes

- **No binary-size cost when unused.** `typedapi` is already an unconditional import of the root package (via `NewTypedClient`/`NewTyped`), so adding a method that references it does not grow the binary for programs that only use `*Client`.
- **Fields are enumerated, not struct-copied.** `BaseClient` holds a `sync.RWMutex` and a `closeDone uint32`; copying the struct wholesale would trip `go vet`. The method builds a fresh `BaseClient` by listing the plain fields, matching what `New`/`NewTyped` already do.
- **Idempotent.** Repeated conversions are safe (the internal meta-header suffix is only appended once).
- **Documented as a one-shot call to be reused.** Each invocation allocates a new `typedapi.MethodAPI` tree and the returned client will re-run the product check on its first request, so the godoc tells callers to cache the returned `*TypedClient` rather than calling it per-request.
- **Backwards compatible.** Purely additive: one new exported method on an existing type.

## Out of scope

- **Documentation under `docs/reference/`** will land in a follow-up PR per our "one logical change per PR" rule.
- **No reverse `(*TypedClient).ToFunctional()`**: not requested, and we're deliberately pushing toward typed, not away from it.

## Test plan

- [x] `make lint` clean
- [x] `make test-unit` — 324 tests pass
- [x] New `TestToTyped` subtests cover:
  - the outgoing client-meta header is updated to record typed-API usage
  - `tc.Transport == c.Transport` (identity, not just equivalence)
  - `compatibilityHeader`, `autoDrainBody`, `disableMetaHeader` are carried over
  - `disableMetaHeader=true` still suppresses the header end-to-end on the converted client
  - repeated conversion is idempotent
  - the source `Client` is not mutated by conversion
