### PR TITLE
docs: sync required Go version in CONTRIBUTING with go.mod (1.25)

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -13,7 +13,7 @@ before we can accept pull requests from you.
 
 ### Prerequisites
 
-You need at least Go 1.21 to build the project.
+You need at least Go 1.25 to build the project.
 
 Docker is used for some tests to spawn an Elasticsearch server.
 


### PR DESCRIPTION
## Summary
- `go.mod` requires `go 1.25.0`, but `CONTRIBUTING.md` stated **Go 1.21** as the minimum version to build.
- Updates CONTRIBUTING.md to require **Go 1.25**, matching the actual toolchain directive.

## Why
Anyone following the CONTRIBUTING guide with Go < 1.25 would hit a build failure (`go.mod` requires 1.25.0). Keeping docs in sync with `go.mod` avoids that.

Detected automatically with [driftcheck](https://github.com/yunaremaia/driftcheck) (a small CLI that flags doc/toolchain version drift).

## Test plan
- [x] `driftcheck` reports no remaining Go drift after the change
- [x] Diff is docs-only (single line in CONTRIBUTING.md)