### PR TITLE
fix(client): remove (*Client).ToTyped() to fix binary-size regression

### DIFF
--- a/elasticsearch.go
+++ b/elasticsearch.go
@@ -380,16 +380,21 @@ func NewTyped(opts ...Option) (*TypedClient, error) {
 	return client, nil
 }
 
-// ToTyped returns a [TypedClient] that shares the underlying transport,
-// connection pool, and configuration of this [Client].
+// NewTypedFrom returns a [TypedClient] that shares c's transport,
+// connection pool, and configuration.
 //
-// ToTyped is intended to be called once per [Client] and the result
-// reused. Each call allocates a new [typedapi.MethodAPI] tree, and the
-// returned client will re-run the product check on its first request.
+// NewTypedFrom is intended to be called once per [Client] and the
+// result reused. Each call allocates a new [typedapi.MethodAPI] tree,
+// and the returned client will re-run the product check on its first
+// request.
+//
+// NewTypedFrom is a free function rather than a method on [Client] so
+// that the Go linker can dead-code-eliminate the typedapi tree for
+// callers that never construct a typed client.
 //
 // Because the transport is shared, closing either client closes the
 // connection pool used by both.
-func (c *Client) ToTyped() *TypedClient {
+func NewTypedFrom(c *Client) *TypedClient {
 	metaHeader := c.metaHeader
 	if !strings.Contains(metaHeader, typedClientMetaFlag) {
 		metaHeader = strings.Join([]string{metaHeader, typedClientMetaFlag}, ",")

--- a/elasticsearch_internal_test.go
+++ b/elasticsearch_internal_test.go
@@ -891,7 +891,7 @@ func toTypedMockTransport(t *testing.T, capture *http.Header) elastictransport.I
 	return tp
 }
 
-func TestToTyped_AddsTypedFlag(t *testing.T) {
+func TestNewTypedFrom_AddsTypedFlag(t *testing.T) {
 	var captured http.Header
 	c, err := New()
 	if err != nil {
@@ -899,7 +899,7 @@ func TestToTyped_AddsTypedFlag(t *testing.T) {
 	}
 	c.Transport = toTypedMockTransport(t, &captured)
 
-	tc := c.ToTyped()
+	tc := NewTypedFrom(c)
 	if _, err := tc.Info().Do(context.Background()); err != nil {
 		t.Fatalf("unexpected error: %s", err)
 	}
@@ -913,23 +913,23 @@ func TestToTyped_AddsTypedFlag(t *testing.T) {
 	}
 }
 
-func TestToTyped_SharesTransport(t *testing.T) {
+func TestNewTypedFrom_SharesTransport(t *testing.T) {
 	c, err := New()
 	if err != nil {
 		t.Fatalf("unexpected error: %s", err)
 	}
-	tc := c.ToTyped()
+	tc := NewTypedFrom(c)
 	if tc.Transport != c.Transport {
 		t.Errorf("expected converted client to share the source transport")
 	}
 }
 
-func TestToTyped_PreservesConfigFlags(t *testing.T) {
+func TestNewTypedFrom_PreservesConfigFlags(t *testing.T) {
 	c, err := New(WithCompatibilityMode(), WithAutoDrainBody())
 	if err != nil {
 		t.Fatalf("unexpected error: %s", err)
 	}
-	tc := c.ToTyped()
+	tc := NewTypedFrom(c)
 	if !tc.compatibilityHeader {
 		t.Errorf("expected compatibilityHeader to be carried over")
 	}
@@ -941,7 +941,7 @@ func TestToTyped_PreservesConfigFlags(t *testing.T) {
 	}
 }
 
-func TestToTyped_PreservesDisableMetaHeader(t *testing.T) {
+func TestNewTypedFrom_PreservesDisableMetaHeader(t *testing.T) {
 	var captured http.Header
 	c, err := New(WithDisableMetaHeader())
 	if err != nil {
@@ -949,7 +949,7 @@ func TestToTyped_PreservesDisableMetaHeader(t *testing.T) {
 	}
 	c.Transport = toTypedMockTransport(t, &captured)
 
-	tc := c.ToTyped()
+	tc := NewTypedFrom(c)
 	if !tc.disableMetaHeader {
 		t.Errorf("expected disableMetaHeader to be carried over")
 	}
@@ -962,12 +962,12 @@ func TestToTyped_PreservesDisableMetaHeader(t *testing.T) {
 	}
 }
 
-func TestToTyped_IdempotentFlag(t *testing.T) {
+func TestNewTypedFrom_IdempotentFlag(t *testing.T) {
 	c, err := New()
 	if err != nil {
 		t.Fatalf("unexpected error: %s", err)
 	}
-	first := c.ToTyped()
+	first := NewTypedFrom(c)
 	if strings.Count(first.metaHeader, "hl=1") != 1 {
 		t.Errorf("expected exactly one hl=1, got: %s", first.metaHeader)
 	}
@@ -975,19 +975,19 @@ func TestToTyped_IdempotentFlag(t *testing.T) {
 	// Simulate a Client whose metaHeader already contains hl=1: the
 	// conversion must not append a second occurrence.
 	c.metaHeader = first.metaHeader
-	second := c.ToTyped()
+	second := NewTypedFrom(c)
 	if strings.Count(second.metaHeader, "hl=1") != 1 {
 		t.Errorf("expected exactly one hl=1, got: %s", second.metaHeader)
 	}
 }
 
-func TestToTyped_SourceNotMutated(t *testing.T) {
+func TestNewTypedFrom_SourceNotMutated(t *testing.T) {
 	c, err := New()
 	if err != nil {
 		t.Fatalf("unexpected error: %s", err)
 	}
 	before := c.metaHeader
-	_ = c.ToTyped()
+	_ = NewTypedFrom(c)
 	if c.metaHeader != before {
 		t.Errorf("source metaHeader mutated: before=%q after=%q", before, c.metaHeader)
 	}


### PR DESCRIPTION
Backport of #1474 to `9.2`.

Cherry-picks `5284fda6de` from `main`. Conflicts resolved:

- `_examples/totyped.go`, `_examples/typed_endpoint.go`: not present on this branch (those example files exist only on `main`); the cherry-pick's modifications to them were dropped.
- `_examples/README.md`: this branch never carried the "Migrating to the Typed API" section that referenced those examples, so the file is kept as-is.

## Test plan

- [x] `make lint` passes.
- [x] All 6 `TestNewTypedFrom_*` unit tests pass.

Refs #1472.
