### PR TITLE
ci: warn on >+10% binary size growth for BaseClient/Client/TypedClient

### DIFF
--- a/.github/workflows/binsize.yml
+++ b/.github/workflows/binsize.yml
@@ -1,0 +1,182 @@
+---
+name: Binary size
+
+on:
+  pull_request:
+    branches:
+      - main
+    types: [opened, synchronize, reopened]
+
+concurrency:
+  group: binsize-${{ github.workflow }}-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+  pull-requests: write
+
+env:
+  # Per-binary increase that triggers a warning. Advisory only; the job
+  # never fails on a size regression.
+  BINSIZE_THRESHOLD_PERCENT: "10"
+
+jobs:
+  binsize:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - uses: actions/setup-go@v6
+        with:
+          go-version-file: go.mod
+
+      - name: Build and compare
+        id: binsize
+        env:
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          BASE_REF: ${{ github.event.pull_request.base.ref }}
+        run: |
+          set -euo pipefail
+
+          variants=(base client typed)
+          threshold="${BINSIZE_THRESHOLD_PERCENT}"
+
+          work_dir="$PWD"
+          base_dir="${work_dir}/tmp/binsize-base"
+          out_dir="${work_dir}/tmp/binsize"
+          fixture_src="${work_dir}/internal/cmd/binsize"
+          mkdir -p "${out_dir}"
+
+          build_variant() {
+            # $1=workdir, $2=variant, $3=output path
+            (cd "$1" && go build -trimpath -o "$3" "./internal/cmd/binsize/$2")
+          }
+
+          file_size() { stat -c%s "$1"; }
+
+          fmt_size()  { awk -v n="$1" 'BEGIN{ printf "%.2f MB", n/1048576 }'; }
+          fmt_delta() { awk -v n="$1" 'BEGIN{ s=(n>=0)?"+":""; printf "%s%.2f MB", s, n/1048576 }'; }
+
+          echo "Building PR binaries (HEAD=${GITHUB_SHA})"
+          for v in "${variants[@]}"; do
+            build_variant "${work_dir}" "$v" "${out_dir}/pr-$v"
+            file_size "${out_dir}/pr-$v" > "${out_dir}/pr-$v.size"
+          done
+
+          echo "Checking out base ref ${BASE_REF} @ ${BASE_SHA}"
+          git fetch --no-tags --depth=1 origin "${BASE_SHA}" 2>/dev/null || true
+
+          base_available=1
+          if ! git rev-parse --verify --quiet "${BASE_SHA}^{commit}" >/dev/null; then
+            base_available=0
+          elif ! git worktree add --detach "${base_dir}" "${BASE_SHA}" 2>/dev/null; then
+            base_available=0
+          fi
+
+          if [ "$base_available" = "1" ]; then
+            # Copy PR fixtures into the base worktree so this check works on
+            # PRs landing before the base contains the fixtures themselves.
+            mkdir -p "${base_dir}/internal/cmd/binsize"
+            cp -R "${fixture_src}/." "${base_dir}/internal/cmd/binsize/"
+
+            echo "Building base binaries"
+            for v in "${variants[@]}"; do
+              build_variant "${base_dir}" "$v" "${out_dir}/base-$v"
+              file_size "${out_dir}/base-$v" > "${out_dir}/base-$v.size"
+            done
+
+            git worktree remove --force "${base_dir}"
+          else
+            echo "::warning::Base ref ${BASE_REF} @ ${BASE_SHA} is unreachable; skipping comparison."
+          fi
+
+          over_threshold=0
+          {
+            echo "<!-- binsize -->"
+            echo "## Binary size vs \`${BASE_REF}\` (threshold: +${threshold}%)"
+            echo
+            echo "Fixtures: [\`internal/cmd/binsize\`](internal/cmd/binsize), built with \`go build -trimpath\` on linux/amd64."
+            echo
+            if [ "$base_available" = "0" ]; then
+              echo "_Base ref \`${BASE_REF}\` @ \`${BASE_SHA}\` was unreachable (likely force-pushed). Skipping comparison; PR binary sizes only._"
+              echo
+              echo "| Variant | PR |"
+              echo "|---|---:|"
+              for v in "${variants[@]}"; do
+                ps=$(cat "${out_dir}/pr-$v.size")
+                echo "| ${v} | $(fmt_size "$ps") |"
+              done
+            else
+              echo "| Variant | Base | PR | Delta | % |"
+              echo "|---|---:|---:|---:|---:|"
+              for v in "${variants[@]}"; do
+                bs=$(cat "${out_dir}/base-$v.size")
+                ps=$(cat "${out_dir}/pr-$v.size")
+                delta=$((ps - bs))
+                pct=$(awk -v d="$delta" -v b="$bs" 'BEGIN{ if (b==0){print "0.00"} else { printf "%.2f", (d/b)*100 } }')
+                over=$(awk -v p="$pct" -v t="$threshold" 'BEGIN{ print (p > t) ? 1 : 0 }')
+                marker=""
+                if [ "$over" = "1" ]; then
+                  marker=" :warning:"
+                  over_threshold=1
+                fi
+                sign=""
+                if awk -v p="$pct" 'BEGIN{ exit (p > 0) ? 0 : 1 }'; then sign="+"; fi
+                echo "| ${v} | $(fmt_size "$bs") | $(fmt_size "$ps") | $(fmt_delta "$delta") | ${sign}${pct}%${marker} |"
+              done
+              echo
+              if [ "$over_threshold" = "1" ]; then
+                echo "_One or more binaries grew by more than +${threshold}%. This is advisory — review whether the increase is expected (e.g., new endpoints, new typedapi types) or an unintended regression like [#1472](https://github.com/elastic/go-elasticsearch/issues/1472)._"
+              else
+                echo "_All binaries within +${threshold}% of base._"
+              fi
+            fi
+          } > "${out_dir}/comment.md"
+
+          cat "${out_dir}/comment.md" >> "${GITHUB_STEP_SUMMARY}"
+
+          if [ "$over_threshold" = "1" ]; then
+            echo "::warning::Binary size grew by more than +${threshold}% for one or more variants. See PR comment for details."
+          fi
+
+      - name: Post binsize comment
+        # Forked-PR runs receive a read-only GITHUB_TOKEN and cannot post
+        # comments. Skip the post step for those rather than failing the job;
+        # the table is still in the workflow summary.
+        if: github.event.pull_request.head.repo.full_name == github.repository
+        continue-on-error: true
+        uses: actions/github-script@v7
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            const fs = require('fs');
+
+            const owner = context.repo.owner;
+            const repo = context.repo.repo;
+            const issue_number = context.payload.pull_request.number;
+            const comments = await github.paginate(
+              github.rest.issues.listComments,
+              { owner, repo, issue_number, per_page: 100 }
+            );
+
+            const marker = '<!-- binsize -->';
+            const body = fs.readFileSync('tmp/binsize/comment.md', 'utf8');
+            const existing = comments.find((c) => c.body?.includes(marker));
+
+            if (existing) {
+              await github.rest.issues.updateComment({
+                owner,
+                repo,
+                comment_id: existing.id,
+                body,
+              });
+            } else {
+              await github.rest.issues.createComment({
+                owner,
+                repo,
+                issue_number,
+                body,
+              });
+            }

