### PR TITLE
esutil: wrap bulk item failures with response context

### DIFF
--- a/esutil/bulk_indexer.go
+++ b/esutil/bulk_indexer.go
@@ -280,6 +280,27 @@ type BulkIndexerResponseItem struct {
 	} `json:"error,omitempty"`
 }
 
+// BulkIndexerItemError wraps an item-level bulk failure and provides
+// access to the corresponding Elasticsearch response item.
+type BulkIndexerItemError struct {
+	Item BulkIndexerResponseItem
+	Err  error
+}
+
+func (e BulkIndexerItemError) Error() string {
+	if e.Err != nil {
+		return e.Err.Error()
+	}
+	if e.Item.Error.Type != "" || e.Item.Error.Reason != "" {
+		return fmt.Sprintf("status=%d type=%s reason=%s", e.Item.Status, e.Item.Error.Type, e.Item.Error.Reason)
+	}
+	return fmt.Sprintf("status=%d", e.Item.Status)
+}
+
+func (e BulkIndexerItemError) Unwrap() error {
+	return e.Err
+}
+
 // BulkResponseJSONDecoder defines the interface for custom JSON decoders.
 type BulkResponseJSONDecoder interface {
 	UnmarshalFromReader(io.Reader, *BulkIndexerResponse) error
@@ -287,7 +308,7 @@ type BulkResponseJSONDecoder interface {
 
 // BulkIndexerDebugLogger defines the interface for a debugging logger.
 type BulkIndexerDebugLogger interface {
-	Printf(string, ...interface{})
+	Printf(string, ...any)
 }
 
 type bulkIndexer struct {
@@ -793,7 +814,13 @@ func (w *worker) flushBuffer(ctx context.Context) error {
 		if info.Error.Type != "" || info.Status > 201 {
 			atomic.AddUint64(&w.bi.stats.numFailed, 1)
 			if item.OnFailure != nil {
-				item.OnFailure(item.ctx, item, info, nil)
+				itemErr := BulkIndexerItemError{Item: info}
+				if info.Error.Type != "" || info.Error.Reason != "" {
+					itemErr.Err = fmt.Errorf("%s: %s", info.Error.Type, info.Error.Reason)
+				} else {
+					itemErr.Err = fmt.Errorf("status: %d", info.Status)
+				}
+				item.OnFailure(item.ctx, item, info, itemErr)
 			}
 		} else {
 			atomic.AddUint64(&w.bi.stats.numFlushed, 1)

--- a/esutil/bulk_indexer_internal_test.go
+++ b/esutil/bulk_indexer_internal_test.go
@@ -604,6 +604,7 @@ func TestBulkIndexer(t *testing.T) {
 			failedIDs            []string
 			successfulItemBodies []string
 			failedItemBodies     []string
+			failureErrs          []error
 
 			numItems       = 4
 			numFailed      = 2
@@ -641,9 +642,10 @@ func TestBulkIndexer(t *testing.T) {
 			}
 			successfulItemBodies = append(successfulItemBodies, string(buf))
 		}
-		failureFunc := func(_ context.Context, item BulkIndexerItem, _ BulkIndexerResponseItem, _ error) {
+		failureFunc := func(_ context.Context, item BulkIndexerItem, _ BulkIndexerResponseItem, err error) {
 			atomic.AddUint64(&countFailed, 1)
 			failedIDs = append(failedIDs, item.DocumentID)
+			failureErrs = append(failureErrs, err)
 
 			buf, rerr := io.ReadAll(item.Body)
 			if rerr != nil {
@@ -741,6 +743,39 @@ func TestBulkIndexer(t *testing.T) {
 
 		if !reflect.DeepEqual(failedItemBodies, []string{`{"title":"bar"}`, `{"title":"baz"}`}) {
 			t.Errorf("Unexpected failedItemBodies: %#v", failedItemBodies)
+		}
+
+		if len(failureErrs) != numFailed {
+			t.Fatalf("Unexpected failure errors: want=%d, got=%d", numFailed, len(failureErrs))
+		}
+
+		for i, failureErr := range failureErrs {
+			var itemErr BulkIndexerItemError
+			if !errors.As(failureErr, &itemErr) {
+				t.Fatalf("Unexpected failure error type for failed item %d: %T", i, failureErr)
+			}
+			if itemErr.Item.DocumentID != failedIDs[i] {
+				t.Errorf("Unexpected failed item id at %d: want=%s, got=%s", i, failedIDs[i], itemErr.Item.DocumentID)
+			}
+		}
+
+		var firstErr BulkIndexerItemError
+		if !errors.As(failureErrs[0], &firstErr) {
+			t.Fatalf("Unexpected first failure error type: %T", failureErrs[0])
+		}
+		if firstErr.Item.Status != http.StatusConflict {
+			t.Errorf("Unexpected first failure status: want=%d, got=%d", http.StatusConflict, firstErr.Item.Status)
+		}
+		if firstErr.Item.Error.Type == "" {
+			t.Errorf("Expected first failure error type to be populated")
+		}
+
+		var secondErr BulkIndexerItemError
+		if !errors.As(failureErrs[1], &secondErr) {
+			t.Fatalf("Unexpected second failure error type: %T", failureErrs[1])
+		}
+		if secondErr.Item.Status != http.StatusNotFound {
+			t.Errorf("Unexpected second failure status: want=%d, got=%d", http.StatusNotFound, secondErr.Item.Status)
 		}
 	})
 


### PR DESCRIPTION
## Summary
Part of #1428 (PR 2/3).

Adds response context to per-item bulk indexer failures so callers can inspect the failed item details via errors. As, while preserving existing callback flow and behavior.

## What changed

- Exported additive error type.
- Updated the bulk flush item-failure path to pass the error into OnFailure.
- 

## Compatibility
- No exported API changes.
- No signature changes.
- This is additive: consumers can opt in to richer inspection using errors.As(err, *BulkIndexerItemError).
- 

## Testing
```
make lint && make test-unit
```


