### PR TITLE
feat(esutil): default Client to elasticsearch.NewBase in NewBulkIndexer

### DIFF
--- a/esutil/bulk_indexer.go
+++ b/esutil/bulk_indexer.go
@@ -295,10 +295,11 @@ type bulkIndexer struct {
 	workers []*worker
 	stats   *bulkIndexerStats
 
-	config     BulkIndexerConfig
-	addCounter atomic.Uint64 // round-robin dispatch counter for Add()
-	flushMu    sync.Mutex    // serialises Flush() and Close()
-	closed     atomic.Bool   // set by Close()
+	config      BulkIndexerConfig
+	ownedClient *elasticsearch.BaseClient // non-nil when NewBulkIndexer auto-created the client; closed by Close
+	addCounter  atomic.Uint64             // round-robin dispatch counter for Add()
+	flushMu     sync.Mutex                // serialises Flush() and Close()
+	closed      atomic.Bool               // set by Close()
 }
 
 type bulkIndexerStats struct {
@@ -316,10 +317,19 @@ type bulkIndexerStats struct {
 
 // NewBulkIndexer creates a new bulk indexer.
 //
-// Returns an error when cfg.Client is nil.
+// If cfg.Client is nil, a default client is created via [elasticsearch.NewBase];
+// see its documentation for address resolution. The auto-created client is
+// closed by [BulkIndexer.Close]. Any error from the underlying client
+// construction is returned.
 func NewBulkIndexer(cfg BulkIndexerConfig) (BulkIndexer, error) {
+	var ownedClient *elasticsearch.BaseClient
 	if cfg.Client == nil {
-		return nil, fmt.Errorf("BulkIndexerConfig.Client is required")
+		client, err := elasticsearch.NewBase()
+		if err != nil {
+			return nil, err
+		}
+		cfg.Client = client
+		ownedClient = client
 	}
 
 	if cfg.Decoder == nil {
@@ -343,8 +353,9 @@ func NewBulkIndexer(cfg BulkIndexerConfig) (BulkIndexer, error) {
 	}
 
 	bi := bulkIndexer{
-		config: cfg,
-		stats:  &bulkIndexerStats{},
+		config:      cfg,
+		stats:       &bulkIndexerStats{},
+		ownedClient: ownedClient,
 	}
 
 	bi.init()
@@ -408,7 +419,10 @@ func (bi *bulkIndexer) Add(ctx context.Context, item BulkIndexerItem) error {
 
 // Close stops the periodic flush, closes the indexer queue channel,
 // which triggers the workers to flush and stop.
-// Note: it is the user's responsibility to call Close on the elasticsearch Client passed in to the BulkIndexerConfig.
+//
+// If the indexer auto-created its client (because BulkIndexerConfig.Client was
+// nil), Close also closes that client. It remains the caller's responsibility
+// to close any client they passed in via BulkIndexerConfig.Client.
 func (bi *bulkIndexer) Close(ctx context.Context) error {
 	bi.flushMu.Lock()
 	bi.closed.Store(true)
@@ -417,28 +431,37 @@ func (bi *bulkIndexer) Close(ctx context.Context) error {
 	}
 	bi.flushMu.Unlock()
 
+	var firstErr error
+
 	if err := ctx.Err(); err != nil {
 		if bi.config.OnError != nil {
 			bi.config.OnError(ctx, err)
 		}
-		return err
-	}
+		firstErr = err
+	} else {
+		done := make(chan struct{})
+		go func() {
+			bi.wg.Wait()
+			close(done)
+		}()
 
-	done := make(chan struct{})
-	go func() {
-		bi.wg.Wait()
-		close(done)
-	}()
-
-	select {
-	case <-done:
-		return nil
-	case <-ctx.Done():
-		if bi.config.OnError != nil {
-			bi.config.OnError(ctx, ctx.Err())
+		select {
+		case <-done:
+		case <-ctx.Done():
+			if bi.config.OnError != nil {
+				bi.config.OnError(ctx, ctx.Err())
+			}
+			firstErr = ctx.Err()
 		}
-		return ctx.Err()
 	}
+
+	if bi.ownedClient != nil {
+		if err := bi.ownedClient.Close(ctx); err != nil && firstErr == nil {
+			firstErr = err
+		}
+	}
+
+	return firstErr
 }
 
 // Flush drains all currently queued items, flushes all worker buffers to

--- a/esutil/bulk_indexer_internal_test.go
+++ b/esutil/bulk_indexer_internal_test.go
@@ -227,9 +227,9 @@ func TestBulkIndexer(t *testing.T) {
 	})
 
 	t.Run("ClientProvidedNotClosed", func(t *testing.T) {
-		es, err := elasticsearch.NewClient(elasticsearch.Config{Transport: &mockTransport{}})
+		es, err := elasticsearch.New(elasticsearch.WithTransportOptions(elastictransport.WithTransport(&mockTransport{})))
 		if err != nil {
-			t.Fatalf("NewClient: %s", err)
+			t.Fatalf("New: %s", err)
 		}
 		bi, err := NewBulkIndexer(BulkIndexerConfig{NumWorkers: 1, Client: es})
 		if err != nil {

--- a/esutil/bulk_indexer_internal_test.go
+++ b/esutil/bulk_indexer_internal_test.go
@@ -197,13 +197,54 @@ func TestBulkIndexer(t *testing.T) {
 		}
 	})
 
-	t.Run("ClientRequired", func(t *testing.T) {
-		_, err := NewBulkIndexer(BulkIndexerConfig{NumWorkers: 1})
-		if err == nil {
-			t.Fatalf("Expected error when client is not provided")
+	t.Run("ClientDefaulted", func(t *testing.T) {
+		bi, err := NewBulkIndexer(BulkIndexerConfig{NumWorkers: 1})
+		if err != nil {
+			t.Fatalf("Unexpected error: %s", err)
 		}
-		if err.Error() != "BulkIndexerConfig.Client is required" {
-			t.Fatalf("Unexpected error message: %s", err.Error())
+		if bi == nil {
+			t.Fatal("Expected a non-nil indexer when Client is not provided")
+		}
+
+		impl, ok := bi.(*bulkIndexer)
+		if !ok {
+			t.Fatalf("Expected *bulkIndexer, got %T", bi)
+		}
+		if impl.ownedClient == nil {
+			t.Fatal("Expected ownedClient to be set when Client is not provided")
+		}
+		owned := impl.ownedClient
+
+		if err := bi.Close(context.Background()); err != nil {
+			t.Fatalf("Close: %s", err)
+		}
+
+		// bi.Close should have closed the auto-created client; closing it
+		// again must report it as already closed.
+		if err := owned.Close(context.Background()); !errors.Is(err, elasticsearch.ErrAlreadyClosed) {
+			t.Fatalf("Expected ErrAlreadyClosed from owned client, got %v", err)
+		}
+	})
+
+	t.Run("ClientProvidedNotClosed", func(t *testing.T) {
+		es, err := elasticsearch.NewClient(elasticsearch.Config{Transport: &mockTransport{}})
+		if err != nil {
+			t.Fatalf("NewClient: %s", err)
+		}
+		bi, err := NewBulkIndexer(BulkIndexerConfig{NumWorkers: 1, Client: es})
+		if err != nil {
+			t.Fatalf("NewBulkIndexer: %s", err)
+		}
+		if err := bi.Close(context.Background()); err != nil {
+			t.Fatalf("Close: %s", err)
+		}
+
+		// A user-supplied client must not be closed by bi.Close: closing it
+		// here should succeed (and a second call would report
+		// ErrAlreadyClosed). This preserves the long-standing contract that
+		// callers own the lifecycle of clients they pass in.
+		if err := es.Close(context.Background()); err != nil {
+			t.Fatalf("Expected nil from first close of user-supplied client, got %v", err)
 		}
 	})
 


### PR DESCRIPTION
## Summary

`esutil.NewBulkIndexer` previously returned `"BulkIndexerConfig.Client is required"` when `cfg.Client` was nil. This PR changes that path to construct a default client via `elasticsearch.NewBase()` and propagate any construction error.

To avoid leaking the auto-created client, `bulkIndexer` now tracks it on a new `ownedClient` field and `BulkIndexer.Close` closes it after the workers drain. User-supplied clients keep their existing caller-owns-lifecycle contract — they are not touched by `Close`. Error precedence in `Close` is: worker-drain / context error wins; the owned-client close error is only returned if there was no earlier error.

The public signature is unchanged, and the behaviour is strictly more permissive (callers who used to get an error now get a working indexer pointed at `ELASTICSEARCH_URL` or `http://localhost:9200`), so this is backwards compatible per `AGENTS.md`.

## Why

Removes a small papercut for the simplest "just bulk into the default cluster" use case, and aligns `esutil` with the new functional-options entry point added in `elasticsearch.NewBase`.

## Notes for reviewers

- The godoc on `NewBulkIndexer` and `Close` was updated to describe the new behaviour. It defers to `elasticsearch.NewBase` for the address-resolution rules rather than restating them, so it doesn't go stale if `NewBase`'s defaults change.
- Two new tests in `bulk_indexer_internal_test.go`:
  - `ClientDefaulted` — replaces the old `ClientRequired` subtest. Asserts construction succeeds without `Client`, that `ownedClient` is populated, and that the auto-created client returns `ErrAlreadyClosed` after `bi.Close` (i.e. it really was closed).
  - `ClientProvidedNotClosed` — asserts a user-supplied client is not closed by `bi.Close`, preserving the long-standing contract.
- I noticed (but did not fix in this PR) a pre-existing double-`Close` panic — calling `BulkIndexer.Close` twice panics with `close of closed channel`. Filed separately as #1465 to keep this PR focused.

## Test plan

- [x] `make lint`
- [x] `make test-unit`
- [x] `go test -race ./esutil/...`
- [x] `go test -run 'TestBulkIndexer/Client' -race -v ./esutil/...` (new subtests)
