### PR TITLE
fix(esutil): omit empty routing query param in BulkIndexer

### DIFF
--- a/esutil/bulk_indexer.go
+++ b/esutil/bulk_indexer.go
@@ -724,7 +724,6 @@ func (w *worker) flushBuffer(ctx context.Context) error {
 
 		Pipeline:            w.bi.config.Pipeline,
 		Refresh:             w.bi.config.Refresh,
-		Routing:             strings.Split(w.bi.config.Routing, ","),
 		Source:              w.bi.config.Source,
 		SourceExcludes:      w.bi.config.SourceExcludes,
 		SourceIncludes:      w.bi.config.SourceIncludes,
@@ -736,6 +735,9 @@ func (w *worker) flushBuffer(ctx context.Context) error {
 		ErrorTrace: w.bi.config.ErrorTrace,
 		FilterPath: w.bi.config.FilterPath,
 		Header:     w.bi.config.Header.Clone(),
+	}
+	if w.bi.config.Routing != "" {
+		req.Routing = strings.Split(w.bi.config.Routing, ",")
 	}
 	if w.bi.config.RequireAlias {
 		req.RequireAlias = &w.bi.config.RequireAlias

--- a/esutil/bulk_indexer_internal_test.go
+++ b/esutil/bulk_indexer_internal_test.go
@@ -29,6 +29,7 @@ import (
 	"io"
 	"log"
 	"net/http"
+	"net/url"
 	"os"
 	"reflect"
 	"regexp"
@@ -378,6 +379,65 @@ func TestBulkIndexer(t *testing.T) {
 		}
 		if !gotError {
 			t.Errorf("Expected timeout error, but none in: %q", errs)
+		}
+	})
+
+	t.Run("Routing query parameter", func(t *testing.T) {
+		tests := []struct {
+			name        string
+			routing     string
+			wantPresent bool
+			wantValue   string
+		}{
+			{name: "unset omits routing param", routing: "", wantPresent: false},
+			{name: "set sends routing param", routing: "abc", wantPresent: true, wantValue: "abc"},
+		}
+		for _, tt := range tests {
+			tt := tt
+			t.Run(tt.name, func(t *testing.T) {
+				var gotQuery url.Values
+				es, err := elasticsearch.NewClient(elasticsearch.Config{Transport: &mockTransport{
+					RoundTripFunc: func(req *http.Request) (*http.Response, error) {
+						gotQuery = req.URL.Query()
+						return &http.Response{
+							StatusCode: http.StatusOK,
+							Body:       io.NopCloser(strings.NewReader("{}")),
+							Header:     http.Header{"X-Elastic-Product": []string{"Elasticsearch"}},
+						}, nil
+					},
+				}})
+				if err != nil {
+					t.Fatalf("Unexpected error: %s", err)
+				}
+
+				bi, err := NewBulkIndexer(BulkIndexerConfig{
+					NumWorkers: 1,
+					Index:      "test-index",
+					Routing:    tt.routing,
+					Client:     es,
+				})
+				if err != nil {
+					t.Fatalf("Unexpected error: %s", err)
+				}
+
+				if err := bi.Add(context.Background(), BulkIndexerItem{
+					Action: "index",
+					Body:   strings.NewReader(`{"x":1}`),
+				}); err != nil {
+					t.Fatalf("Unexpected error: %s", err)
+				}
+				if err := bi.Close(context.Background()); err != nil {
+					t.Fatalf("Unexpected error: %s", err)
+				}
+
+				_, present := gotQuery["routing"]
+				if present != tt.wantPresent {
+					t.Errorf("routing param present = %v, want %v (query: %q)", present, tt.wantPresent, gotQuery.Encode())
+				}
+				if tt.wantPresent && gotQuery.Get("routing") != tt.wantValue {
+					t.Errorf("routing = %q, want %q", gotQuery.Get("routing"), tt.wantValue)
+				}
+			})
 		}
 	})
 

--- a/esutil/bulk_indexer_internal_test.go
+++ b/esutil/bulk_indexer_internal_test.go
@@ -396,7 +396,7 @@ func TestBulkIndexer(t *testing.T) {
 			tt := tt
 			t.Run(tt.name, func(t *testing.T) {
 				var gotQuery url.Values
-				es, err := elasticsearch.NewClient(elasticsearch.Config{Transport: &mockTransport{
+				es, err := elasticsearch.New(elasticsearch.WithTransportOptions(elastictransport.WithTransport(&mockTransport{
 					RoundTripFunc: func(req *http.Request) (*http.Response, error) {
 						gotQuery = req.URL.Query()
 						return &http.Response{
@@ -405,7 +405,7 @@ func TestBulkIndexer(t *testing.T) {
 							Header:     http.Header{"X-Elastic-Product": []string{"Elasticsearch"}},
 						}, nil
 					},
-				}})
+				})))
 				if err != nil {
 					t.Fatalf("Unexpected error: %s", err)
 				}


### PR DESCRIPTION
## What

When `BulkIndexerConfig.Routing` is left at its default (`""`), `esutil.BulkIndexer` sends an empty `routing=` query parameter on every `_bulk` request. Stateful Elasticsearch tolerates it, but Serverless validates query params strictly and rejects the request with a `400`:

> Parameter validation failed for [/{index}/_bulk]: The http parameter [routing] (with value []) is not permitted when running in serverless mode

## Root cause

In `esutil/bulk_indexer.go`, `flushBuffer` built the request with:

```go
Routing: strings.Split(w.bi.config.Routing, ","),
```

`strings.Split("", ",")` returns `[]string{""}` — a slice of length 1, not empty. The generated `esapi/api.bulk.go` guard `if len(r.Routing) > 0` is therefore true, so `params["routing"]` is set to an empty string and sent on the wire.

## Fix

Set `req.Routing` only when `config.Routing` is non-empty, mirroring how `RequireAlias` is already handled in the same function:

```go
if w.bi.config.Routing != "" {
    req.Routing = strings.Split(w.bi.config.Routing, ",")
}
```

Unset routing now produces a nil slice and no query param. Behavior when routing *is* configured is unchanged.

## Test

Adds a table-driven regression test (`TestBulkIndexer/Routing query parameter`):
- `Routing` unset → no `routing` key in the request query
- `Routing: "abc"` → `routing=abc`

Verified the test fails on the unfixed code (`routing param present = true, want false (query: "routing=")`, matching the issue repro) and passes with the fix. `make lint` clean; full `./esutil/` suite green.

## Notes for reviewers

- Backwards-compatible, non-breaking: no exported API change, only suppresses an empty param that should never have been sent.
- No generated code touched.

Closes #1507
