### PR TITLE
test(gentests): skip flaky x-pack API key invalidate assertion

### DIFF
--- a/internal/build/cmd/generate/commands/gentests/skips.go
+++ b/internal/build/cmd/generate/commands/gentests/skips.go
@@ -47,4 +47,10 @@ eql/10_basic.yml:
   - "eql basic tests"
 security/140_user.yml:
   - "security.user"
+# TODO(https://github.com/elastic/go-elasticsearch/issues/1509): the final
+# assertion 'match: { invalidated_api_keys: [$id] }' fails against current
+# Elasticsearch builds (the invalidate-api-key response no longer matches the
+# stashed key id exactly). Unskip once the upstream test/format is reconciled.
+security/10_api_key_basic.yml:
+  - "API Key"
 `


### PR DESCRIPTION
## What

Adds `security/10_api_key_basic.yml` → `API Key` to the gentests skip list in `internal/build/cmd/generate/commands/gentests/skips.go`.

## Why

The generated YAML-driven test `TestXpack_SecurityApiKeyBasic/API_Key` (sourced from `elasticsearch-clients-tests` `tests/security/10_api_key_basic.yml`) fails in Buildkite on its final assertion:

```
xpack_security__api_key_basic_test.go:929: Expected [invalidated_api_keys] to match '[$id]'
```

```yaml
- do:
    security.invalidate_api_key: { body: { ids: [$id] } }
- match: { invalidated_api_keys: [$id] }
```

The `invalidate_api_key` response's `invalidated_api_keys` array no longer equals the stashed `$id` exactly against current Elasticsearch builds. This is **already red on `main`**, independent of any feature PR, and blocks unrelated PRs' Buildkite gen-tests stage.

## Notes

- Skip carries a `TODO` comment pointing at #1509 for follow-up to reconcile the upstream test/response format and unskip.
- Touches only the generator skip list — no generated output committed (`make gen-tests` runs in Buildkite).
- Verified the package's `init()` still decodes `skipTestsYAML` (no panic), and the skip key/name match the generator's `BaseFilename()` = `security/10_api_key_basic.yml` and `OrigName` = `API Key`.

Refs #1509
