### PR TITLE
ci: remove unnecessary goimports installation (#1550)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -451,7 +451,6 @@ endif
 		rm -rf $(output)/*_test.go && \
 		rm -rf $(output)/xpack && \
 		cd internal/build && \
-		go get golang.org/x/tools/cmd/goimports && \
 		go generate ./... && \
 		go run main.go apitests --input '$(PWD)/$(input)/tests/**/*.y*ml' --output '$(PWD)/$(output)' $(args); \
 	}


### PR DESCRIPTION
(cherry picked from commit e06041b9da5ebe337d332ed5241e3dbfbe1b6701)