--- a/internal/cmd/binsize/base/main.go
+++ b/internal/cmd/binsize/base/main.go
@@ -1,0 +1,48 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+// Binary-size fixture for [elasticsearch.BaseClient]. Built by CI and
+// compared against the PR's base branch to detect unintended growth.
+// Must not transitively reach esapi or typedapi.
+package main
+
+import (
+	"fmt"
+	"net/http"
+	"os"
+
+	"github.com/elastic/go-elasticsearch/v9"
+)
+
+func main() {
+	c, err := elasticsearch.NewBase()
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+	req, err := http.NewRequest(http.MethodGet, "/", nil)
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+	res, err := c.Perform(req)
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		return
+	}
+	res.Body.Close()
+}

--- a/internal/cmd/binsize/client/main.go
+++ b/internal/cmd/binsize/client/main.go
@@ -1,0 +1,44 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+// Binary-size fixture for [elasticsearch.Client]. Built by CI and
+// compared against the PR's base branch to detect unintended growth.
+// Must not import typedapi: instantiating *Client makes every exported
+// method (including any path into typedapi) linker-reachable, so a
+// regression like elastic/go-elasticsearch#1472 shows up as a delta here.
+package main
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/elastic/go-elasticsearch/v9"
+)
+
+func main() {
+	c, err := elasticsearch.New()
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+	res, err := c.Info()
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		return
+	}
+	res.Body.Close()
+}

