### PR TITLE
fix(client): remove (*Client).ToTyped() to fix binary-size regression

### DIFF
--- a/_examples/README.md
+++ b/_examples/README.md
@@ -8,9 +8,9 @@ The [**`configuration.go`**](./configuration.go) and [**`customization.go`**](./
 
 ## Migrating to the Typed API
 
-The [**`totyped.go`**](./totyped.go) file demonstrates incremental migration from the functional (low-level) API to the typed API using `(*Client).ToTyped()`. The returned `*TypedClient` shares the source client's transport and configuration, so existing call sites keep working while new code can use the typed builder API.
+The [**`totyped.go`**](./totyped.go) file demonstrates incremental migration from the functional (low-level) API to the typed API using `elasticsearch.NewTypedFrom(c)`. The returned `*TypedClient` shares the source client's transport and configuration, so existing call sites keep working while new code can use the typed builder API.
 
-The [**`typed_endpoint.go`**](./typed_endpoint.go) file shows the lightest-weight migration step: using a single typed endpoint (for example `typedapi/core/search`) directly against the existing functional `*elasticsearch.Client`, without constructing a full `*TypedClient` or calling `ToTyped()`. Every typed endpoint package exports a `New(elastictransport.Interface)` constructor, and the functional client satisfies that interface via its embedded `BaseClient.Perform`. The same file also shows `elasticsearch.NewBase(...)`, which returns a raw `*BaseClient` for fresh code that only ever needs a handful of typed endpoints, skipping both the `esapi` tree and the typedapi `MethodAPI` tree.
+The [**`typed_endpoint.go`**](./typed_endpoint.go) file shows the lightest-weight migration step: using a single typed endpoint (for example `typedapi/core/search`) directly against the existing functional `*elasticsearch.Client`, without constructing a full `*TypedClient` or calling `NewTypedFrom`. Every typed endpoint package exports a `New(elastictransport.Interface)` constructor, and the functional client satisfies that interface via its embedded `BaseClient.Perform`. The same file also shows `elasticsearch.NewBase(...)`, which returns a raw `*BaseClient` for fresh code that only ever needs a handful of typed endpoints, skipping both the `esapi` tree and the typedapi `MethodAPI` tree.
 
 ## Logging
 

--- a/_examples/totyped.go
+++ b/_examples/totyped.go
@@ -21,8 +21,8 @@
 // This example demonstrates incremental migration from the functional
 // (low-level) API to the typed API.
 //
-// (*Client).ToTyped() returns a *TypedClient that shares the source
-// client's transport, connection pool, compatibility header, and
+// elasticsearch.NewTypedFrom(c) returns a *TypedClient that shares the
+// source client's transport, connection pool, compatibility header, and
 // instrumentation. There is no second transport and no second product
 // check once both clients have exchanged a first request: the existing
 // *Client keeps working for code that has not been migrated, while new
@@ -53,8 +53,8 @@ func main() {
 		log.Fatalf("error creating the client: %s", err)
 	}
 	// The functional and typed clients share the same transport (see
-	// ToTyped below), so closing es also closes the pool used by the
-	// typed client.
+	// NewTypedFrom below), so closing es also closes the pool used by
+	// the typed client.
 	defer func() {
 		closeCtx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 		defer cancel()
@@ -83,10 +83,10 @@ func main() {
 	}
 	log.Printf("[functional] server version: %s", info.Version.Number)
 
-	// Migrate one call at a time. ToTyped reuses the same transport,
-	// connection pool, and configuration, so no second client setup is
-	// required. Call it once and reuse the result.
-	typed := es.ToTyped()
+	// Migrate one call at a time. NewTypedFrom reuses the same
+	// transport, connection pool, and configuration, so no second
+	// client setup is required. Call it once and reuse the result.
+	typed := elasticsearch.NewTypedFrom(es)
 
 	// Migrated call site using the typed builder API. The response is
 	// a decoded Go struct; no body.Close, no manual JSON parsing.

--- a/_examples/typed_endpoint.go
+++ b/_examples/typed_endpoint.go
@@ -34,7 +34,7 @@
 // BaseClient, which implements Perform. That means the existing
 // low-level client can be passed straight into any typed endpoint
 // constructor, sharing its transport, connection pool, retry policy,
-// and instrumentation. No second client, no ToTyped() call, no
+// and instrumentation. No second client, no NewTypedFrom call, no
 // MethodAPI tree: just the one endpoint you want to migrate.
 //
 // Use this when you want to try out the typed API for a single call

--- a/elasticsearch.go
+++ b/elasticsearch.go
@@ -392,16 +392,21 @@ func NewTyped(opts ...Option) (*TypedClient, error) {
 	return client, nil
 }
 
-// ToTyped returns a [TypedClient] that shares the underlying transport,
-// connection pool, and configuration of this [Client].
+// NewTypedFrom returns a [TypedClient] that shares c's transport,
+// connection pool, and configuration.
 //
-// ToTyped is intended to be called once per [Client] and the result
-// reused. Each call allocates a new [typedapi.MethodAPI] tree, and the
-// returned client will re-run the product check on its first request.
+// NewTypedFrom is intended to be called once per [Client] and the
+// result reused. Each call allocates a new [typedapi.MethodAPI] tree,
+// and the returned client will re-run the product check on its first
+// request.
+//
+// NewTypedFrom is a free function rather than a method on [Client] so
+// that the Go linker can dead-code-eliminate the typedapi tree for
+// callers that never construct a typed client.
 //
 // Because the transport is shared, closing either client closes the
 // connection pool used by both.
-func (c *Client) ToTyped() *TypedClient {
+func NewTypedFrom(c *Client) *TypedClient {
 	metaHeader := c.metaHeader
 	if !strings.Contains(metaHeader, typedClientMetaFlag) {
 		metaHeader = strings.Join([]string{metaHeader, typedClientMetaFlag}, ",")

--- a/elasticsearch_internal_test.go
+++ b/elasticsearch_internal_test.go
@@ -943,7 +943,7 @@ func toTypedMockTransport(t *testing.T, capture *http.Header) elastictransport.I
 	return tp
 }
 
-func TestToTyped_AddsTypedFlag(t *testing.T) {
+func TestNewTypedFrom_AddsTypedFlag(t *testing.T) {
 	var captured http.Header
 	c, err := New()
 	if err != nil {
@@ -951,7 +951,7 @@ func TestToTyped_AddsTypedFlag(t *testing.T) {
 	}
 	c.Transport = toTypedMockTransport(t, &captured)
 
-	tc := c.ToTyped()
+	tc := NewTypedFrom(c)
 	if _, err := tc.Info().Do(context.Background()); err != nil {
 		t.Fatalf("unexpected error: %s", err)
 	}
@@ -965,23 +965,23 @@ func TestToTyped_AddsTypedFlag(t *testing.T) {
 	}
 }
 
-func TestToTyped_SharesTransport(t *testing.T) {
+func TestNewTypedFrom_SharesTransport(t *testing.T) {
 	c, err := New()
 	if err != nil {
 		t.Fatalf("unexpected error: %s", err)
 	}
-	tc := c.ToTyped()
+	tc := NewTypedFrom(c)
 	if tc.Transport != c.Transport {
 		t.Errorf("expected converted client to share the source transport")
 	}
 }
 
-func TestToTyped_PreservesConfigFlags(t *testing.T) {
+func TestNewTypedFrom_PreservesConfigFlags(t *testing.T) {
 	c, err := New(WithCompatibilityMode(), WithAutoDrainBody())
 	if err != nil {
 		t.Fatalf("unexpected error: %s", err)
 	}
-	tc := c.ToTyped()
+	tc := NewTypedFrom(c)
 	if !tc.compatibilityHeader {
 		t.Errorf("expected compatibilityHeader to be carried over")
 	}
@@ -993,7 +993,7 @@ func TestToTyped_PreservesConfigFlags(t *testing.T) {
 	}
 }
 
-func TestToTyped_PreservesDisableMetaHeader(t *testing.T) {
+func TestNewTypedFrom_PreservesDisableMetaHeader(t *testing.T) {
 	var captured http.Header
 	c, err := New(WithDisableMetaHeader())
 	if err != nil {
@@ -1001,7 +1001,7 @@ func TestToTyped_PreservesDisableMetaHeader(t *testing.T) {
 	}
 	c.Transport = toTypedMockTransport(t, &captured)
 
-	tc := c.ToTyped()
+	tc := NewTypedFrom(c)
 	if !tc.disableMetaHeader {
 		t.Errorf("expected disableMetaHeader to be carried over")
 	}
@@ -1014,12 +1014,12 @@ func TestToTyped_PreservesDisableMetaHeader(t *testing.T) {
 	}
 }
 
-func TestToTyped_IdempotentFlag(t *testing.T) {
+func TestNewTypedFrom_IdempotentFlag(t *testing.T) {
 	c, err := New()
 	if err != nil {
 		t.Fatalf("unexpected error: %s", err)
 	}
-	first := c.ToTyped()
+	first := NewTypedFrom(c)
 	if strings.Count(first.metaHeader, "hl=1") != 1 {
 		t.Errorf("expected exactly one hl=1, got: %s", first.metaHeader)
 	}
@@ -1027,19 +1027,19 @@ func TestToTyped_IdempotentFlag(t *testing.T) {
 	// Simulate a Client whose metaHeader already contains hl=1: the
 	// conversion must not append a second occurrence.
 	c.metaHeader = first.metaHeader
-	second := c.ToTyped()
+	second := NewTypedFrom(c)
 	if strings.Count(second.metaHeader, "hl=1") != 1 {
 		t.Errorf("expected exactly one hl=1, got: %s", second.metaHeader)
 	}
 }
 
-func TestToTyped_SourceNotMutated(t *testing.T) {
+func TestNewTypedFrom_SourceNotMutated(t *testing.T) {
 	c, err := New()
 	if err != nil {
 		t.Fatalf("unexpected error: %s", err)
 	}
 	before := c.metaHeader
-	_ = c.ToTyped()
+	_ = NewTypedFrom(c)
 	if c.metaHeader != before {
 		t.Errorf("source metaHeader mutated: before=%q after=%q", before, c.metaHeader)
 	}


### PR DESCRIPTION
## Summary

Fixes the binary-size regression introduced by v9.4.0's `(*Client).ToTyped()` (#1472). As a method on the concrete `*Client` type, `ToTyped()` was kept live by Go's linker in every binary that imported `*elasticsearch.Client` and used a library that introspects type methods (DI containers, observability SDKs, generic serialization), pulling in the entire `typedapi` tree. Functional-API-only consumers (e.g. Jaeger) reported ~40 MB / ~36% of binary growth on v9.3.1 → v9.4.0.

## What changed

- **Removed:** `(*elasticsearch.Client).ToTyped()` (breaking).
- **Added:** `elasticsearch.NewTypedFrom(c *Client) *TypedClient` — a free function with identical semantics (shared transport, idempotent `hl=1` meta-header flag, preserved `compatibilityHeader` / `autoDrainBody` / `disableMetaHeader`). As a free function it is subject to per-function DCE, so the `typedapi` tree is only linked into binaries that statically call it (or one of the other typed constructors).

## Migration

```go
// v9.4.0
typed := client.ToTyped()

// v9.4.1
typed := elasticsearch.NewTypedFrom(client)
```

No new import, same package, same return type. The returned `*TypedClient` is identical to what `ToTyped()` returned previously.

## Verification

The binsize CI fixtures introduced in #1473 (and upgraded in #1476 to actually exercise the regression class via a `reflect.ValueOf(c).NumMethod()` walk) confirm the fix:

| fixture | main HEAD (with bug) | this PR | delta |
| --- | --- | --- | --- |
| `client` | 74 MB / 31,155 typedapi syms | **31 MB / 0 syms** | **-44 MB / -58%** |
| `typed`  | 55 MB / 31,155 syms | 55 MB / 31,155 syms | ~0 (typedapi is intentionally linked here) |
| `base`   | 9.3 MB / 0 syms | 9.3 MB / 0 syms | ~0 |

The -44 MB delta on `client` matches the issue reporter's Jaeger numbers (120 MB → 164 MB on v9.3.1 → v9.4.0).

## Why a free function rather than a method or a sub-package

Earlier drafts tried two other shapes:

- `(*Client).BaseForTyped() BaseClient` plus a `typedapi/bridge` sub-package wrapping it: works for DCE, but adds a sub-package, a helper method that returns a half-constructed `BaseClient`, and a second import at the call site — all to solve a problem that one free function already solves.
- `(*Client).ToTyped()` kept as-is: the original v9.4.0 shape, which is precisely what causes #1472.

A free function in the root package matches the existing `NewTyped` / `NewTypedClient` constructor style, keeps the API surface minimal (one new exported symbol), and gives the linker the same DCE eligibility as the sub-package approach. No `opts ...Option` parameter for now: the original `.ToTyped()` was opt-less and no concrete need has been articulated; variadic options can be added later non-breakingly if a use case appears.

## Test plan

- [x] `make lint` passes.
- [x] `make test-unit` passes; 6 `TestNewTypedFrom_*` unit tests cover the BaseClient-cloning semantics (`hl=1` added, shared transport, preserved config flags, preserved `disableMetaHeader`, idempotent flag, source not mutated).
- [x] Binsize fixtures locally verified — `client` drops from 74 MB to 31 MB with this change.
- [ ] Reviewer to confirm the `BREAKING-CHANGE:` footer is picked up correctly by release-please from the squash-merged commit.

## Related PRs

- Docs counterpart: #1475 (needs an update to reference `NewTypedFrom` instead of `bridge.ToTyped`; I'll push that in a moment).
- Binsize fixture fix that makes the regression visible to CI: #1476 (merged).
