### PR TITLE
[Backport 8.19] feat(client): add (*Client).ToTyped() conversion method

### DIFF
--- a/elasticsearch.go
+++ b/elasticsearch.go
@@ -57,6 +57,8 @@ const (
 	HeaderClientMeta = "x-elastic-client-meta"
 
 	compatibilityHeader = "application/vnd.elasticsearch+json;compatible-with=8"
+
+	typedClientMetaFlag = "hl=1"
 )
 
 var (
@@ -269,7 +271,7 @@ func NewTypedClient(cfg Config) (*TypedClient, error) {
 	compatHeaderEnv := os.Getenv(esCompatHeader)
 	compatibilityHeader, _ := strconv.ParseBool(compatHeaderEnv)
 
-	metaHeader := strings.Join([]string{initMetaHeader(tp), "hl=1"}, ",")
+	metaHeader := strings.Join([]string{initMetaHeader(tp), typedClientMetaFlag}, ",")
 
 	client := &TypedClient{
 		BaseClient: BaseClient{
@@ -358,7 +360,7 @@ func NewBase(opts ...Option) (*BaseClient, error) {
 //	    elasticsearch.WithAPIKey("base64-encoded-key"),
 //	)
 func NewTyped(opts ...Option) (*TypedClient, error) {
-	ro, err := resolveOptions(opts, "hl=1")
+	ro, err := resolveOptions(opts, typedClientMetaFlag)
 	if err != nil {
 		return nil, err
 	}
@@ -376,6 +378,34 @@ func NewTyped(opts ...Option) (*TypedClient, error) {
 		go func() { _ = client.DiscoverNodes() }()
 	}
 	return client, nil
+}
+
+// ToTyped returns a [TypedClient] that shares the underlying transport,
+// connection pool, and configuration of this [Client].
+//
+// ToTyped is intended to be called once per [Client] and the result
+// reused. Each call allocates a new [typedapi.API] tree, and the
+// returned client will re-run the product check on its first request.
+//
+// Because the transport is shared, closing either client closes the
+// connection pool used by both.
+func (c *Client) ToTyped() *TypedClient {
+	metaHeader := c.metaHeader
+	if !strings.Contains(metaHeader, typedClientMetaFlag) {
+		metaHeader = strings.Join([]string{metaHeader, typedClientMetaFlag}, ",")
+	}
+
+	tc := &TypedClient{
+		BaseClient: BaseClient{
+			Transport:           c.Transport,
+			disableMetaHeader:   c.disableMetaHeader,
+			metaHeader:          metaHeader,
+			compatibilityHeader: c.compatibilityHeader,
+			autoDrainBody:       c.autoDrainBody,
+		},
+	}
+	tc.API = typedapi.New(tc)
+	return tc
 }
 
 func newTransport(cfg Config) (*elastictransport.Client, error) {

--- a/elasticsearch_internal_test.go
+++ b/elasticsearch_internal_test.go
@@ -882,6 +882,138 @@ func TestNewTypedClient(t *testing.T) {
 	}
 }
 
+func toTypedMockTransport(t *testing.T, capture *http.Header) elastictransport.Interface {
+	t.Helper()
+	tp, err := elastictransport.NewClient(
+		elastictransport.WithURLs(&url.URL{Scheme: "http", Host: "foo"}),
+		elastictransport.WithTransport(&mockTransp{
+			RoundTripFunc: func(req *http.Request) (*http.Response, error) {
+				if capture != nil {
+					*capture = req.Header.Clone()
+				}
+				return &http.Response{
+					Header:     http.Header{"X-Elastic-Product": []string{"Elasticsearch"}},
+					StatusCode: http.StatusOK,
+					Status:     "OK",
+					Body: io.NopCloser(strings.NewReader(`{
+						"version":{"number":"8.0.0-SNAPSHOT","build_flavor":"default"},
+						"tagline":"You Know, for Search"
+					}`)),
+				}, nil
+			},
+		}),
+	)
+	if err != nil {
+		t.Fatalf("unexpected error: %s", err)
+	}
+	return tp
+}
+
+func TestToTyped_AddsTypedFlag(t *testing.T) {
+	var captured http.Header
+	c, err := New()
+	if err != nil {
+		t.Fatalf("unexpected error: %s", err)
+	}
+	c.Transport = toTypedMockTransport(t, &captured)
+
+	tc := c.ToTyped()
+	if _, err := tc.Info().Do(context.Background()); err != nil {
+		t.Fatalf("unexpected error: %s", err)
+	}
+
+	h := captured.Get(HeaderClientMeta)
+	if !metaHeaderReValidation.MatchString(h) {
+		t.Errorf("expected meta header to match regexp, got: %s", h)
+	}
+	if !strings.Contains(h, "hl=1") {
+		t.Errorf("expected meta header to contain hl=1, got: %s", h)
+	}
+}
+
+func TestToTyped_SharesTransport(t *testing.T) {
+	c, err := New()
+	if err != nil {
+		t.Fatalf("unexpected error: %s", err)
+	}
+	tc := c.ToTyped()
+	if tc.Transport != c.Transport {
+		t.Errorf("expected converted client to share the source transport")
+	}
+}
+
+func TestToTyped_PreservesConfigFlags(t *testing.T) {
+	c, err := New(WithCompatibilityMode(), WithAutoDrainBody())
+	if err != nil {
+		t.Fatalf("unexpected error: %s", err)
+	}
+	tc := c.ToTyped()
+	if !tc.compatibilityHeader {
+		t.Errorf("expected compatibilityHeader to be carried over")
+	}
+	if !tc.autoDrainBody {
+		t.Errorf("expected autoDrainBody to be carried over")
+	}
+	if tc.disableMetaHeader {
+		t.Errorf("expected disableMetaHeader to remain false")
+	}
+}
+
+func TestToTyped_PreservesDisableMetaHeader(t *testing.T) {
+	var captured http.Header
+	c, err := New(WithDisableMetaHeader())
+	if err != nil {
+		t.Fatalf("unexpected error: %s", err)
+	}
+	c.Transport = toTypedMockTransport(t, &captured)
+
+	tc := c.ToTyped()
+	if !tc.disableMetaHeader {
+		t.Errorf("expected disableMetaHeader to be carried over")
+	}
+
+	if _, err := tc.Info().Do(context.Background()); err != nil {
+		t.Fatalf("unexpected error: %s", err)
+	}
+	if h := captured.Get(HeaderClientMeta); h != "" {
+		t.Errorf("expected no meta header when disabled, got: %s", h)
+	}
+}
+
+func TestToTyped_IdempotentFlag(t *testing.T) {
+	c, err := New()
+	if err != nil {
+		t.Fatalf("unexpected error: %s", err)
+	}
+	first := c.ToTyped()
+	if strings.Count(first.metaHeader, "hl=1") != 1 {
+		t.Errorf("expected exactly one hl=1, got: %s", first.metaHeader)
+	}
+
+	// Simulate a Client whose metaHeader already contains hl=1: the
+	// conversion must not append a second occurrence.
+	c.metaHeader = first.metaHeader
+	second := c.ToTyped()
+	if strings.Count(second.metaHeader, "hl=1") != 1 {
+		t.Errorf("expected exactly one hl=1, got: %s", second.metaHeader)
+	}
+}
+
+func TestToTyped_SourceNotMutated(t *testing.T) {
+	c, err := New()
+	if err != nil {
+		t.Fatalf("unexpected error: %s", err)
+	}
+	before := c.metaHeader
+	_ = c.ToTyped()
+	if c.metaHeader != before {
+		t.Errorf("source metaHeader mutated: before=%q after=%q", before, c.metaHeader)
+	}
+	if strings.Contains(c.metaHeader, "hl=1") {
+		t.Errorf("source Client metaHeader should not contain hl=1, got: %s", c.metaHeader)
+	}
+}
+
 func TestContentTypeOverride(t *testing.T) {
 	t.Run("default JSON Content-Type", func(t *testing.T) {
 		contentType := "application/json"


### PR DESCRIPTION
Backport of #1445 to `8.19`.

## What

Adds `(*Client).ToTyped() *TypedClient` so callers holding a `*elasticsearch.Client` can obtain a `*TypedClient` without rebuilding the transport.

```go
c, _ := elasticsearch.New(...)
tc := c.ToTyped()
_, _ = tc.Info().Do(ctx)
```

## Backport notes

- Conflict in `elasticsearch.go` on `compatibilityHeader`: kept `compatible-with=8` for the 8.19 branch while taking the new `typedClientMetaFlag = "hl=1"` constant from the source commit.
- Adapted `ToTyped()` to the 8.19 typedapi shape: `tc.API = typedapi.New(tc)` (the 8.x branch uses `*typedapi.API` / `typedapi.New`, not the `MethodAPI`/`NewMethodAPI` tree introduced on `main`). Godoc reference updated to match.
- No other changes vs. #1445.

## Test plan

- [x] `go build ./...` clean
- [x] `go test -race .` passes, including the new `TestToTyped` subtests
