### PR TITLE
fix(ci): pin ESAPI generator tooling

### DIFF
--- a/.github/workflows/generate-esapi.yml
+++ b/.github/workflows/generate-esapi.yml
@@ -92,10 +92,13 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v6
         with:
-          go-version-file: go.mod
+          go-version-file: internal/build/go.mod
 
       - name: Install goimports
-        run: go install golang.org/x/tools/cmd/goimports@latest
+        working-directory: internal/build
+        run: |
+          version=$(go list -m -f '{{.Version}}' golang.org/x/tools)
+          go install golang.org/x/tools/cmd/goimports@"${version}"
 
       - name: Derive ES version
         id: es-version


### PR DESCRIPTION
## Summary

- configure the generation workflow from `internal/build/go.mod`
- install the `goimports` version pinned by the generator module instead of `@latest`

## Context

The [ESAPI generation run](https://github.com/elastic/go-elasticsearch/actions/runs/29032226440) failed for 8.19 and 9.3 after `@latest` resolved to `golang.org/x/tools` v0.48.0, which requires Go 1.25.

Using the generator module as the source for both the Go toolchain and `x/tools` version keeps each branch internally consistent. This is also required for 8.19, where the root module supports Go 1.21 but the generator module requires Go 1.24.

## Validation

- `make lint`
- `make test-unit`
