### PR TITLE
test: centralize mock transport across tests and benchmarks

### DIFF
--- a/elasticsearch_benchmark_test.go
+++ b/elasticsearch_benchmark_test.go
@@ -31,6 +31,7 @@ import (
 	"github.com/elastic/elastic-transport-go/v8/elastictransport"
 	"github.com/elastic/go-elasticsearch/v9"
 	"github.com/elastic/go-elasticsearch/v9/esapi"
+	"github.com/elastic/go-elasticsearch/v9/internal/test/mocktransport"
 	"github.com/elastic/go-elasticsearch/v9/typedapi/esdsl"
 	"github.com/elastic/go-elasticsearch/v9/typedapi/types"
 )
@@ -243,19 +244,10 @@ func BenchmarkClientAPI(b *testing.B) {
 	})
 }
 
-type mockTransp struct {
-	RoundTripFunc func(request *http.Request) (*http.Response, error)
-}
-
-func (m mockTransp) RoundTrip(request *http.Request) (*http.Response, error) {
-	return m.RoundTripFunc(request)
-}
-
 func BenchmarkAllocsSearch(t *testing.B) {
 	t.Run("struct search", func(b *testing.B) {
 		c, err := elasticsearch.NewTyped(elasticsearch.WithTransportOptions(
-			elastictransport.WithTransport(&mockTransp{
-				RoundTripFunc: func(_ *http.Request) (*http.Response, error) {
+			elastictransport.WithTransport(&mocktransport.Transport{RoundTripFn: func(_ *http.Request) (*http.Response, error) {
 					return &http.Response{
 						Header:     http.Header{"X-Elastic-Product": []string{"Elasticsearch"}},
 						StatusCode: http.StatusOK,
@@ -285,8 +277,7 @@ func BenchmarkAllocsSearch(t *testing.B) {
 
 	t.Run("esdsl search", func(b *testing.B) {
 		c, err := elasticsearch.NewTyped(elasticsearch.WithTransportOptions(
-			elastictransport.WithTransport(&mockTransp{
-				RoundTripFunc: func(_ *http.Request) (*http.Response, error) {
+			elastictransport.WithTransport(&mocktransport.Transport{RoundTripFn: func(_ *http.Request) (*http.Response, error) {
 					return &http.Response{
 						Header:     http.Header{"X-Elastic-Product": []string{"Elasticsearch"}},
 						StatusCode: http.StatusOK,

--- a/elasticsearch_internal_test.go
+++ b/elasticsearch_internal_test.go
@@ -50,15 +50,12 @@ import (
 
 	"github.com/elastic/elastic-transport-go/v8/elastictransport"
 	"github.com/elastic/go-elasticsearch/v9/esapi"
+	"github.com/elastic/go-elasticsearch/v9/internal/test/mocktransport"
 	"github.com/elastic/go-elasticsearch/v9/typedapi/types"
 )
 
 var metaHeaderReValidation = regexp.MustCompile(`^[a-z]{1,}=[a-z0-9\.\-]{1,}(?:,[a-z]{1,}=[a-z0-9\.\-]+)*$`)
 var called bool
-
-type mockTransp struct {
-	RoundTripFunc func(*http.Request) (*http.Response, error)
-}
 
 var defaultRoundTripFunc = func(req *http.Request) (*http.Response, error) {
 	response := &http.Response{Header: http.Header{"X-Elastic-Product": []string{"Elasticsearch"}}}
@@ -77,13 +74,6 @@ var defaultRoundTripFunc = func(req *http.Request) (*http.Response, error) {
 	}
 
 	return response, nil
-}
-
-func (t *mockTransp) RoundTrip(req *http.Request) (*http.Response, error) {
-	if t.RoundTripFunc == nil {
-		return defaultRoundTripFunc(req)
-	}
-	return t.RoundTripFunc(req)
 }
 
 //nolint:gocyclo
@@ -234,7 +224,7 @@ func TestClientConfiguration(t *testing.T) {
 
 func TestClientInterface(t *testing.T) {
 	t.Run("Transport", func(t *testing.T) {
-		c, err := New(WithTransportOptions(elastictransport.WithTransport(&mockTransp{})))
+		c, err := New(WithTransportOptions(elastictransport.WithTransport(&mocktransport.Transport{DefaultRoundTripFn: defaultRoundTripFunc})))
 
 		if err != nil {
 			t.Fatalf("Unexpected error: %s", err)
@@ -509,7 +499,7 @@ func TestResponseCheckOnly(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			c, err := New(WithTransportOptions(
-				elastictransport.WithTransport(&mockTransp{RoundTripFunc: func(_ *http.Request) (*http.Response, error) {
+				elastictransport.WithTransport(&mocktransport.Transport{RoundTripFn: func(_ *http.Request) (*http.Response, error) {
 					return tt.response, tt.requestErr
 				}}),
 			))
@@ -690,8 +680,8 @@ func TestCompatibilityHeader(t *testing.T) {
 			t.Setenv(esCompatHeader, strconv.FormatBool(test.compatibilityHeader))
 
 			opts := []Option{
-				WithTransportOptions(elastictransport.WithTransport(&mockTransp{
-					RoundTripFunc: func(req *http.Request) (*http.Response, error) {
+				WithTransportOptions(elastictransport.WithTransport(&mocktransport.Transport{
+					RoundTripFn: func(req *http.Request) (*http.Response, error) {
 						if test.compatibilityHeader {
 							if !reflect.DeepEqual(req.Header["Accept"], test.expectsHeader) {
 								t.Errorf("Compatibility header enabled but header is, not in request headers, got: %s, want: %s", req.Header["Accept"], test.expectsHeader)
@@ -798,8 +788,8 @@ func TestMetaHeader(t *testing.T) {
 	t.Run("MetaHeader with elastictransport", func(t *testing.T) {
 		tp, err := elastictransport.New(elastictransport.Config{
 			URLs: []*url.URL{{Scheme: "http", Host: "foo"}},
-			Transport: &mockTransp{
-				RoundTripFunc: func(request *http.Request) (*http.Response, error) {
+			Transport: &mocktransport.Transport{
+				RoundTripFn: func(request *http.Request) (*http.Response, error) {
 					h := request.Header.Get(HeaderClientMeta)
 					if !metaHeaderReValidation.MatchString(h) {
 						t.Errorf("expected client metaheader to validate regexp, got: %s", h)
@@ -833,8 +823,8 @@ func TestMetaHeader(t *testing.T) {
 	t.Run("Metaheader with typedclient", func(t *testing.T) {
 		tp, err := elastictransport.New(elastictransport.Config{
 			URLs: []*url.URL{{Scheme: "http", Host: "foo"}},
-			Transport: &mockTransp{
-				RoundTripFunc: func(request *http.Request) (*http.Response, error) {
+			Transport: &mocktransport.Transport{
+				RoundTripFn: func(request *http.Request) (*http.Response, error) {
 					h := request.Header.Get(HeaderClientMeta)
 					if !metaHeaderReValidation.MatchString(h) {
 						t.Errorf("expected client metaheader to validate regexp, got: %s", h)
@@ -869,8 +859,8 @@ func TestMetaHeader(t *testing.T) {
 func TestNewTypedClient(t *testing.T) {
 	tp, err := elastictransport.New(elastictransport.Config{
 		URLs: []*url.URL{{Scheme: "http", Host: "foo"}},
-		Transport: &mockTransp{
-			RoundTripFunc: func(request *http.Request) (*http.Response, error) {
+		Transport: &mocktransport.Transport{
+			RoundTripFn: func(request *http.Request) (*http.Response, error) {
 				h := request.Header.Get(HeaderClientMeta)
 				if !metaHeaderReValidation.MatchString(h) {
 					t.Errorf("expected client metaheader to validate regexp, got: %s", h)
@@ -920,8 +910,8 @@ func toTypedMockTransport(t *testing.T, capture *http.Header) elastictransport.I
 	t.Helper()
 	tp, err := elastictransport.NewClient(
 		elastictransport.WithURLs(&url.URL{Scheme: "http", Host: "foo"}),
-		elastictransport.WithTransport(&mockTransp{
-			RoundTripFunc: func(req *http.Request) (*http.Response, error) {
+		elastictransport.WithTransport(&mocktransport.Transport{
+			RoundTripFn: func(req *http.Request) (*http.Response, error) {
 				if capture != nil {
 					*capture = req.Header.Clone()
 				}
@@ -1054,8 +1044,8 @@ func TestContentTypeOverride(t *testing.T) {
 
 		tp, err := elastictransport.New(elastictransport.Config{
 			URLs: []*url.URL{{Scheme: "http", Host: "foo"}},
-			Transport: &mockTransp{
-				RoundTripFunc: func(request *http.Request) (*http.Response, error) {
+			Transport: &mocktransport.Transport{
+				RoundTripFn: func(request *http.Request) (*http.Response, error) {
 					h := request.Header.Get("Content-Type")
 					if h != contentType {
 						t.Fatalf("unexpected content-type, wanted %s, got: %s", contentType, h)
@@ -1090,8 +1080,8 @@ func TestContentTypeOverride(t *testing.T) {
 
 		tp, err := elastictransport.New(elastictransport.Config{
 			URLs: []*url.URL{{Scheme: "http", Host: "foo"}},
-			Transport: &mockTransp{
-				RoundTripFunc: func(request *http.Request) (*http.Response, error) {
+			Transport: &mocktransport.Transport{
+				RoundTripFn: func(request *http.Request) (*http.Response, error) {
 					h := request.Header.Get("Content-Type")
 					if h != contentType {
 						t.Fatalf("unexpected content-type, wanted %s, got: %s", contentType, h)
@@ -1128,8 +1118,8 @@ func TestContentTypeOverride(t *testing.T) {
 
 		tp, err := elastictransport.New(elastictransport.Config{
 			URLs: []*url.URL{{Scheme: "http", Host: "foo"}},
-			Transport: &mockTransp{
-				RoundTripFunc: func(request *http.Request) (*http.Response, error) {
+			Transport: &mocktransport.Transport{
+				RoundTripFn: func(request *http.Request) (*http.Response, error) {
 					h := request.Header.Get("Content-Type")
 					if h != contentType {
 						t.Fatalf("unexpected content-type, wanted %s, got: %s", contentType, h)
@@ -1388,7 +1378,7 @@ func TestInstrumentation(t *testing.T) {
 				instrument.AfterRequestFunc = test.want.AfterRequestFunc
 
 				es, err := NewTyped(
-					WithTransportOptions(elastictransport.WithTransport(&mockTransp{RoundTripFunc: test.args.roundTripFunc})),
+					WithTransportOptions(elastictransport.WithTransport(&mocktransport.Transport{RoundTripFn: test.args.roundTripFunc})),
 					WithInstrumentation(instrument),
 				)
 				if err != nil {
@@ -1433,7 +1423,7 @@ func TestInstrumentation(t *testing.T) {
 				instrument.AfterRequestFunc = test.want.AfterRequestFunc
 
 				es, err := New(
-					WithTransportOptions(elastictransport.WithTransport(&mockTransp{RoundTripFunc: test.args.roundTripFunc})),
+					WithTransportOptions(elastictransport.WithTransport(&mocktransport.Transport{RoundTripFn: test.args.roundTripFunc})),
 					WithInstrumentation(instrument),
 				)
 				if err != nil {
@@ -1482,15 +1472,15 @@ func TestClose(t *testing.T) {
 		c    func() closeable
 	}{
 		{name: "BaseClient", c: func() closeable {
-			c, _ := NewBase(WithTransportOptions(elastictransport.WithTransport(&mockTransp{})))
+			c, _ := NewBase(WithTransportOptions(elastictransport.WithTransport(&mocktransport.Transport{DefaultRoundTripFn: defaultRoundTripFunc})))
 			return c
 		}},
 		{name: "Client", c: func() closeable {
-			c, _ := New(WithTransportOptions(elastictransport.WithTransport(&mockTransp{})))
+			c, _ := New(WithTransportOptions(elastictransport.WithTransport(&mocktransport.Transport{DefaultRoundTripFn: defaultRoundTripFunc})))
 			return c
 		}},
 		{name: "TypedClient", c: func() closeable {
-			c, _ := NewTyped(WithTransportOptions(elastictransport.WithTransport(&mockTransp{})))
+			c, _ := NewTyped(WithTransportOptions(elastictransport.WithTransport(&mocktransport.Transport{DefaultRoundTripFn: defaultRoundTripFunc})))
 			return c
 		}},
 	}
@@ -1703,7 +1693,7 @@ func TestIntercepts(t *testing.T) {
 			t.Run("typed client", func(t *testing.T) {
 				es, _ := NewTyped(
 					WithTransportOptions(
-						elastictransport.WithTransport(&mockTransp{RoundTripFunc: successTp}),
+						elastictransport.WithTransport(&mocktransport.Transport{RoundTripFn: successTp}),
 						elastictransport.WithInterceptors(tt.args.interceptors...),
 					),
 				)
@@ -1715,7 +1705,7 @@ func TestIntercepts(t *testing.T) {
 			t.Run("low-level client", func(t *testing.T) {
 				es, _ := New(
 					WithTransportOptions(
-						elastictransport.WithTransport(&mockTransp{RoundTripFunc: successTp}),
+						elastictransport.WithTransport(&mocktransport.Transport{RoundTripFn: successTp}),
 						elastictransport.WithInterceptors(tt.args.interceptors...),
 					),
 				)
@@ -1740,7 +1730,7 @@ func (m mockESTransport) Perform(req *http.Request) (*http.Response, error) {
 	if m.PerformFunc != nil {
 		return m.PerformFunc(req)
 	}
-	t := &mockTransp{}
+	t := &mocktransport.Transport{DefaultRoundTripFn: defaultRoundTripFunc}
 	return t.RoundTrip(req)
 }
 

--- a/esapi/esapi_benchmark_test.go
+++ b/esapi/esapi_benchmark_test.go
@@ -28,9 +28,8 @@ import (
 	"github.com/elastic/elastic-transport-go/v8/elastictransport"
 	"github.com/elastic/go-elasticsearch/v9"
 	"github.com/elastic/go-elasticsearch/v9/esapi"
+	"github.com/elastic/go-elasticsearch/v9/internal/test/mocktransport"
 )
-
-// TODO(karmi): Refactor into a shared mock/testing package
 
 var (
 	defaultResponse = &http.Response{
@@ -64,17 +63,9 @@ var (
 	}
 )
 
-type FakeTransport struct {
-	RoundTripFn func(*http.Request) (*http.Response, error)
-}
-
-func (t *FakeTransport) RoundTrip(req *http.Request) (*http.Response, error) {
-	return t.RoundTripFn(req)
-}
-
 func newFakeClient(b *testing.B) *elasticsearch.Client {
 	es, err := elasticsearch.New(
-		elasticsearch.WithTransportOptions(elastictransport.WithTransport(&FakeTransport{RoundTripFn: defaultRoundTripFn})),
+		elasticsearch.WithTransportOptions(elastictransport.WithTransport(&mocktransport.Transport{RoundTripFn: defaultRoundTripFn})),
 	)
 
 	if err != nil {
@@ -86,7 +77,7 @@ func newFakeClient(b *testing.B) *elasticsearch.Client {
 
 func newFakeClientWithError(b *testing.B) *elasticsearch.Client {
 	es, err := elasticsearch.New(
-		elasticsearch.WithTransportOptions(elastictransport.WithTransport(&FakeTransport{RoundTripFn: errorRoundTripFn})),
+		elasticsearch.WithTransportOptions(elastictransport.WithTransport(&mocktransport.Transport{RoundTripFn: errorRoundTripFn})),
 	)
 
 	if err != nil {

--- a/esutil/bulk_indexer_benchmark_test.go
+++ b/esutil/bulk_indexer_benchmark_test.go
@@ -30,6 +30,7 @@ import (
 	"testing"
 
 	"github.com/elastic/go-elasticsearch/v9"
+	"github.com/elastic/go-elasticsearch/v9/internal/test/mocktransport"
 	"github.com/elastic/go-elasticsearch/v9/esutil"
 )
 
@@ -52,19 +53,17 @@ var mockResponseBody = `{
   ]
 }`
 
-type mockTransp struct{}
-
-func (t *mockTransp) RoundTrip(_ *http.Request) (*http.Response, error) {
-	return &http.Response{Body: io.NopCloser(strings.NewReader(mockResponseBody))}, nil // 1x alloc
-}
-
 func BenchmarkBulkIndexer(b *testing.B) {
 	b.ReportAllocs()
 
 	b.Run("Basic", func(b *testing.B) {
 		b.ResetTimer()
 
-		es, err := elasticsearch.NewClient(elasticsearch.Config{Transport: &mockTransp{}})
+		es, err := elasticsearch.NewClient(elasticsearch.Config{Transport: &mocktransport.Transport{
+			RoundTripFn: func(_ *http.Request) (*http.Response, error) {
+				return &http.Response{Body: io.NopCloser(strings.NewReader(mockResponseBody))}, nil // 1x alloc
+			},
+		}})
 		if err != nil {
 			b.Fatalf("Unexpected error: %s", err)
 		}

--- a/esutil/bulk_indexer_internal_test.go
+++ b/esutil/bulk_indexer_internal_test.go
@@ -43,21 +43,11 @@ import (
 
 	"github.com/elastic/go-elasticsearch/v9"
 	"github.com/elastic/go-elasticsearch/v9/esapi"
+	"github.com/elastic/go-elasticsearch/v9/internal/test/mocktransport"
 )
 
 var defaultRoundTripFunc = func(*http.Request) (*http.Response, error) {
 	return &http.Response{Body: io.NopCloser(strings.NewReader(`{}`))}, nil
-}
-
-type mockTransport struct {
-	RoundTripFunc func(*http.Request) (*http.Response, error)
-}
-
-func (t *mockTransport) RoundTrip(req *http.Request) (*http.Response, error) {
-	if t.RoundTripFunc == nil {
-		return defaultRoundTripFunc(req)
-	}
-	return t.RoundTripFunc(req)
 }
 
 //nolint:gocyclo
@@ -92,8 +82,8 @@ func TestBulkIndexer(t *testing.T) {
 					numItems  = 6
 				)
 
-				es, err := tt.makeClient(elasticsearch.Config{Transport: &mockTransport{
-					RoundTripFunc: func(*http.Request) (*http.Response, error) {
+				es, err := tt.makeClient(elasticsearch.Config{Transport: &mocktransport.Transport{
+					RoundTripFn: func(*http.Request) (*http.Response, error) {
 						countReqs++
 						switch countReqs {
 						case 1:
@@ -227,7 +217,7 @@ func TestBulkIndexer(t *testing.T) {
 	})
 
 	t.Run("ClientProvidedNotClosed", func(t *testing.T) {
-		es, err := elasticsearch.New(elasticsearch.WithTransportOptions(elastictransport.WithTransport(&mockTransport{})))
+		es, err := elasticsearch.New(elasticsearch.WithTransportOptions(elastictransport.WithTransport(&mocktransport.Transport{DefaultRoundTripFn: defaultRoundTripFunc})))
 		if err != nil {
 			t.Fatalf("New: %s", err)
 		}
@@ -314,7 +304,7 @@ func TestBulkIndexer(t *testing.T) {
 		for _, tt := range tests {
 			tt := tt
 			t.Run(tt.name, func(t *testing.T) {
-				es, err := elasticsearch.NewClient(elasticsearch.Config{Transport: &mockTransport{}})
+				es, err := elasticsearch.NewClient(elasticsearch.Config{Transport: &mocktransport.Transport{DefaultRoundTripFn: defaultRoundTripFunc}})
 				if err != nil {
 					t.Fatalf("Unexpected error: %s", err)
 				}
@@ -350,7 +340,7 @@ func TestBulkIndexer(t *testing.T) {
 	})
 
 	t.Run("Add() Timeout", func(t *testing.T) {
-		es, err := elasticsearch.NewClient(elasticsearch.Config{Transport: &mockTransport{}})
+		es, err := elasticsearch.NewClient(elasticsearch.Config{Transport: &mocktransport.Transport{DefaultRoundTripFn: defaultRoundTripFunc}})
 		if err != nil {
 			t.Fatalf("Unexpected error: %s", err)
 		}
@@ -382,7 +372,7 @@ func TestBulkIndexer(t *testing.T) {
 	})
 
 	t.Run("Close() Cancel", func(t *testing.T) {
-		es, err := elasticsearch.NewClient(elasticsearch.Config{Transport: &mockTransport{}})
+		es, err := elasticsearch.NewClient(elasticsearch.Config{Transport: &mocktransport.Transport{DefaultRoundTripFn: defaultRoundTripFunc}})
 		if err != nil {
 			t.Fatalf("Unexpected error: %s", err)
 		}
@@ -407,7 +397,7 @@ func TestBulkIndexer(t *testing.T) {
 	})
 
 	t.Run("Close() Already Cancelled Context", func(t *testing.T) {
-		es, err := elasticsearch.NewClient(elasticsearch.Config{Transport: &mockTransport{}})
+		es, err := elasticsearch.NewClient(elasticsearch.Config{Transport: &mocktransport.Transport{DefaultRoundTripFn: defaultRoundTripFunc}})
 		if err != nil {
 			t.Fatalf("Unexpected error: %s", err)
 		}
@@ -432,8 +422,8 @@ func TestBulkIndexer(t *testing.T) {
 		release := make(chan struct{})
 		defer close(release)
 
-		es, err := elasticsearch.NewClient(elasticsearch.Config{Transport: &mockTransport{
-			RoundTripFunc: func(*http.Request) (*http.Response, error) {
+		es, err := elasticsearch.NewClient(elasticsearch.Config{Transport: &mocktransport.Transport{
+			RoundTripFn: func(*http.Request) (*http.Response, error) {
 				close(started)
 				<-release
 				return &http.Response{
@@ -495,8 +485,8 @@ func TestBulkIndexer(t *testing.T) {
 
 	t.Run("Indexer Callback", func(t *testing.T) {
 		esCfg := elasticsearch.Config{
-			Transport: &mockTransport{
-				RoundTripFunc: func(*http.Request) (*http.Response, error) {
+			Transport: &mocktransport.Transport{
+				RoundTripFn: func(*http.Request) (*http.Response, error) {
 					return nil, fmt.Errorf("Mock transport error")
 				},
 			},
@@ -544,8 +534,8 @@ func TestBulkIndexer(t *testing.T) {
 
 	t.Run("Indexer Callback invoked once on flush response error", func(t *testing.T) {
 		es, err := elasticsearch.NewClient(elasticsearch.Config{
-			Transport: &mockTransport{
-				RoundTripFunc: func(*http.Request) (*http.Response, error) {
+			Transport: &mocktransport.Transport{
+				RoundTripFn: func(*http.Request) (*http.Response, error) {
 					return &http.Response{
 						StatusCode: http.StatusInternalServerError,
 						Status:     "500 Internal Server Error",
@@ -610,8 +600,8 @@ func TestBulkIndexer(t *testing.T) {
 			bodyContent, _ = os.ReadFile("testdata/bulk_response_2.json")
 		)
 
-		es, err := elasticsearch.NewClient(elasticsearch.Config{Transport: &mockTransport{
-			RoundTripFunc: func(*http.Request) (*http.Response, error) {
+		es, err := elasticsearch.NewClient(elasticsearch.Config{Transport: &mocktransport.Transport{
+			RoundTripFn: func(*http.Request) (*http.Response, error) {
 				return &http.Response{
 					Body:   io.NopCloser(bytes.NewBuffer(bodyContent)),
 					Header: http.Header{"X-Elastic-Product": []string{"Elasticsearch"}},
@@ -746,7 +736,7 @@ func TestBulkIndexer(t *testing.T) {
 
 	t.Run("OnFlush callbacks", func(t *testing.T) {
 		type contextKey string
-		es, err := elasticsearch.NewClient(elasticsearch.Config{Transport: &mockTransport{}})
+		es, err := elasticsearch.NewClient(elasticsearch.Config{Transport: &mocktransport.Transport{DefaultRoundTripFn: defaultRoundTripFunc}})
 		if err != nil {
 			t.Fatalf("Unexpected error: %s", err)
 		}
@@ -788,8 +778,8 @@ func TestBulkIndexer(t *testing.T) {
 	})
 
 	t.Run("Automatic flush", func(t *testing.T) {
-		es, err := elasticsearch.NewClient(elasticsearch.Config{Transport: &mockTransport{
-			RoundTripFunc: func(*http.Request) (*http.Response, error) {
+		es, err := elasticsearch.NewClient(elasticsearch.Config{Transport: &mocktransport.Transport{
+			RoundTripFn: func(*http.Request) (*http.Response, error) {
 				return &http.Response{
 					StatusCode: http.StatusOK,
 					Status:     "200 OK",
@@ -858,8 +848,8 @@ func TestBulkIndexer(t *testing.T) {
 		)
 
 		esCfg := elasticsearch.Config{
-			Transport: &mockTransport{
-				RoundTripFunc: func(*http.Request) (*http.Response, error) {
+			Transport: &mocktransport.Transport{
+				RoundTripFn: func(*http.Request) (*http.Response, error) {
 					countReqs++
 					if countReqs <= 4 {
 						return &http.Response{
@@ -955,8 +945,8 @@ func TestBulkIndexer(t *testing.T) {
 		)
 
 		esCfg := elasticsearch.Config{
-			Transport: &mockTransport{
-				RoundTripFunc: func(*http.Request) (*http.Response, error) {
+			Transport: &mocktransport.Transport{
+				RoundTripFn: func(*http.Request) (*http.Response, error) {
 					return &http.Response{
 						StatusCode: http.StatusTooManyRequests,
 						Status:     "429 TooManyRequests",
@@ -1030,7 +1020,7 @@ func TestBulkIndexer(t *testing.T) {
 	})
 
 	t.Run("JSON Decoder Failure", func(t *testing.T) {
-		es, _ := elasticsearch.NewClient(elasticsearch.Config{Transport: &mockTransport{}})
+		es, _ := elasticsearch.NewClient(elasticsearch.Config{Transport: &mocktransport.Transport{DefaultRoundTripFn: defaultRoundTripFunc}})
 
 		biFailureCallbacksCalled := atomic.Uint32{}
 		bi, _ := NewBulkIndexer(BulkIndexerConfig{
@@ -1076,7 +1066,7 @@ func TestBulkIndexer(t *testing.T) {
 	})
 
 	t.Run("Custom JSON Decoder", func(t *testing.T) {
-		es, err := elasticsearch.NewClient(elasticsearch.Config{Transport: &mockTransport{}})
+		es, err := elasticsearch.NewClient(elasticsearch.Config{Transport: &mocktransport.Transport{DefaultRoundTripFn: defaultRoundTripFunc}})
 		if err != nil {
 			t.Fatalf("Unexpected error: %s", err)
 		}
@@ -1298,8 +1288,8 @@ func TestBulkIndexer(t *testing.T) {
 				esConfig := elasticsearch.Config{
 					DisableMetaHeader: tt.args.disableMetaHeader,
 					Header:            tt.args.header,
-					Transport: &mockTransport{
-						RoundTripFunc: func(request *http.Request) (*http.Response, error) {
+					Transport: &mocktransport.Transport{
+						RoundTripFn: func(request *http.Request) (*http.Response, error) {
 							headerMeta := request.Header.Get(elasticsearch.HeaderClientMeta)
 
 							if !reValidation.MatchString(headerMeta) {
@@ -1354,8 +1344,8 @@ func TestBulkIndexer(t *testing.T) {
 
 	t.Run("Concurrent Flushing", func(_ *testing.T) {
 		esConfig := elasticsearch.Config{
-			Transport: &mockTransport{
-				RoundTripFunc: func(_ *http.Request) (*http.Response, error) {
+			Transport: &mocktransport.Transport{
+				RoundTripFn: func(_ *http.Request) (*http.Response, error) {
 					return &http.Response{
 						StatusCode: http.StatusOK,
 						Status:     "200 OK",
@@ -1396,8 +1386,8 @@ func TestBulkIndexer(t *testing.T) {
 
 	t.Run("Oversized Payload", func(t *testing.T) {
 		esConfig := elasticsearch.Config{
-			Transport: &mockTransport{
-				RoundTripFunc: func(_ *http.Request) (*http.Response, error) {
+			Transport: &mocktransport.Transport{
+				RoundTripFn: func(_ *http.Request) (*http.Response, error) {
 					return &http.Response{
 						StatusCode: http.StatusOK,
 						Status:     "200 OK",
@@ -1438,8 +1428,8 @@ func TestBulkIndexer(t *testing.T) {
 	})
 
 	t.Run("FlushedBytes and FlushedMs", func(t *testing.T) {
-		es, _ := elasticsearch.NewClient(elasticsearch.Config{Transport: &mockTransport{
-			RoundTripFunc: func(*http.Request) (*http.Response, error) {
+		es, _ := elasticsearch.NewClient(elasticsearch.Config{Transport: &mocktransport.Transport{
+			RoundTripFn: func(*http.Request) (*http.Response, error) {
 				time.Sleep(10 * time.Millisecond) // Simulate some latency
 				return &http.Response{
 					StatusCode: http.StatusOK,
@@ -1485,8 +1475,8 @@ func TestBulkIndexer(t *testing.T) {
 	})
 
 	t.Run("FlushedBytes and FlushedMs not recorded on error response", func(t *testing.T) {
-		es, _ := elasticsearch.NewClient(elasticsearch.Config{Transport: &mockTransport{
-			RoundTripFunc: func(*http.Request) (*http.Response, error) {
+		es, _ := elasticsearch.NewClient(elasticsearch.Config{Transport: &mocktransport.Transport{
+			RoundTripFn: func(*http.Request) (*http.Response, error) {
 				return &http.Response{
 					StatusCode: http.StatusInternalServerError,
 					Status:     "500 Internal Server Error",
@@ -1533,8 +1523,8 @@ func TestBulkIndexer(t *testing.T) {
 
 	t.Run("Item not lost after full buffer flush failure", func(t *testing.T) {
 		es, err := elasticsearch.NewClient(elasticsearch.Config{
-			Transport: &mockTransport{
-				RoundTripFunc: func(_ *http.Request) (*http.Response, error) {
+			Transport: &mocktransport.Transport{
+				RoundTripFn: func(_ *http.Request) (*http.Response, error) {
 					return &http.Response{
 						StatusCode: http.StatusInternalServerError,
 						Status:     "500 Internal Server Error",
@@ -1691,8 +1681,8 @@ func TestBulkIndexerUsesClientInstrumentation(t *testing.T) {
 
 	es, err := elasticsearch.NewClient(elasticsearch.Config{
 		Instrumentation: elastictransport.Instrumentation(instr),
-		Transport: &mockTransport{
-			RoundTripFunc: func(req *http.Request) (*http.Response, error) {
+		Transport: &mocktransport.Transport{
+			RoundTripFn: func(req *http.Request) (*http.Response, error) {
 				// If BulkIndexer correctly propagates instrumentation into esapi.BulkRequest,
 				// the request context will carry the value set by Instrumentation.Start().
 				if got := req.Context().Value(bulkIndexerInstrCtxKey); got != "bulk" {
@@ -1762,8 +1752,8 @@ func TestBulkIndexerContextPropagation(t *testing.T) {
 	t.Run("OnSuccess receives Add context", func(t *testing.T) {
 		responseBody := `{"took":1,"errors":false,"items":[{"index":{"_index":"test","_id":"1","_version":1,"result":"created","status":201}}]}`
 
-		es, err := elasticsearch.NewClient(elasticsearch.Config{Transport: &mockTransport{
-			RoundTripFunc: func(_ *http.Request) (*http.Response, error) {
+		es, err := elasticsearch.NewClient(elasticsearch.Config{Transport: &mocktransport.Transport{
+			RoundTripFn: func(_ *http.Request) (*http.Response, error) {
 				return &http.Response{
 					StatusCode: 200,
 					Body:       io.NopCloser(strings.NewReader(responseBody)),
@@ -1811,8 +1801,8 @@ func TestBulkIndexerContextPropagation(t *testing.T) {
 	t.Run("OnFailure receives Add context", func(t *testing.T) {
 		responseBody := `{"took":1,"errors":true,"items":[{"index":{"_index":"test","_id":"1","status":400,"error":{"type":"mapper_parsing_exception","reason":"failed to parse"}}}]}`
 
-		es, err := elasticsearch.NewClient(elasticsearch.Config{Transport: &mockTransport{
-			RoundTripFunc: func(_ *http.Request) (*http.Response, error) {
+		es, err := elasticsearch.NewClient(elasticsearch.Config{Transport: &mocktransport.Transport{
+			RoundTripFn: func(_ *http.Request) (*http.Response, error) {
 				return &http.Response{
 					StatusCode: 200,
 					Body:       io.NopCloser(strings.NewReader(responseBody)),
@@ -1863,8 +1853,8 @@ func TestBulkIndexerFlush(t *testing.T) {
 	t.Run("Basic", func(t *testing.T) {
 		responseBody := `{"took":1,"errors":false,"items":[{"index":{"_index":"test","_id":"1","_version":1,"result":"created","status":201}}]}`
 
-		es, err := elasticsearch.NewClient(elasticsearch.Config{Transport: &mockTransport{
-			RoundTripFunc: func(_ *http.Request) (*http.Response, error) {
+		es, err := elasticsearch.NewClient(elasticsearch.Config{Transport: &mocktransport.Transport{
+			RoundTripFn: func(_ *http.Request) (*http.Response, error) {
 				return &http.Response{
 					StatusCode: 200,
 					Body:       io.NopCloser(strings.NewReader(responseBody)),
@@ -1922,7 +1912,7 @@ func TestBulkIndexerFlush(t *testing.T) {
 	})
 
 	t.Run("Empty", func(t *testing.T) {
-		es, err := elasticsearch.NewClient(elasticsearch.Config{Transport: &mockTransport{}})
+		es, err := elasticsearch.NewClient(elasticsearch.Config{Transport: &mocktransport.Transport{DefaultRoundTripFn: defaultRoundTripFunc}})
 		if err != nil {
 			t.Fatalf("Unexpected error: %s", err)
 		}
@@ -1946,7 +1936,7 @@ func TestBulkIndexerFlush(t *testing.T) {
 	})
 
 	t.Run("AfterClose", func(t *testing.T) {
-		es, err := elasticsearch.NewClient(elasticsearch.Config{Transport: &mockTransport{}})
+		es, err := elasticsearch.NewClient(elasticsearch.Config{Transport: &mocktransport.Transport{DefaultRoundTripFn: defaultRoundTripFunc}})
 		if err != nil {
 			t.Fatalf("Unexpected error: %s", err)
 		}
@@ -1972,8 +1962,8 @@ func TestBulkIndexerFlush(t *testing.T) {
 	t.Run("ContextCancelled", func(t *testing.T) {
 		release := make(chan struct{})
 
-		es, err := elasticsearch.NewClient(elasticsearch.Config{Transport: &mockTransport{
-			RoundTripFunc: func(_ *http.Request) (*http.Response, error) {
+		es, err := elasticsearch.NewClient(elasticsearch.Config{Transport: &mocktransport.Transport{
+			RoundTripFn: func(_ *http.Request) (*http.Response, error) {
 				<-release
 				body := `{"took":1,"errors":false,"items":[{"index":{"_index":"test","_id":"1","_version":1,"result":"created","status":201}}]}`
 				return &http.Response{
@@ -2018,8 +2008,8 @@ func TestBulkIndexerFlush(t *testing.T) {
 	})
 
 	t.Run("ConcurrentWithAdd", func(t *testing.T) {
-		es, err := elasticsearch.NewClient(elasticsearch.Config{Transport: &mockTransport{
-			RoundTripFunc: func(_ *http.Request) (*http.Response, error) {
+		es, err := elasticsearch.NewClient(elasticsearch.Config{Transport: &mocktransport.Transport{
+			RoundTripFn: func(_ *http.Request) (*http.Response, error) {
 				body := `{"took":1,"errors":false,"items":[{"index":{"_index":"test","_id":"1","_version":1,"result":"created","status":201}}]}`
 				return &http.Response{
 					StatusCode: 200,
@@ -2075,8 +2065,8 @@ func TestBulkIndexerFlush(t *testing.T) {
 	})
 
 	t.Run("ConcurrentFlushes", func(t *testing.T) {
-		es, err := elasticsearch.NewClient(elasticsearch.Config{Transport: &mockTransport{
-			RoundTripFunc: func(_ *http.Request) (*http.Response, error) {
+		es, err := elasticsearch.NewClient(elasticsearch.Config{Transport: &mocktransport.Transport{
+			RoundTripFn: func(_ *http.Request) (*http.Response, error) {
 				body := `{"took":1,"errors":false,"items":[{"index":{"_index":"test","_id":"1","_version":1,"result":"created","status":201}}]}`
 				return &http.Response{
 					StatusCode: 200,
@@ -2114,8 +2104,8 @@ func TestBulkIndexerFlush(t *testing.T) {
 	})
 
 	t.Run("MultipleSequential", func(t *testing.T) {
-		es, err := elasticsearch.NewClient(elasticsearch.Config{Transport: &mockTransport{
-			RoundTripFunc: func(_ *http.Request) (*http.Response, error) {
+		es, err := elasticsearch.NewClient(elasticsearch.Config{Transport: &mocktransport.Transport{
+			RoundTripFn: func(_ *http.Request) (*http.Response, error) {
 				body := `{"took":1,"errors":false,"items":[{"index":{"_index":"test","_id":"1","_version":1,"result":"created","status":201}}]}`
 				return &http.Response{
 					StatusCode: 200,
@@ -2169,8 +2159,8 @@ func TestBulkIndexerFlush(t *testing.T) {
 	t.Run("MultiWorker", func(t *testing.T) {
 		responseBody := `{"took":1,"errors":false,"items":[{"index":{"_index":"test","_id":"1","_version":1,"result":"created","status":201}}]}`
 
-		es, err := elasticsearch.NewClient(elasticsearch.Config{Transport: &mockTransport{
-			RoundTripFunc: func(_ *http.Request) (*http.Response, error) {
+		es, err := elasticsearch.NewClient(elasticsearch.Config{Transport: &mocktransport.Transport{
+			RoundTripFn: func(_ *http.Request) (*http.Response, error) {
 				return &http.Response{
 					StatusCode: 200,
 					Body:       io.NopCloser(strings.NewReader(responseBody)),
@@ -2266,8 +2256,8 @@ func TestBulkIndexerNextFlushInterval(t *testing.T) {
 func TestBulkIndexerFlushJitter(t *testing.T) {
 	t.Run("auto-flush fires with jitter configured", func(t *testing.T) {
 		es, err := elasticsearch.New(elasticsearch.WithTransportOptions(
-			elastictransport.WithTransport(&mockTransport{
-				RoundTripFunc: func(*http.Request) (*http.Response, error) {
+			elastictransport.WithTransport(&mocktransport.Transport{
+				RoundTripFn: func(*http.Request) (*http.Response, error) {
 					return &http.Response{
 						StatusCode: http.StatusOK,
 						Status:     "200 OK",
@@ -2311,8 +2301,8 @@ func TestBulkIndexerFlushJitter(t *testing.T) {
 
 	t.Run("default FlushJitter is zero", func(t *testing.T) {
 		es, err := elasticsearch.New(elasticsearch.WithTransportOptions(
-			elastictransport.WithTransport(&mockTransport{
-				RoundTripFunc: func(*http.Request) (*http.Response, error) {
+			elastictransport.WithTransport(&mocktransport.Transport{
+				RoundTripFn: func(*http.Request) (*http.Response, error) {
 					return &http.Response{
 						StatusCode: http.StatusOK,
 						Status:     "200 OK",

--- a/internal/test/mocktransport/mocktransport.go
+++ b/internal/test/mocktransport/mocktransport.go
@@ -1,0 +1,47 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package mocktransport
+
+import "net/http"
+
+// RoundTripFunc is a function adapter for http.RoundTripper.
+type RoundTripFunc func(*http.Request) (*http.Response, error)
+
+// Transport is a mock implementation of http.RoundTripper.
+type Transport struct {
+	RoundTripFn        RoundTripFunc
+	DefaultRoundTripFn RoundTripFunc
+}
+
+// RoundTrip executes the configured round-trip function.
+func (t *Transport) RoundTrip(req *http.Request) (*http.Response, error) {
+	if t.RoundTripFn != nil {
+		return t.RoundTripFn(req)
+	}
+
+	if t.DefaultRoundTripFn != nil {
+		return t.DefaultRoundTripFn(req)
+	}
+
+	return nil, nil
+}
+
+// Perform executes the configured round-trip function.
+func (t *Transport) Perform(req *http.Request) (*http.Response, error) {
+	return t.RoundTrip(req)
+}

--- a/options_test.go
+++ b/options_test.go
@@ -30,6 +30,7 @@ import (
 	"testing"
 
 	"github.com/elastic/elastic-transport-go/v8/elastictransport"
+	"github.com/elastic/go-elasticsearch/v9/internal/test/mocktransport"
 )
 
 func TestNew_DefaultClient(t *testing.T) {
@@ -170,8 +171,7 @@ func TestNew_WithBasicAuth(t *testing.T) {
 	c, err := New(
 		WithBasicAuth("testuser", "testpass"),
 		WithTransportOptions(
-			elastictransport.WithTransport(&mockTransp{
-				RoundTripFunc: func(req *http.Request) (*http.Response, error) {
+			elastictransport.WithTransport(&mocktransport.Transport{RoundTripFn: func(req *http.Request) (*http.Response, error) {
 					capturedReq = req
 					return &http.Response{
 						StatusCode: http.StatusOK,
@@ -210,8 +210,7 @@ func TestNew_WithAPIKey(t *testing.T) {
 	c, err := New(
 		WithAPIKey("dGVzdGtleQ=="),
 		WithTransportOptions(
-			elastictransport.WithTransport(&mockTransp{
-				RoundTripFunc: func(req *http.Request) (*http.Response, error) {
+			elastictransport.WithTransport(&mocktransport.Transport{RoundTripFn: func(req *http.Request) (*http.Response, error) {
 					capturedReq = req
 					return &http.Response{
 						StatusCode: http.StatusOK,
@@ -242,7 +241,7 @@ func TestNew_WithTransportOptions(t *testing.T) {
 
 	c, err := New(
 		WithTransportOptions(
-			elastictransport.WithTransport(&mockTransp{}),
+			elastictransport.WithTransport(&mocktransport.Transport{DefaultRoundTripFn: defaultRoundTripFunc}),
 			elastictransport.WithMaxRetries(5),
 		),
 	)
@@ -263,8 +262,7 @@ func TestNew_WithCompatibilityMode(t *testing.T) {
 	c, err := New(
 		WithCompatibilityMode(),
 		WithTransportOptions(
-			elastictransport.WithTransport(&mockTransp{
-				RoundTripFunc: func(req *http.Request) (*http.Response, error) {
+			elastictransport.WithTransport(&mocktransport.Transport{RoundTripFn: func(req *http.Request) (*http.Response, error) {
 					capturedReq = req
 					return &http.Response{
 						StatusCode: http.StatusOK,
@@ -302,8 +300,7 @@ func TestNew_WithCompatibilityModeEnv(t *testing.T) {
 
 	c, err := New(
 		WithTransportOptions(
-			elastictransport.WithTransport(&mockTransp{
-				RoundTripFunc: func(_ *http.Request) (*http.Response, error) {
+			elastictransport.WithTransport(&mocktransport.Transport{RoundTripFn: func(_ *http.Request) (*http.Response, error) {
 					return &http.Response{
 						StatusCode: http.StatusOK,
 						Header:     http.Header{"X-Elastic-Product": []string{"Elasticsearch"}},
@@ -335,8 +332,7 @@ func TestNew_WithDisableMetaHeader(t *testing.T) {
 	c, err := New(
 		WithDisableMetaHeader(),
 		WithTransportOptions(
-			elastictransport.WithTransport(&mockTransp{
-				RoundTripFunc: func(req *http.Request) (*http.Response, error) {
+			elastictransport.WithTransport(&mocktransport.Transport{RoundTripFn: func(req *http.Request) (*http.Response, error) {
 					capturedReq = req
 					return &http.Response{
 						StatusCode: http.StatusOK,
@@ -366,8 +362,7 @@ func TestNew_MetaHeader(t *testing.T) {
 
 	c, err := New(
 		WithTransportOptions(
-			elastictransport.WithTransport(&mockTransp{
-				RoundTripFunc: func(req *http.Request) (*http.Response, error) {
+			elastictransport.WithTransport(&mocktransport.Transport{RoundTripFn: func(req *http.Request) (*http.Response, error) {
 					h := req.Header.Get(HeaderClientMeta)
 					if !metaHeaderReValidation.MatchString(h) {
 						t.Errorf("expected meta header to match regexp, got: %s", h)
@@ -411,8 +406,7 @@ func TestNewTyped_MetaHeader(t *testing.T) {
 
 	c, err := NewTyped(
 		WithTransportOptions(
-			elastictransport.WithTransport(&mockTransp{
-				RoundTripFunc: func(req *http.Request) (*http.Response, error) {
+			elastictransport.WithTransport(&mocktransport.Transport{RoundTripFn: func(req *http.Request) (*http.Response, error) {
 					h := req.Header.Get(HeaderClientMeta)
 					if !metaHeaderReValidation.MatchString(h) {
 						t.Errorf("expected meta header to match regexp, got: %s", h)
@@ -452,7 +446,7 @@ func TestNew_Close(t *testing.T) {
 	t.Parallel()
 	c, err := New(
 		WithTransportOptions(
-			elastictransport.WithTransport(&mockTransp{}),
+			elastictransport.WithTransport(&mocktransport.Transport{DefaultRoundTripFn: defaultRoundTripFunc}),
 		),
 	)
 	if err != nil {
@@ -495,7 +489,7 @@ func TestNewBase_Close(t *testing.T) {
 	t.Parallel()
 	c, err := NewBase(
 		WithTransportOptions(
-			elastictransport.WithTransport(&mockTransp{}),
+			elastictransport.WithTransport(&mocktransport.Transport{DefaultRoundTripFn: defaultRoundTripFunc}),
 		),
 	)
 	if err != nil {
@@ -514,7 +508,7 @@ func TestNewTyped_Close(t *testing.T) {
 	t.Parallel()
 	c, err := NewTyped(
 		WithTransportOptions(
-			elastictransport.WithTransport(&mockTransp{}),
+			elastictransport.WithTransport(&mocktransport.Transport{DefaultRoundTripFn: defaultRoundTripFunc}),
 		),
 	)
 	if err != nil {

--- a/typedapi/esql/query/helpers_test.go
+++ b/typedapi/esql/query/helpers_test.go
@@ -27,6 +27,8 @@ import (
 	"reflect"
 	"strings"
 	"testing"
+
+	"github.com/elastic/go-elasticsearch/v9/internal/test/mocktransport"
 )
 
 type Doc struct {
@@ -259,10 +261,6 @@ var testPayload = `{
   ]
 }`
 
-type mockTransp struct {
-	RoundTripFunc func(*http.Request) (*http.Response, error)
-}
-
 var successfullRoundTripFunc = func(*http.Request) (*http.Response, error) {
 	res := &http.Response{}
 	res.Header = http.Header{}
@@ -285,13 +283,6 @@ var customErrorRoundTripFunc = func(*http.Request) (*http.Response, error) {
 	return nil, fmt.Errorf("something really bad happened")
 }
 
-func (t mockTransp) Perform(request *http.Request) (*http.Response, error) {
-	if t.RoundTripFunc == nil {
-		return successfullRoundTripFunc(request)
-	}
-	return t.RoundTripFunc(request)
-}
-
 func TestHelper(t *testing.T) {
 	type args struct {
 		ctx       context.Context
@@ -309,7 +300,7 @@ func TestHelper(t *testing.T) {
 			args: args{
 				ctx: context.Background(),
 				esqlQuery: &Query{
-					transport: mockTransp{},
+					transport: &mocktransport.Transport{DefaultRoundTripFn: successfullRoundTripFunc},
 					values:    make(url.Values),
 					headers:   make(http.Header),
 					buf:       bytes.NewBuffer(nil),
@@ -351,7 +342,7 @@ func TestHelper(t *testing.T) {
 			args: args{
 				ctx: context.Background(),
 				esqlQuery: &Query{
-					transport: mockTransp{badPayloadRoundTripFunc},
+					transport: &mocktransport.Transport{RoundTripFn: badPayloadRoundTripFunc},
 					values:    make(url.Values),
 					headers:   make(http.Header),
 					buf:       bytes.NewBuffer(nil),
@@ -367,7 +358,7 @@ func TestHelper(t *testing.T) {
 			args: args{
 				ctx: context.Background(),
 				esqlQuery: &Query{
-					transport: mockTransp{customErrorRoundTripFunc},
+					transport: &mocktransport.Transport{RoundTripFn: customErrorRoundTripFunc},
 					values:    make(url.Values),
 					headers:   make(http.Header),
 					buf:       bytes.NewBuffer(nil),
@@ -411,7 +402,7 @@ func TestNewIteratorHelper(t *testing.T) {
 			args: args{
 				ctx: context.Background(),
 				query: &Query{
-					transport: mockTransp{},
+					transport: &mocktransport.Transport{DefaultRoundTripFn: successfullRoundTripFunc},
 					values:    make(url.Values),
 					headers:   make(http.Header),
 					buf:       bytes.NewBuffer(nil),
@@ -453,7 +444,7 @@ func TestNewIteratorHelper(t *testing.T) {
 			args: args{
 				ctx: context.Background(),
 				query: &Query{
-					transport: mockTransp{badPayloadRoundTripFunc},
+					transport: &mocktransport.Transport{RoundTripFn: badPayloadRoundTripFunc},
 					values:    make(url.Values),
 					headers:   make(http.Header),
 					buf:       bytes.NewBuffer(nil),
@@ -469,7 +460,7 @@ func TestNewIteratorHelper(t *testing.T) {
 			args: args{
 				ctx: context.Background(),
 				query: &Query{
-					transport: mockTransp{customErrorRoundTripFunc},
+					transport: &mocktransport.Transport{RoundTripFn: customErrorRoundTripFunc},
 					values:    make(url.Values),
 					headers:   make(http.Header),
 					buf:       bytes.NewBuffer(nil),


### PR DESCRIPTION
## Summary
Part of #1428 (PR 3/3).

This PR consolidates duplicated mock transport implementations used in tests and benchmarks into a single shared internal helper.

## Testing
```
make lint && make test-unit
```