### PR TITLE
fix(esutil): reject expired contexts in BulkIndexer.Add

### DIFF
--- a/esutil/bulk_indexer.go
+++ b/esutil/bulk_indexer.go
@@ -369,6 +369,13 @@ func NewBulkIndexer(cfg BulkIndexerConfig) (BulkIndexer, error) {
 func (bi *bulkIndexer) Add(ctx context.Context, item BulkIndexerItem) error {
 	atomic.AddUint64(&bi.stats.numAdded, 1)
 
+	if err := ctx.Err(); err != nil {
+		if bi.config.OnError != nil {
+			bi.config.OnError(ctx, err)
+		}
+		return err
+	}
+
 	if item.ctx == nil {
 		item.ctx = ctx
 	}

--- a/esutil/bulk_indexer_internal_test.go
+++ b/esutil/bulk_indexer_internal_test.go
@@ -61,6 +61,18 @@ func (t *mockTransport) RoundTrip(req *http.Request) (*http.Response, error) {
 	return t.RoundTripFunc(req)
 }
 
+type errReadSeeker struct {
+	err error
+}
+
+func (r errReadSeeker) Read(_ []byte) (int, error) {
+	return 0, r.err
+}
+
+func (r errReadSeeker) Seek(_ int64, _ int) (int64, error) {
+	return 0, r.err
+}
+
 //nolint:gocyclo
 func TestBulkIndexer(t *testing.T) {
 	t.Run("Basic", func(t *testing.T) {
@@ -351,34 +363,63 @@ func TestBulkIndexer(t *testing.T) {
 	})
 
 	t.Run("Add() Timeout", func(t *testing.T) {
-		es, err := elasticsearch.NewClient(elasticsearch.Config{Transport: &mockTransport{}})
+		var requestCalls atomic.Uint32
+		es, err := elasticsearch.NewClient(elasticsearch.Config{Transport: &mockTransport{
+			RoundTripFunc: func(*http.Request) (*http.Response, error) {
+				requestCalls.Add(1)
+				return &http.Response{
+					StatusCode: http.StatusOK,
+					Body:       io.NopCloser(strings.NewReader(`{"took":1,"errors":false,"items":[]}`)),
+					Header:     http.Header{"X-Elastic-Product": []string{"Elasticsearch"}},
+				}, nil
+			},
+		}})
 		if err != nil {
 			t.Fatalf("Unexpected error: %s", err)
 		}
-		bi, err := NewBulkIndexer(BulkIndexerConfig{NumWorkers: 1, Client: es})
+
+		var onErrorCalls atomic.Uint32
+		var onError error
+		bi, err := NewBulkIndexer(BulkIndexerConfig{
+			NumWorkers:          1,
+			QueueSizeMultiplier: 10,
+			FlushInterval:       time.Hour,
+			Client:              es,
+			OnError: func(_ context.Context, err error) {
+				onErrorCalls.Add(1)
+				onError = err
+			},
+		})
 		if err != nil {
 			t.Fatalf("Unexpected error: %s", err)
 		}
-		ctx, cancel := context.WithTimeout(context.Background(), time.Nanosecond)
+
+		ctx, cancel := context.WithDeadline(context.Background(), time.Now().Add(-time.Second))
 		defer cancel()
-		time.Sleep(100 * time.Millisecond)
 
-		var errs []error
-		for i := 0; i < 10; i++ {
-			errs = append(errs, bi.Add(ctx, BulkIndexerItem{Action: "delete", DocumentID: "timeout"}))
+		err = bi.Add(ctx, BulkIndexerItem{
+			Action:     "delete",
+			DocumentID: "timeout",
+			Body:       errReadSeeker{err: errors.New("item preparation should not run")},
+		})
+		if !errors.Is(err, context.DeadlineExceeded) {
+			t.Errorf("Expected context.DeadlineExceeded, got: %v", err)
 		}
+		if onErrorCalls.Load() != 1 {
+			t.Errorf("Unexpected OnError callbacks: want=1, got=%d", onErrorCalls.Load())
+		}
+		if !errors.Is(onError, context.DeadlineExceeded) {
+			t.Errorf("Expected OnError to receive context.DeadlineExceeded, got: %v", onError)
+		}
+		if stats := bi.Stats(); stats.NumAdded != 1 {
+			t.Errorf("Unexpected NumAdded: want=1, got=%d", stats.NumAdded)
+		}
+
 		if err := bi.Close(context.Background()); err != nil {
-			t.Errorf("Unexpected error: %s", err)
+			t.Fatalf("Unexpected error: %s", err)
 		}
-
-		var gotError bool
-		for _, err := range errs {
-			if err != nil && err.Error() == "context deadline exceeded" {
-				gotError = true
-			}
-		}
-		if !gotError {
-			t.Errorf("Expected timeout error, but none in: %q", errs)
+		if requestCalls.Load() != 0 {
+			t.Errorf("Unexpected bulk requests: want=0, got=%d", requestCalls.Load())
 		}
 	})
 

--- a/esutil/bulk_indexer_internal_test.go
+++ b/esutil/bulk_indexer_internal_test.go
@@ -364,7 +364,7 @@ func TestBulkIndexer(t *testing.T) {
 
 	t.Run("Add() Timeout", func(t *testing.T) {
 		var requestCalls atomic.Uint32
-		es, err := elasticsearch.NewClient(elasticsearch.Config{Transport: &mockTransport{
+		es, err := elasticsearch.New(elasticsearch.WithTransportOptions(elastictransport.WithTransport(&mockTransport{
 			RoundTripFunc: func(*http.Request) (*http.Response, error) {
 				requestCalls.Add(1)
 				return &http.Response{
@@ -373,7 +373,7 @@ func TestBulkIndexer(t *testing.T) {
 					Header:     http.Header{"X-Elastic-Product": []string{"Elasticsearch"}},
 				}, nil
 			},
-		}})
+		})))
 		if err != nil {
 			t.Fatalf("Unexpected error: %s", err)
 		}


### PR DESCRIPTION
## Summary

Fixes #1468.

`BulkIndexer.Add` attempted its non-blocking worker enqueue paths before checking the caller's context. As a result, an item could be accepted when its context had already expired if a worker queue had available capacity.

Check `ctx.Err()` immediately after updating `NumAdded`, before item preparation and worker dispatch. This ensures an already-cancelled or expired context is returned immediately while preserving the existing `NumAdded` accounting and `OnError` behavior.

## Testing

Replaced the timing-dependent timeout test with a deterministic regression test that:

* uses an already-expired context;
* provides a worker queue with known spare capacity;
* verifies `context.DeadlineExceeded` is returned;
* verifies `OnError` is called exactly once with the context error;
* verifies `NumAdded` continues to count the attempted call;
* verifies item preparation is skipped;
* verifies the item is not sent to Elasticsearch.

Validation:

* `go test ./esutil/...`
* `go test -race ./esutil/...`
* `make test-unit`
* `make lint`

All unit and lint checks pass with the repository-pinned Go 1.25.12 toolchain.
