### PR TITLE
ci: force method retention in client and typed binsize fixtures

### DIFF
--- a/internal/cmd/binsize/client/main.go
+++ b/internal/cmd/binsize/client/main.go
@@ -17,14 +17,27 @@
 
 // Binary-size fixture for [elasticsearch.Client]. Built by CI and
 // compared against the PR's base branch to detect unintended growth.
-// Must not import typedapi: instantiating *Client makes every exported
-// method (including any path into typedapi) linker-reachable, so a
-// regression like elastic/go-elasticsearch#1472 shows up as a delta here.
+// Must not import typedapi: a regression like elastic/go-elasticsearch#1472
+// (a method on *Client transitively pulling in the typedapi tree) shows
+// up as a delta here.
+//
+// The reflect.ValueOf(c).NumMethod() loop below is deliberate. Go's
+// linker performs per-method dead-code elimination on concrete types
+// when it can prove no reachable code path uses a given method. A
+// minimal program that calls only c.Info() lets the linker eliminate
+// every other *Client method (including any that accidentally reach
+// into typedapi), which hides exactly the regression class this
+// fixture exists to detect. Real-world apps that hit #1472 use
+// reflection-based libraries (DI containers, observability SDKs,
+// generic serialization) which keep the full *Client method set live;
+// the reflect walk simulates that and forces the linker to retain
+// every method body so a transitive heavy-package edge is visible.
 package main
 
 import (
 	"fmt"
 	"os"
+	"reflect"
 
 	"github.com/elastic/go-elasticsearch/v9"
 )
@@ -34,6 +47,10 @@ func main() {
 	if err != nil {
 		fmt.Fprintln(os.Stderr, err)
 		os.Exit(1)
+	}
+	v := reflect.ValueOf(c)
+	for i := 0; i < v.NumMethod(); i++ {
+		_ = v.Type().Method(i).Name
 	}
 	res, err := c.Info()
 	if err != nil {

--- a/internal/cmd/binsize/typed/main.go
+++ b/internal/cmd/binsize/typed/main.go
@@ -17,12 +17,23 @@
 
 // Binary-size fixture for [elasticsearch.TypedClient]. Built by CI and
 // compared against the PR's base branch to detect unintended growth.
+//
+// The reflect.ValueOf(c).NumMethod() loop below is deliberate. Go's
+// linker performs per-method dead-code elimination on concrete types
+// when it can prove no reachable code path uses a given method. A
+// fixture that calls only c.Info().Do(ctx) lets the linker eliminate
+// every other typed namespace method, which keeps the binary at ~9 MB
+// with ~38 typedapi symbols out of ~31,000: a regression in any typed
+// endpoint other than Info would be invisible. The reflect walk forces
+// the linker to retain the full typed surface (~55 MB / ~31,155
+// symbols) so that growth in any typed namespace is tracked here.
 package main
 
 import (
 	"context"
 	"fmt"
 	"os"
+	"reflect"
 
 	"github.com/elastic/go-elasticsearch/v9"
 )
@@ -32,6 +43,10 @@ func main() {
 	if err != nil {
 		fmt.Fprintln(os.Stderr, err)
 		os.Exit(1)
+	}
+	v := reflect.ValueOf(c)
+	for i := 0; i < v.NumMethod(); i++ {
+		_ = v.Type().Method(i).Name
 	}
 	if _, err := c.Info().Do(context.Background()); err != nil {
 		fmt.Fprintln(os.Stderr, err)


### PR DESCRIPTION
## Summary

The `client` and `typed` binsize fixtures added in #1473 do not actually catch the regression classes they're meant to guard. Go 1.26's linker performs per-method dead-code elimination on concrete types: when a fixture calls only one method, every other method (and its transitive dependencies) is eliminated.

Built against current `main`:

| fixture | size | `typedapi` symbols | what regressions it catches |
| --- | --- | --- | --- |
| `client` (current) | 16 MB | **0** | nothing — the v9.4.0 `(*Client).ToTyped()` bug DCEs cleanly here |
| `typed` (current) | 9.5 MB | **38** out of ~31,000 | only regressions in `Info`; every other typed endpoint is invisible |

The CI comment on #1474 showed `-0.03 MB / -0.16%` on `client`, which made the fix look like a no-op even though local measurement shows a -44 MB drop in the realistic scenario.

## What changed

Add a `reflect.ValueOf(c).NumMethod()` walk to both `client` and `typed`. This mirrors what real-world apps that hit #1472 actually do: reflection-based DI (Uber fx, Wire), observability SDKs (OpenTelemetry, Jaeger), and generic serialization libraries all introspect a type's method set, which keeps every method live and lets transitive heavy edges (like the old `ToTyped → typedapi.NewMethodAPI` chain) reach into the binary.

`base` is unchanged: `*BaseClient` has no methods that reach into `esapi` or `typedapi`, so its 9.0 MB / 0 esapi / 0 typedapi baseline is already accurate.

## Verification

| fixture | against `main` (with bug) | against #1474 (fixed) | delta |
| --- | --- | --- | --- |
| `client` (current) | 16 MB / 0 syms | 16 MB / 0 syms | -0.03 MB (false clean) |
| `client` (this PR) | **74 MB / 31,155 syms** | **31 MB / 0 syms** | **-44 MB / -58%** |
| `typed` (current) | 9.5 MB / 38 syms | 9.5 MB / 38 syms | ~0 |
| `typed` (this PR) | **55 MB / 31,155 syms** | 55 MB / 31,155 syms | ~0 (typedapi is intentionally linked here) |

For `typed`, the absolute size doesn't change between buggy and fixed (typedapi is supposed to be there), but the fixture now actually tracks the full typed surface, so future regressions in any namespace become visible as a delta.

Once this lands and #1474 is rebased on top of the new `main`, the binsize CI on #1474 will show the real ~-44 MB / -58% drop on `client`.

## Test plan

- [x] `go build -trimpath` succeeds for all three fixtures (`base`, `client`, `typed`).
- [x] Locally verified the empirical numbers in the table above.
- [ ] After merge, confirm the binsize CI comment on #1474 reflects the real delta.

Refs #1472, #1473
