### PR TITLE
docs(examples): replace TODO docstring in xkcdsearch

### DIFF
--- a/_examples/xkcdsearch/cmd/xkcd/commands/root.go
+++ b/_examples/xkcdsearch/cmd/xkcd/commands/root.go
@@ -35,7 +35,7 @@ var (
 var rootCmd = &cobra.Command{
 	Use:   "xkcd",
 	Short: "xkcd allows you to index and search xkcd.com",
-	// Long:  "TODO",
+	Long:  "xkcd is an example CLI application demonstrating how to build a search engine for xkcd.com using Elasticsearch in Go.",
 }
 
 func init() {


### PR DESCRIPTION
Fixes #1431. Replaces the placeholder `TODO` docstring with a brief description of the xkcd CLI application example.