### PR TITLE
chore: update esapi schedule to supported branches

### DIFF
--- a/.github/workflows/generate-esapi.yml
+++ b/.github/workflows/generate-esapi.yml
@@ -41,7 +41,7 @@ jobs:
         run: |
           set -euo pipefail
 
-          input="${{ github.event_name == 'schedule' && 'main,9.4,9.3,9.2,8.19' || inputs.branches }}"
+          input="${{ github.event_name == 'schedule' && 'main,9.4,9.3,8.19' || inputs.branches }}"
 
           # Remove spaces around commas and split into array
           IFS=',' read -ra entries <<< "${input//[[:space:]]/}"


### PR DESCRIPTION
## Summary

Update the `Generate ESAPI Client` scheduled branch list to the currently supported branches.

- **Before:** `main,9.4,9.3,9.2,8.19`
- **After:** `main,9.4,9.3,8.19`

Drops `9.2` (no longer supported). The `schedule:` trigger is currently commented out, so this only affects what runs if/when it is re-enabled. Manual `workflow_dispatch` runs are unaffected (they use the `branches` input).
