### PR TITLE
ci: pin apidiff to go1.25-compatible x/exp version

### DIFF
--- a/.github/workflows/apidiff-pr.yml
+++ b/.github/workflows/apidiff-pr.yml
@@ -30,7 +30,9 @@ jobs:
           go-version-file: go.mod
 
       - name: Install apidiff
-        run: go install golang.org/x/exp/cmd/apidiff@latest
+        # Pinned to the last golang.org/x/exp commit whose go.mod allows the
+        # Go version in this repo's go.mod (newer commits require go >= 1.26).
+        run: go install golang.org/x/exp/cmd/apidiff@v0.0.0-20260820122028-d6e0b57b1a69
 
       - name: Run apidiff
         id: apidiff


### PR DESCRIPTION
The apidiff job on #1575 fails at the install step:

```
go: golang.org/x/exp/cmd/apidiff@latest: golang.org/x/exp@v0.0.0-20260824195058-e88cd73687aa requires go >= 1.26.0 (running go 1.25.12; GOTOOLCHAIN=local)
```

`golang.org/x/exp` bumped its go directive to 1.26 on 2026-08-20 (golang/exp@ca536658362e), while this branch's go.mod pins go 1.25 / toolchain go1.25.12, which we can't bump. This pins the apidiff install to `v0.0.0-20260820122028-d6e0b57b1a69`, the parent of that bump commit; its go.mod requires go 1.25.0.

Once the branch moves to Go 1.26+, the pin can be dropped back to `@latest` (or bumped forward).
