### PR TITLE
docs(migration): document (*Client).ToTyped() conversion method

### DIFF
--- a/docs/reference/low-level-api/migration.md
+++ b/docs/reference/low-level-api/migration.md
@@ -252,6 +252,43 @@ func main() {
 
 The same pattern applies to every typed endpoint package: `typedapi/indices/create`, `typedapi/core/bulk`, `typedapi/cluster/health`, and so on. Import the package for the endpoint you want to migrate, call `New(client)`, and use the builder.
 
+### Get a full typed client from an existing low-level client [_to_typed]
+
+If you want the full typed API surface (not just one endpoint package at a time) but the existing `*elasticsearch.Client` must keep working for other call sites, use `ToTyped`. It returns a `*elasticsearch.TypedClient` that reuses the source client's transport, connection pool, and configuration, without building a second transport:
+
+```go
+client, err := elasticsearch.New(
+    elasticsearch.WithAddresses("https://localhost:9200"),
+    elasticsearch.WithAPIKey("API_KEY"),
+)
+if err != nil {
+    log.Fatal(err)
+}
+defer client.Close(context.Background())
+
+typed := client.ToTyped() // <1>
+
+// Low-level call sites keep working.
+res, err := client.Indices.Exists([]string{"my-index"})
+// ...
+
+// Typed call sites go through `typed`.
+info, err := typed.Info().Do(context.Background())
+// ...
+```
+
+1. `ToTyped` copies the source client's compatibility mode, auto-drain-body, and disable-meta-header settings into the new `*TypedClient`, and shares the underlying transport (and its connection pool).
+
+This is the most common choice when the `*Client` is constructed in a shared infrastructure package you don't own, and you can't swap the constructor for `elasticsearch.NewTyped` without coordinating with other teams.
+
+#### Call `ToTyped` once and reuse it [_to_typed_reuse]
+
+`ToTyped` allocates a new typed API tree, and the returned client re-runs the product check on its first request. Call it once at setup and cache the result; do not call it per request or per handler invocation.
+
+#### Shared lifecycle [_to_typed_close]
+
+Because the `*TypedClient` returned by `ToTyped` shares the transport with the source `*Client`, **closing either one closes the connection pool used by both**. After `typed.Close(ctx)` returns, subsequent requests on the original `*Client` will fail with a closed-connection error, and vice versa. In a partial-migration setup, treat the source `*Client` as the lifecycle owner: let whichever code owns the `*Client` call `Close`, and do not call `Close` on the `*TypedClient` returned by `ToTyped`.
+
 ### Strategy [_partial_migration_strategy]
 
 A typical gradual migration looks like:

--- a/docs/reference/typed-api/index.md
+++ b/docs/reference/typed-api/index.md
@@ -52,7 +52,7 @@ graph TB
     OPTS --> TP
 ```
 
-Because both clients implement the same transport interface, individual typed endpoint packages (`typedapi/core/search`, `typedapi/indices/create`, ...) accept either client type. That means you can mix the two styles in a single application, and you can migrate existing low-level code to the typed API one endpoint at a time. See the [migration guide](../low-level-api/migration.md).
+Because both clients implement the same transport interface, individual typed endpoint packages (`typedapi/core/search`, `typedapi/indices/create`, ...) accept either client type. That means you can mix the two styles in a single application, and you can migrate existing low-level code to the typed API one endpoint at a time. If you already hold a `*elasticsearch.Client` and want the full typed surface without rebuilding the transport, call `client.ToTyped()`. See the [migration guide](../low-level-api/migration.md) for details on both approaches.
 
 ## API namespaces [_typed_api_namespaces]
 


### PR DESCRIPTION
## What

Documents the `(*Client).ToTyped()` method added in #1445.

Two doc changes:

- **`docs/reference/low-level-api/migration.md`** — adds a new subsection under "Partial migration" titled "Get a full typed client from an existing low-level client", describing when to use `ToTyped`, how to call it, the one-shot-and-cache guidance, and the shared-close warning.
- **`docs/reference/typed-api/index.md`** — adds one sentence to the "Relationship to the low-level client" section pointing readers who already hold a `*elasticsearch.Client` at `ToTyped`, with a link into the migration guide.

## Why

#1445 adds the method but the migration guide was the natural place to explain it, and that PR deliberately left docs alone per our "one logical change per PR" rule.

The migration guide already covers two migration paths (full constructor swap, per-endpoint `search.New(client)` style). `ToTyped` is a third path that specifically helps the common case where the `*Client` is constructed in a shared infrastructure package the caller doesn't own. Without the doc, that option is easy to miss.

The shared-close behavior is the one sharp edge of the method — both clients point at the same transport, so `Close` on either tears down the pool used by both. Calling that out explicitly prevents a class of "why did my other client stop working" bugs.

## Review notes

- Depends on #1445. This can merge as soon as that lands — the docs describe a method that only exists on that branch.
- No code or tests changed. Pure docs PR.

## Test plan

- [x] Markdown renders correctly locally (headings, code blocks, anchors consistent with neighboring doc style).
- [x] Internal links resolve: the new subsection uses an anchor `[_to_typed]` consistent with the surrounding `_partial_migration_*` pattern.
