### PR TITLE
fix(ci): remove unnecessary goimports installation

### DIFF
--- a/.github/workflows/generate-esapi.yml
+++ b/.github/workflows/generate-esapi.yml
@@ -94,12 +94,6 @@ jobs:
         with:
           go-version-file: internal/build/go.mod
 
-      - name: Install goimports
-        working-directory: internal/build
-        run: |
-          version=$(go list -m -f '{{.Version}}' golang.org/x/tools)
-          go install golang.org/x/tools/cmd/goimports@"${version}"
-
       - name: Derive ES version
         id: es-version
         run: |

--- a/Makefile
+++ b/Makefile
@@ -452,7 +452,6 @@ endif
 		rm -rf $(output)/*_test.go && \
 		rm -rf $(output)/xpack && \
 		cd internal/build && \
-		go get golang.org/x/tools/cmd/goimports && \
 		go generate ./... && \
 		go run main.go apitests --input '$(PWD)/$(input)/tests/**/*.y*ml' --output '$(PWD)/$(output)' $(args); \
 	}


### PR DESCRIPTION
## Summary

- stop running `go get golang.org/x/tools/cmd/goimports` from `make gen-tests`
- remove the redundant `goimports` installation from the generation workflow

## Context

A follow-up ESAPI generation run still resolved `golang.org/x/tools` v0.48.0 from the `go get` inside `make gen-tests`. That version requires Go 1.25 and cannot be built by the Go 1.24 generator toolchain on 9.3 and 8.19.

The generator uses the `golang.org/x/tools/imports` package through the version pinned in `internal/build/go.mod`. It does not execute the `goimports` binary, so neither command is required.

This change needs backports because the workflow checks out each target branch before running its Makefile.

## Validation

- `go generate ./...` in `internal/build`, with no generated or module-file changes
- `make lint`
- `make test-unit`