--- a/internal/cmd/binsize/typed/main.go
+++ b/internal/cmd/binsize/typed/main.go
@@ -1,0 +1,40 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+// Binary-size fixture for [elasticsearch.TypedClient]. Built by CI and
+// compared against the PR's base branch to detect unintended growth.
+package main
+
+import (
+	"context"
+	"fmt"
+	"os"
+
+	"github.com/elastic/go-elasticsearch/v9"
+)
+
+func main() {
+	c, err := elasticsearch.NewTyped()
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+	if _, err := c.Info().Do(context.Background()); err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		return
+	}
+}


### PR DESCRIPTION
## Summary

Adds a `Binary size` workflow that builds three minimal fixtures (`BaseClient`, `Client`, `TypedClient`) on PRs against `main`, compares each binary against the PR's base ref, and posts an advisory sticky comment plus a workflow-summary table.

Motivation: catch future regressions like #1472, where `(*Client).ToTyped()` made the entire `typedapi` tree linker-reachable from binaries that only use `*Client` (+43 MB / +36% for the reporter's app). A check on raw output size catches that class of regression without needing per-symbol analysis.

## Behavior

- Trigger: `pull_request` against `main` (`opened`, `synchronize`, `reopened`).
- Per-binary, independent threshold. Emits a `::warning::` and flags the offending row in the comment when any single variant grows by more than `BINSIZE_THRESHOLD_PERCENT` (default `10`). **Advisory only — the job never fails.** Edit the one env value to retune.
- Fork PRs (read-only `GITHUB_TOKEN`) and force-pushed base refs (`BASE_SHA` unreachable) both degrade gracefully without failing the job.
- Fixtures are copied from PR head into the base worktree before building, so this PR itself works against a `main` that doesn't contain the fixtures yet.

## Files

- `internal/cmd/binsize/{base,client,typed}/main.go` — three minimal `main` programs in the root module so they import the local package without a `replace`. The `client` fixture deliberately does **not** import `typedapi`; if a future change re-introduces a reachable path from `*Client` into `typedapi`, that binary's delta surfaces it.
- `.github/workflows/binsize.yml` — the workflow.

## Local sanity check

Built on macOS/arm64 (CI measures linux/amd64, so absolute numbers will differ):

| Variant | Size |
|---|---:|
| base | 8.90 MB |
| client | 15.72 MB |
| typed | 9.08 MB |

`client > typed` already reflects #1472: `*Client` keeps every `*TypedClient` method reachable via `ToTyped`, so the client fixture pulls in more of `typedapi` than the typed fixture (which only calls `Info().Do`). Any future fix that breaks the `*Client → typedapi` link should show up as a large negative delta on `client`.

## Test plan

- [ ] First run of this workflow (on this PR) posts the size table; base/PR sizes should be approximately equal because the fixtures are copied into the base worktree before building, and emits no `::warning::`.
- [ ] After this lands, a follow-up no-op PR shows a ~0% delta against the new baseline on `main`.
- [ ] A synthetic PR that adds a `typedapi` import to `internal/cmd/binsize/base/main.go` triggers the warning on the `base` row only.
- [ ] A synthetic PR that lowers `BINSIZE_THRESHOLD_PERCENT` to `0` triggers warnings on all rows that grew at all.
